### PR TITLE
PWD should not be HOME.

### DIFF
--- a/1.0/Dockerfile.rhel7
+++ b/1.0/Dockerfile.rhel7
@@ -7,7 +7,7 @@ EXPOSE 8080
 ENV DOTNET_CORE_VERSION=1.0
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8 \
-    HOME=/opt/app-root/src \
+    HOME=/opt/app-root \
     PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     STI_SCRIPTS_PATH=/usr/libexec/s2i
 
@@ -64,7 +64,7 @@ RUN cd /opt/app-root/src && mkdir cache-warmup && \
     cd .. && \
     rm -rf cache-warmup && \
     rm -rf /tmp/NuGetScratch && \
-    find .nuget -name '*.cs' -exec rm '{}' \;
+    find ${HOME}/.nuget -name '*.cs' -exec rm '{}' \;
 
 # Switch back to root for changing dir ownership/permissions
 USER 0
@@ -85,7 +85,9 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/etc/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/etc/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/etc/scl_enable"
 
-# Directory with the sources is set as the working directory. Set it to ${HOME}
+# Directory with the sources is set as the working directory. This should
+# be a folder outside $HOME as this might cause issues when compiling sources.
+# See https://github.com/redhat-developer/s2i-dotnetcore/issues/28
 WORKDIR /opt/app-root/src
 
 # Run container by default as user with id 1001 (default)

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -186,6 +186,12 @@ test_web_application() {
   test_scl_usage "dotnet --version" "1.0.0-preview2-003156" "${cid_file}"
   check_result $?
 
+  # Verify $HOME != $CWD. See https://github.com/redhat-developer/s2i-dotnetcore/issues/28
+  test_scl_usage "pwd" "/opt/app-root/src" "${cid_file}"
+  check_result $?
+  test_scl_usage "echo \$HOME" "/opt/app-root" "${cid_file}"
+  check_result $?
+
   test_http "/" "Hello world"
   check_result $?
   test_http "/TextFile.txt" "A text file."

--- a/1.1/Dockerfile.rhel7
+++ b/1.1/Dockerfile.rhel7
@@ -7,7 +7,7 @@ EXPOSE 8080
 ENV DOTNET_CORE_VERSION=1.1
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8 \
-    HOME=/opt/app-root/src \
+    HOME=/opt/app-root \
     PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     STI_SCRIPTS_PATH=/usr/libexec/s2i
 
@@ -64,7 +64,7 @@ RUN cd /opt/app-root/src && mkdir cache-warmup && \
     cd .. && \
     rm -rf cache-warmup && \
     rm -rf /tmp/NuGetScratch && \
-    find .nuget -name '*.cs' -exec rm '{}' \;
+    find ${HOME}/.nuget -name '*.cs' -exec rm '{}' \;
 
 # Switch back to root for changing dir ownership/permissions
 USER 0
@@ -85,7 +85,9 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/etc/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/etc/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/etc/scl_enable"
 
-# Directory with the sources is set as the working directory. Set it to ${HOME}
+# Directory with the sources is set as the working directory. This should
+# be a folder outside $HOME as this might cause issues when compiling sources.
+# See https://github.com/redhat-developer/s2i-dotnetcore/issues/28
 WORKDIR /opt/app-root/src
 
 # Run container by default as user with id 1001 (default)

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -186,6 +186,12 @@ test_web_application() {
   test_scl_usage "dotnet --version" "1.0.0-preview2-1-003175" "${cid_file}"
   check_result $?
 
+  # Verify $HOME != $CWD. See https://github.com/redhat-developer/s2i-dotnetcore/issues/28
+  test_scl_usage "pwd" "/opt/app-root/src" "${cid_file}"
+  check_result $?
+  test_scl_usage "echo \$HOME" "/opt/app-root" "${cid_file}"
+  check_result $?
+
   test_http "/" "Hello world"
   check_result $?
   test_http "/TextFile.txt" "A text file."


### PR DESCRIPTION
When the current working directory is the same as HOME this might
cause problems when building .NET Core apps. The problem stems
from some nuget packages including C# source files. When
"dotnet build" is invoked in a directory which is also the HOME
folder, it will attempt to recursively build all source files
under it. That might fail for some source files in $HOME/.nuget.

See issue #28 for details. The fix is to set HOME to one level
up. That is the current working directory will not be outside the
recursive search path when "dotnet build" is being invoked.

Closes issue #28.