### PR TITLE
Publish the dotnet application and run it from the published folder

### DIFF
--- a/1.0/s2i/bin/assemble
+++ b/1.0/s2i/bin/assemble
@@ -17,7 +17,7 @@ echo "---> Installing dependencies ..."
 dotnet restore $DOTNET_RESTORE_ROOT
 
 echo "---> Building application from source ..."
-dotnet build -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" "$DOTNET_STARTUP_PROJECT"
+dotnet publish -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" "$DOTNET_STARTUP_PROJECT"
 
 for TEST_PROJECT in $DOTNET_TEST_PROJECTS; do
     echo "---> Running test project: $TEST_PROJECT..."

--- a/1.0/s2i/bin/run
+++ b/1.0/s2i/bin/run
@@ -10,14 +10,14 @@ DOTNET_STARTUP_PROJECT="${DOTNET_STARTUP_PROJECT:-.}"
 # Private environment
 DOTNET_FRAMEWORK="netcoreapp1.0"
 APP_DLL_NAME="$(basename "$(realpath "${DOTNET_STARTUP_PROJECT}")").dll"
-APP_DLL_PATH="${DOTNET_STARTUP_PROJECT}/bin/${DOTNET_CONFIGURATION}/${DOTNET_FRAMEWORK}/${APP_DLL_NAME}"
+APP_DLL_DIR="${DOTNET_STARTUP_PROJECT}/bin/${DOTNET_CONFIGURATION}/${DOTNET_FRAMEWORK}/publish"
 
 ARG_FILE="arguments.txt"
 if [[ -f "${ARG_FILE}" ]]; then
   echo "---> Running application with arguments from file '${ARG_FILE}' ..."
   PROG_ARGS="$(cat ${ARG_FILE})"
-  exec dotnet "${APP_DLL_PATH}" ${PROG_ARGS}
+  cd "${APP_DLL_DIR}" && exec dotnet "${APP_DLL_NAME}" ${PROG_ARGS}
 else
   echo "---> Running application ..."
-  exec dotnet "${APP_DLL_PATH}"
+  cd "${APP_DLL_DIR}" && exec dotnet "${APP_DLL_NAME}"
 fi

--- a/1.0/test/asp-net-hello-world-envvar/src/app/Program.cs
+++ b/1.0/test/asp-net-hello-world-envvar/src/app/Program.cs
@@ -16,6 +16,8 @@ namespace SampleApp
         {
             loggerFactory.AddConsole(LogLevel.Trace);
 
+            app.UseStaticFiles();
+
             app.Run(async context =>
             {
                 Console.WriteLine("{0} {1}{2}{3}",

--- a/1.0/test/asp-net-hello-world-envvar/src/app/project.json
+++ b/1.0/test/asp-net-hello-world-envvar/src/app/project.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
     "Microsoft.Extensions.Logging.Console": "1.0.0",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0",
     "lib": "1.0.0-*"
   },
   "buildOptions": {
@@ -19,5 +20,10 @@
       },
       "imports": "dnxcore50"
     }
+  },
+  "publishOptions": {
+    "include": [
+      "wwwroot"
+    ]
   }
 }

--- a/1.0/test/asp-net-hello-world-envvar/src/app/wwwroot/TextFile.txt
+++ b/1.0/test/asp-net-hello-world-envvar/src/app/wwwroot/TextFile.txt
@@ -1,0 +1,1 @@
+A text file.

