### PR TITLE
Add env vars for configuration and framework

### DIFF
--- a/1.0/README.md
+++ b/1.0/README.md
@@ -88,3 +88,21 @@ Repository organization
 
     ASP .Net hello world example app used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
 
+Environment variables
+---------------------
+
+To set these environment variables, you can place them as a key value pair into
+a `.s2i/environment` file inside your source code repository.
+
+* **DOTNET_CONFIGURATION**
+
+    Used to run the application in Debug or Release mode. This should be either
+    `Release` or `Debug`.  This is passed to the `dotnet build` invocation.
+    Defaults to `Release`.
+
+* **DOTNET_FRAMEWORK**
+
+    Used to run the select the target framework to run this application under.
+    This is passed to the `dotnet build` invocation. The framework needs to be
+    defined in the `project.json` file. Defaults to `netcoreapp1.0`.
+

--- a/1.0/s2i/bin/assemble
+++ b/1.0/s2i/bin/assemble
@@ -9,7 +9,10 @@ echo "---> Installing dependencies ..."
 dotnet restore
 
 echo "---> Building application from source ..."
-dotnet build
+DOTNET_CONFIGURATION="${DOTNET_CONFIGURATION:-Release}"
+DOTNET_FRAMEWORK="${DOTNET_FRAMEWORK:-netcoreapp1.0}"
+
+dotnet build -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION"
 
 # Fix source directory permissions
 fix-permissions ./

--- a/1.1/README.md
+++ b/1.1/README.md
@@ -88,3 +88,21 @@ Repository organization
 
     ASP .Net hello world example app used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
 
+Environment variables
+---------------------
+
+To set these environment variables, you can place them as a key value pair into
+a `.s2i/environment` file inside your source code repository.
+
+* **DOTNET_CONFIGURATION**
+
+    Used to run the application in Debug or Release mode. This should be either
+    `Release` or `Debug`.  This is passed to the `dotnet build` invocation.
+    Defaults to `Release`.
+
+* **DOTNET_FRAMEWORK**
+
+    Used to run the select the target framework to run this application under.
+    This is passed to the `dotnet build` invocation. The framework needs to be
+    defined in the `project.json` file. Defaults to `netcoreapp1.1`.
+

--- a/1.1/s2i/bin/assemble
+++ b/1.1/s2i/bin/assemble
@@ -9,7 +9,10 @@ echo "---> Installing dependencies ..."
 dotnet restore
 
 echo "---> Building application from source ..."
-dotnet build
+DOTNET_CONFIGURATION="${DOTNET_CONFIGURATION:-Release}"
+DOTNET_FRAMEWORK="${DOTNET_FRAMEWORK:-netcoreapp1.1}"
+
+dotnet build -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION"
 
 # Fix source directory permissions
 fix-permissions ./

--- a/1.1/test/asp-net-hello-world/project.json
+++ b/1.1/test/asp-net-hello-world/project.json
@@ -9,7 +9,7 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "version": "1.1.0",


### PR DESCRIPTION
Add environment variables to set the configuration (`Release` or `Debug`) and framework (`netcoreapp1.1`, `netcoreapp1.0`, etc).

`Release` vs `Debug` lets users select which optimizations should be used and whether asserts should be enabled.

Setting an explicit framework lets dotnet only use the specified frameworks. Other frameworks in `project.json` are ignored. This lets users skip frameworks that dotnet can not handle (such as `net45`).