### PR TITLE
Don't require a TTY when running tests.

### DIFF
--- a/1.0/test/run
+++ b/1.0/test/run
@@ -58,7 +58,7 @@ run_test_application() {
 }
 
 run_cli_test_application() {
-  docker run --user=100001 ${CONTAINER_ARGS} -it --rm ${IMAGE_NAME}-testapp
+  docker run --user=100001 ${CONTAINER_ARGS} -i --rm ${IMAGE_NAME}-testapp
 }
 
 cleanup_app() {

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -58,7 +58,7 @@ run_test_application() {
 }
 
 run_cli_test_application() {
-  docker run --user=100001 ${CONTAINER_ARGS} -it --rm ${IMAGE_NAME}-testapp
+  docker run --user=100001 ${CONTAINER_ARGS} -i --rm ${IMAGE_NAME}-testapp
 }
 
 cleanup_app() {


### PR DESCRIPTION
This breaks builder setups in Jenkins with:
"cannot enable tty mode on non tty input"