--- a/1.0/test/asp-net-hello-world/Startup.cs
+++ b/1.0/test/asp-net-hello-world/Startup.cs
@@ -15,6 +15,8 @@ namespace SampleApp
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(LogLevel.Trace);
+            
+            app.UseStaticFiles();
 
             app.Run(async context =>
             {

--- a/1.0/test/asp-net-hello-world/project.json
+++ b/1.0/test/asp-net-hello-world/project.json
@@ -3,7 +3,8 @@
   "dependencies": {
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel.Https": "1.0.0-*",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-*"
+    "Microsoft.Extensions.Logging.Console": "1.0.0-*",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-*"
   },
   "buildOptions": {
     "emitEntryPoint": true
@@ -21,6 +22,7 @@
   },
   "publishOptions": {
     "include": [
+      "wwwroot",
       "hosting.json",
       "testCert.pfx"
     ]

--- a/1.0/test/asp-net-hello-world/wwwroot/TextFile.txt
+++ b/1.0/test/asp-net-hello-world/wwwroot/TextFile.txt
@@ -1,0 +1,1 @@
+A text file.

--- a/1.0/test/qotd/project.json
+++ b/1.0/test/qotd/project.json
@@ -13,5 +13,10 @@
     "netcoreapp1.0": {
       "imports": "dnxcore50"
     }
+  },
+  "publishOptions": {
+    "include": [
+      "quotes.txt"
+    ]
   }
 }

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -146,20 +146,23 @@ test_scl_usage() {
   fi
 }
 
-test_connection() {
-  info "Testing the HTTP connection (http://$(container_ip):${test_port}) ${CONTAINER_ARGS} output file ${1}..."
-  local output_file=$1
+test_http() {
+  local path=$1
+  local expected=$2
+  local output_file=$(mktemp --suffix=.dotnet_out)
   local max_attempts=30
   local sleep_time=1
   local attempt=1
   local result=1
+  local url=http://$(container_ip):${test_port}${path}
+  info "Testing HTTP ($url) ${CONTAINER_ARGS} output file ${output_file}..."
   while [ $attempt -le $max_attempts ]; do
-    response_code=$(curl -s -w %{http_code} -o ${output_file} http://$(container_ip):${test_port}/)
+    response_code=$(curl -s -w %{http_code} -o ${output_file} ${url})
     status=$?
     if [ $status -eq 0 ]; then
       if [ $response_code -eq 200 ]; then
         output=$(cat ${output_file})
-        if [ "${output}_" == "Hello World_" ]; then
+        if [ "${output}_" == "${expected}_" ]; then
           result=0
         fi
       fi
@@ -168,12 +171,12 @@ test_connection() {
     attempt=$(( $attempt + 1 ))
     sleep $sleep_time
   done
+  rm -rf ${output_file}
   return $result
 }
 
 test_web_application() {
   local cid_file=$(mktemp -u --suffix=.cid)
-  local out_file=$(mktemp --suffix=.dotnet_out)
   # Verify that the HTTP connection can be established to test application container
   run_test_application &
 
@@ -184,8 +187,9 @@ test_web_application() {
 
   test_scl_usage "dotnet --version" "1.0.0-preview2-003156" "${cid_file}"
   check_result $?
-  test_connection ${out_file}
-  rm -rf ${out_file}
+  test_http "/" "Hello world"
+  check_result $?
+  test_http "/TextFile.txt" "A text file."
   check_result $?
   cleanup_app
 }

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -182,15 +182,18 @@ test_web_application() {
 
   # Wait for the container to write it's CID file
   wait_for_cid
-  test_pid_1 "${cid_file}"
-  check_result $?
 
   test_scl_usage "dotnet --version" "1.0.0-preview2-003156" "${cid_file}"
   check_result $?
+
   test_http "/" "Hello world"
   check_result $?
   test_http "/TextFile.txt" "A text file."
   check_result $?
+
+  test_pid_1 "${cid_file}"
+  check_result $?
+
   cleanup_app
 }
 

--- a/1.1/s2i/bin/assemble
+++ b/1.1/s2i/bin/assemble
@@ -17,7 +17,7 @@ echo "---> Installing dependencies ..."
 dotnet restore $DOTNET_RESTORE_ROOT
 
 echo "---> Building application from source ..."
-dotnet build -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" "$DOTNET_STARTUP_PROJECT"
+dotnet publish -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" "$DOTNET_STARTUP_PROJECT"
 
 for TEST_PROJECT in $DOTNET_TEST_PROJECTS; do
     echo "---> Running test project: $TEST_PROJECT..."

--- a/1.1/s2i/bin/run
+++ b/1.1/s2i/bin/run
@@ -10,14 +10,14 @@ DOTNET_STARTUP_PROJECT="${DOTNET_STARTUP_PROJECT:-.}"
 # Private environment
 DOTNET_FRAMEWORK="netcoreapp1.1"
 APP_DLL_NAME="$(basename "$(realpath "${DOTNET_STARTUP_PROJECT}")").dll"
-APP_DLL_PATH="${DOTNET_STARTUP_PROJECT}/bin/${DOTNET_CONFIGURATION}/${DOTNET_FRAMEWORK}/${APP_DLL_NAME}"
+APP_DLL_DIR="${DOTNET_STARTUP_PROJECT}/bin/${DOTNET_CONFIGURATION}/${DOTNET_FRAMEWORK}/publish"
 
 ARG_FILE="arguments.txt"
 if [[ -f "${ARG_FILE}" ]]; then
   echo "---> Running application with arguments from file '${ARG_FILE}' ..."
   PROG_ARGS="$(cat ${ARG_FILE})"
-  exec dotnet "${APP_DLL_PATH}" ${PROG_ARGS}
+  cd "${APP_DLL_DIR}" && exec dotnet "${APP_DLL_NAME}" ${PROG_ARGS}
 else
   echo "---> Running application ..."
-  exec dotnet "${APP_DLL_PATH}"
+  cd "${APP_DLL_DIR}" && exec dotnet "${APP_DLL_NAME}"
 fi

--- a/1.1/test/asp-net-hello-world-envvar/src/app/Program.cs
+++ b/1.1/test/asp-net-hello-world-envvar/src/app/Program.cs
@@ -16,6 +16,8 @@ namespace SampleApp
         {
             loggerFactory.AddConsole(LogLevel.Trace);
 
+            app.UseStaticFiles();
+
             app.Run(async context =>
             {
                 Console.WriteLine("{0} {1}{2}{3}",

--- a/1.1/test/asp-net-hello-world-envvar/src/app/project.json
+++ b/1.1/test/asp-net-hello-world-envvar/src/app/project.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "Microsoft.AspNetCore.Server.Kestrel": "1.1.0",
     "Microsoft.Extensions.Logging.Console": "1.1.0",
+    "Microsoft.AspNetCore.StaticFiles": "1.1.0",
     "lib": "1.0.0-*"
   },
   "buildOptions": {
@@ -19,5 +20,10 @@
       },
       "imports": "dnxcore50"
     }
+  },
+  "publishOptions": {
+    "include": [
+      "wwwroot"
+    ]
   }
 }

--- a/1.1/test/asp-net-hello-world-envvar/src/app/wwwroot/TextFile.txt
+++ b/1.1/test/asp-net-hello-world-envvar/src/app/wwwroot/TextFile.txt
@@ -1,0 +1,1 @@
+A text file.

--- a/1.1/test/asp-net-hello-world/Startup.cs
+++ b/1.1/test/asp-net-hello-world/Startup.cs
@@ -16,6 +16,8 @@ namespace SampleApp
         {
             loggerFactory.AddConsole(LogLevel.Trace);
 
+            app.UseStaticFiles();
+
             app.Run(async context =>
             {
                 Console.WriteLine("{0} {1}{2}{3}",

--- a/1.1/test/asp-net-hello-world/project.json
+++ b/1.1/test/asp-net-hello-world/project.json
@@ -3,7 +3,8 @@
   "dependencies": {
     "Microsoft.AspNetCore.Server.Kestrel": "1.1.0-*",
     "Microsoft.AspNetCore.Server.Kestrel.Https": "1.1.0-*",
-    "Microsoft.Extensions.Logging.Console": "1.1.0-*"
+    "Microsoft.Extensions.Logging.Console": "1.1.0-*",
+    "Microsoft.AspNetCore.StaticFiles": "1.1.0-*"
   },
   "buildOptions": {
     "emitEntryPoint": true
@@ -21,6 +22,7 @@
   },
   "publishOptions": {
     "include": [
+      "wwwroot",
       "hosting.json",
       "testCert.pfx"
     ]

--- a/1.1/test/asp-net-hello-world/wwwroot/TextFile.txt
+++ b/1.1/test/asp-net-hello-world/wwwroot/TextFile.txt
@@ -1,0 +1,1 @@
+A text file.

--- a/1.1/test/qotd/project.json
+++ b/1.1/test/qotd/project.json
@@ -13,5 +13,10 @@
     "netcoreapp1.1": {
       "imports": "dnxcore50"
     }
+  },
+  "publishOptions": {
+    "include": [
+      "quotes.txt"
+    ]
   }
 }

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -146,20 +146,23 @@ test_scl_usage() {
   fi
 }
 
-test_connection() {
-  info "Testing the HTTP connection (http://$(container_ip):${test_port}) ${CONTAINER_ARGS} output file ${1}..."
-  local output_file=$1
+test_http() {
+  local path=$1
+  local expected=$2
+  local output_file=$(mktemp --suffix=.dotnet_out)
   local max_attempts=30
   local sleep_time=1
   local attempt=1
   local result=1
+  local url=http://$(container_ip):${test_port}${path}
+  info "Testing HTTP ($url) ${CONTAINER_ARGS} output file ${output_file}..."
   while [ $attempt -le $max_attempts ]; do
-    response_code=$(curl -s -w %{http_code} -o ${output_file} http://$(container_ip):${test_port}/)
+    response_code=$(curl -s -w %{http_code} -o ${output_file} ${url})
     status=$?
     if [ $status -eq 0 ]; then
       if [ $response_code -eq 200 ]; then
         output=$(cat ${output_file})
-        if [ "${output}_" == "Hello World_" ]; then
+        if [ "${output}_" == "${expected}_" ]; then
           result=0
         fi
       fi
@@ -168,12 +171,12 @@ test_connection() {
     attempt=$(( $attempt + 1 ))
     sleep $sleep_time
   done
+  rm -rf ${output_file}
   return $result
 }
 
 test_web_application() {
   local cid_file=$(mktemp -u --suffix=.cid)
-  local out_file=$(mktemp --suffix=.dotnet_out)
   # Verify that the HTTP connection can be established to test application container
   run_test_application &
 
@@ -184,8 +187,9 @@ test_web_application() {
 
   test_scl_usage "dotnet --version" "1.0.0-preview2-1-003175" "${cid_file}"
   check_result $?
-  test_connection ${out_file}
-  rm -rf ${out_file}
+  test_http "/" "Hello world"
+  check_result $?
+  test_http "/TextFile.txt" "A text file."
   check_result $?
   cleanup_app
 }

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -182,15 +182,18 @@ test_web_application() {
 
   # Wait for the container to write it's CID file
   wait_for_cid
-  test_pid_1 "${cid_file}"
-  check_result $?
 
   test_scl_usage "dotnet --version" "1.0.0-preview2-1-003175" "${cid_file}"
   check_result $?
+
   test_http "/" "Hello world"
   check_result $?
   test_http "/TextFile.txt" "A text file."
   check_result $?
+
+  test_pid_1 "${cid_file}"
+  check_result $?
+
   cleanup_app
 }
 


### PR DESCRIPTION
The publish command is intended to pack the application and all its dependencies in a folder. The user can perform some additional steps as part of the publish operation and specify the artifacts that need to be copied.
The published folder is then used as the working directory when executing the application. This is important because many applications set the ASP.NET ContentRoot to the current directory.