### PR TITLE
Add test for DOTNET_FRAMEWORK env var.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+project.lock.json

--- a/1.0/test/dotnetbot/arguments.txt
+++ b/1.0/test/dotnetbot/arguments.txt
@@ -1,0 +1,1 @@
+foo bar baz

--- a/1.0/test/hw_framework_config/Program.cs
+++ b/1.0/test/hw_framework_config/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace HelloWorldSample 
+{
+	public static class Program 
+	{
+		public static void Main() 
+		{
+			Console.WriteLine("Hello World!");
+		}
+	}
+}

--- a/1.0/test/hw_framework_config/project.json
+++ b/1.0/test/hw_framework_config/project.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+  "frameworks": {
+    "net451": {},
+    "netcoreapp1.0": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      }
+    }
+  }
+}

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -9,7 +9,7 @@
 # Example usage: $ sudo ./test/run
 IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnetcore-10-rhel7}
 
-# TODO: Add tests for other apps
+declare -a CLI_APPS=(helloworld qotd dotnetbot)
 declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
@@ -55,6 +55,10 @@ prepare() {
 
 run_test_application() {
   docker run --user=100001 ${CONTAINER_ARGS} -d --cidfile=${cid_file} -p ${test_port}:${test_port} ${IMAGE_NAME}-testapp
+}
+
+run_cli_test_application() {
+  docker run --user=100001 ${CONTAINER_ARGS} -it --rm ${IMAGE_NAME}-testapp
 }
 
 cleanup_app() {
@@ -171,6 +175,120 @@ test_web_application() {
   cleanup_app
 }
 
+echo_details() {
+  local expected="$1"
+  local actual="$2"
+  cat <<EOF
+expected:
+
+-------->8
+${expected}
+8<--------
+
+but got:
+
+-------->8
+${actual}
+8<--------
+
+EOF
+}
+
+get_expected_cli() {
+  local app="$1"
+  case "${app}" in
+    "helloworld")
+      echo 'Hello World!'
+      ;;
+    "dotnetbot")
+      echo foobarbaz
+      ;;
+    "qotd")
+      echo IGNORE_ME
+      ;;
+    *)
+      echo "Unknown CLI app ${app}"
+      exit 1
+      ;;
+  esac
+}
+
+filter_cli() {
+  local app="$1"
+  local all_output="$2"
+  case "${app}" in
+    "helloworld")
+      # Note: tail -n1 => Omit "--> Running application ..." output
+      echo "${all_output}" | tail -n1
+      ;;
+    "dotnetbot")
+      # Only interested in the first 3 lines
+      echo "${all_output}" | head -n3
+      ;;
+    "qotd")
+      # Note: tail -n1 => Omit "--> Running application with ..." output
+      echo "${all_output}" | tail -n1
+      ;;
+    *)
+      echo "Unknown CLI app ${app}"
+      exit 1
+      ;;
+  esac
+}
+
+success_cli() {
+  local app="$1"
+  local actual="$2"
+  local expected="$3"
+  case "${app}" in
+    "helloworld")
+      echo "${actual}" | grep -q "${expected}"
+      return $?
+      ;;
+    "dotnetbot")
+      local retval=0
+      # Expect running with arguments from arguments.txt
+      echo "${actual}" | head -n1 | grep -q "arguments.txt"
+      retval=$(( ${retval} + $? ))
+      # Expect to have foobarbaz on 3rd line
+      echo "${actual}" | tail -n1 | grep -q "${expected}"
+      retval=$(( ${retval} + $? ))
+      return ${retval}
+      ;;
+    "qotd")
+      local retval=0
+      # Only match for the QOTD prefix
+      echo ${actual} | grep -q "\[QOTD\]: "
+      retval=$(( ${retval} + $? ))
+      return ${retval}
+      ;;
+    *)
+      echo "Unknown CLI app ${app}"
+      exit 1
+      ;;
+  esac
+}
+
+test_cli_app() {
+  local app="$1"
+  info "Testing CLI app: ${app} ..."
+  prepare ${app}
+  run_s2i_build ${app}
+  check_result $?
+
+  local expected="$( get_expected_cli ${app} )"
+  local actual_pre="$( run_cli_test_application )"
+  local actual="$( filter_cli "${app}" "${actual_pre}" )"
+  if ! success_cli "${app}" "${actual}" "${expected}"; then
+    info "Test CLI app: ${app} FAILED."
+    echo_details "${expected}" "${actual}"
+    cleanup ${app}
+    exit 1
+  else
+    info "Test CLI app: ${app} PASSED."
+  fi
+  cleanup ${app}
+}
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
@@ -183,6 +301,11 @@ check_result $?
 # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
 test_docker_run_usage
 check_result $?
