### PR TITLE
Fix target for asp-net-hello-world-envvar on 1.0

### DIFF
--- a/1.0/test/asp-net-hello-world-envvar/src/app/project.json
+++ b/1.0/test/asp-net-hello-world-envvar/src/app/project.json
@@ -10,7 +10,7 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.1": {
+    "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",


### PR DESCRIPTION
There was a typo introduced with #12. The sample app with
environment variables should target .NET Core 1.0 *not*
.NET Core 1.1 for the 1.0 tree.