### PR TITLE
Update .Net image stream definition for OpenShift.

### DIFF
--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -1,5 +1,5 @@
 {
-    "kind": "List",
+    "kind": "ImageStreamList",
     "apiVersion": "v1",
     "metadata": {
         "name": "dotnet-image-streams",
@@ -12,21 +12,39 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "dotnetcore-10-rhel7"
+                "name": "dotnet"
             },
             "spec": {
-                "dockerImageRepository": "registry.access.redhat.com/dotnet/dotnetcore-10-rhel7",
                 "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                          "description": ".Net Core 1.0 S2I image.",
+                          "iconClass": "icon-dotnet",
+                          "tags": "builder,.net,dotnet,dotnetcore,rh-dotnetcore10",
+                          "supports":"dotnet",
+                          "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore.git",
+                          "sampleContextDir": "1.0/test/asp-net-hello-world"
+                        },
+                        "from": {
+                          "kind": "ImageStreamTag",
+                          "name": "1.0"
+                        }
+                    },
                     {
                         "name": "1.0",
                         "annotations": {
                             "description": ".Net Core 1.0 S2I image.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnetcore10",
-                            "supports":"dotnet:1.0",
+                            "supports":"dotnet:1.0,dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore.git",
                             "sampleContextDir": "1.0/test/asp-net-hello-world",
                             "version": "1.0"
+                        },
+                        "from": {
+                          "kind": "DockerImage",
+                          "name": "registry.access.redhat.com/dotnet/dotnetcore-10-rhel7:1.0"
                         }
                     }
                 ]


### PR DESCRIPTION
- Add missing "latest" tag.
- Fix "supports" definition.
- "kind" should be "ImageStreamList"
- "name" should be "dotnet"