+
+# Verify that some CLI s2i apps build and run properly
+for app in ${CLI_APPS[@]}; do
+  test_cli_app "${app}"
+done
 
 for app in ${WEB_APPS[@]}; do
   prepare ${app}

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -9,7 +9,7 @@
 # Example usage: $ sudo ./test/run
 IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnetcore-10-rhel7}
 
-declare -a CLI_APPS=(helloworld qotd dotnetbot)
+declare -a CLI_APPS=(hw_framework_config helloworld qotd dotnetbot)
 declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
@@ -200,6 +200,9 @@ get_expected_cli() {
     "helloworld")
       echo 'Hello World!'
       ;;
+    "hw_framework_config")
+      echo 'Hello World!'
+      ;;
     "dotnetbot")
       echo foobarbaz
       ;;
@@ -218,6 +221,10 @@ filter_cli() {
   local all_output="$2"
   case "${app}" in
     "helloworld")
+      # Note: tail -n1 => Omit "--> Running application ..." output
+      echo "${all_output}" | tail -n1
+      ;;
+    "hw_framework_config")
       # Note: tail -n1 => Omit "--> Running application ..." output
       echo "${all_output}" | tail -n1
       ;;
@@ -242,6 +249,10 @@ success_cli() {
   local expected="$3"
   case "${app}" in
     "helloworld")
+      echo "${actual}" | grep -q "${expected}"
+      return $?
+      ;;
+    "hw_framework_config")
       echo "${actual}" | grep -q "${expected}"
       return $?
       ;;

--- a/1.1/test/dotnetbot/arguments.txt
+++ b/1.1/test/dotnetbot/arguments.txt
@@ -1,0 +1,1 @@
+foo bar baz

--- a/1.1/test/hw_framework_config/Program.cs
+++ b/1.1/test/hw_framework_config/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace HelloWorldSample 
+{
+	public static class Program 
+	{
+		public static void Main() 
+		{
+			Console.WriteLine("Hello World!");
+		}
+	}
+}

--- a/1.1/test/hw_framework_config/project.json
+++ b/1.1/test/hw_framework_config/project.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+  "frameworks": {
+    "net451": {},
+    "netcoreapp1.1": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.1.0"
+        }
+      }
+    }
+  }
+}

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -9,7 +9,7 @@
 # Example usage: $ sudo ./test/run
 IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnetcore-11-rhel7}
 
-# TODO: Add tests for other apps
+declare -a CLI_APPS=(helloworld qotd dotnetbot)
 declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
@@ -55,6 +55,10 @@ prepare() {
 
 run_test_application() {
   docker run --user=100001 ${CONTAINER_ARGS} -d --cidfile=${cid_file} -p ${test_port}:${test_port} ${IMAGE_NAME}-testapp
+}
+
+run_cli_test_application() {
+  docker run --user=100001 ${CONTAINER_ARGS} -it --rm ${IMAGE_NAME}-testapp
 }
 
 cleanup_app() {
@@ -171,6 +175,120 @@ test_web_application() {
   cleanup_app
 }
 
+echo_details() {
+  local expected="$1"
+  local actual="$2"
+  cat <<EOF
+expected:
+
+-------->8
+${expected}
+8<--------
+
+but got:
+
+-------->8
+${actual}
+8<--------
+
+EOF
+}
+
+get_expected_cli() {
+  local app="$1"
+  case "${app}" in
+    "helloworld")
+      echo 'Hello World!'
+      ;;
+    "dotnetbot")
+      echo foobarbaz
+      ;;
+    "qotd")
+      echo IGNORE_ME
+      ;;
+    *)
+      echo "Unknown CLI app ${app}"
+      exit 1
+      ;;
+  esac
+}
+
+filter_cli() {
+  local app="$1"
+  local all_output="$2"
+  case "${app}" in
+    "helloworld")
+      # Note: tail -n1 => Omit "--> Running application ..." output
+      echo "${all_output}" | tail -n1
+      ;;
+    "dotnetbot")
+      # Only interested in the first 3 lines
+      echo "${all_output}" | head -n3
+      ;;
+    "qotd")
+      # Note: tail -n1 => Omit "--> Running application with ..." output
+      echo "${all_output}" | tail -n1
+      ;;
+    *)
+      echo "Unknown CLI app ${app}"
+      exit 1
+      ;;
+  esac
+}
+
+success_cli() {
+  local app="$1"
+  local actual="$2"
+  local expected="$3"
+  case "${app}" in
+    "helloworld")
+      echo "${actual}" | grep -q "${expected}"
+      return $?
+      ;;
+    "dotnetbot")
+      local retval=0
+      # Expect running with arguments from arguments.txt
+      echo "${actual}" | head -n1 | grep -q "arguments.txt"
+      retval=$(( ${retval} + $? ))
+      # Expect to have foobarbaz on 3rd line
+      echo "${actual}" | tail -n1 | grep -q "${expected}"
+      retval=$(( ${retval} + $? ))
+      return ${retval}
+      ;;
+    "qotd")
+      local retval=0
+      # Only match for the QOTD prefix
+      echo ${actual} | grep -q "\[QOTD\]: "
+      retval=$(( ${retval} + $? ))
+      return ${retval}
+      ;;
+    *)
+      echo "Unknown CLI app ${app}"
+      exit 1
+      ;;
+  esac
+}
+
+test_cli_app() {
+  local app="$1"
+  info "Testing CLI app: ${app} ..."
+  prepare ${app}
+  run_s2i_build ${app}
+  check_result $?
+
+  local expected="$( get_expected_cli ${app} )"
+  local actual_pre="$( run_cli_test_application )"
+  local actual="$( filter_cli "${app}" "${actual_pre}" )"
+  if ! success_cli "${app}" "${actual}" "${expected}"; then
+    info "Test CLI app: ${app} FAILED."
+    echo_details "${expected}" "${actual}"
+    cleanup ${app}
+    exit 1
+  else
+    info "Test CLI app: ${app} PASSED."
+  fi
+  cleanup ${app}
+}
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
@@ -183,6 +301,11 @@ check_result $?
 # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
 test_docker_run_usage
 check_result $?
+
+# Verify that some CLI s2i apps build and run properly
+for app in ${CLI_APPS[@]}; do
+  test_cli_app "${app}"
+done
 
 for app in ${WEB_APPS[@]}; do
   prepare ${app}

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -9,7 +9,7 @@
 # Example usage: $ sudo ./test/run
 IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnetcore-11-rhel7}
 
-declare -a CLI_APPS=(helloworld qotd dotnetbot)
+declare -a CLI_APPS=(hw_framework_config helloworld qotd dotnetbot)
 declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
@@ -200,6 +200,9 @@ get_expected_cli() {
     "helloworld")
       echo 'Hello World!'
       ;;
+    "hw_framework_config")
+      echo 'Hello World!'
+      ;;
     "dotnetbot")
       echo foobarbaz
       ;;
@@ -218,6 +221,10 @@ filter_cli() {
   local all_output="$2"
   case "${app}" in
     "helloworld")
+      # Note: tail -n1 => Omit "--> Running application ..." output
+      echo "${all_output}" | tail -n1
+      ;;
+    "hw_framework_config")
       # Note: tail -n1 => Omit "--> Running application ..." output
       echo "${all_output}" | tail -n1
       ;;
@@ -242,6 +249,10 @@ success_cli() {
   local expected="$3"
   case "${app}" in
     "helloworld")
+      echo "${actual}" | grep -q "${expected}"
+      return $?
+      ;;
+    "hw_framework_config")
       echo "${actual}" | grep -q "${expected}"
       return $?
       ;;

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Build Docker images and run tests.
+#
+# PRE: Docker daemon running, s2i binary available.
+#
+# Supported environment variables:
+#
+# -----------------------------------------------------
+# VERSIONS     The list of versions to build/test.
+#              Defaults to all versions. i.e "1.0 1.1".
+# -----------------------------------------------------
+#
+# Usage:
+#       $ sudo ./build.sh
+#       $ sudo VERSIONS=1.0 ./build.sh
+#
+
+version_no_dot() {
+  local version=$1
+  echo ${version} | sed 's/\.//g'
+}
+
+image_exists() {
+  docker inspect $1 &>/dev/null
+}
+
+check_result_msg() {
+  local retval=$1
+  local msg=$2
+  if [ ${retval} -ne 0 ]; then
+    echo 1>&2 "${msg}"
+    exit 1
+  fi
+}
+
+VERSIONS="${VERSIONS:-1.0 1.1}"
+
+for v in ${VERSIONS}; do
+  v_no_dot="$( version_no_dot ${v} )"
+  img_name="dotnet/dotnetcore-${v_no_dot}-rhel7"
+  pushd ${v} &>/dev/null
+    if ! image_exists ${img_name}; then
+      echo "Building Docker image ${img_name} ..."
+      docker build -f Dockerfile.rhel7 -t ${img_name} .
+      check_result_msg $? "Building Docker image ${img_name} FAILED!"
+    fi
+    echo "Running tests on image ${img_name} ..."
+    ./test/run
+    check_result_msg $? "Tests for image ${img_name} FAILED!"
+  popd &>/dev/null
+done
+
+echo "ALL builds and tests were successful!"
+exit 0


### PR DESCRIPTION
The idea is to have one failing test if `-f <framework>` is not being passed to `dotnet build` in `s2i/assemble`. It fails on the s2i build, prior #11 and passes after.

This patch depends on #16.