### PR TITLE
Remove unneeded work-around.

### DIFF
--- a/1.0/Dockerfile.rhel7
+++ b/1.0/Dockerfile.rhel7
@@ -55,16 +55,12 @@ ENV NUGET_XMLDOC_MODE=skip
 #   Move to the proper command to do this once https://github.com/dotnet/cli/issues/3692 is fixed.
 # - Removal of /tmp/NuGetScratch is needed due to:
 #   https://github.com/NuGet/Home/issues/2793
-# - Work around corefx issue 12758 where some C# source files are included
-#   in nuget packages. See:
-#   https://github.com/dotnet/corefx/issues/12758
 RUN cd /opt/app-root/src && mkdir cache-warmup && \
     cd cache-warmup && \
     scl enable rh-dotnetcore10 -- dotnet new && \
     cd .. && \
     rm -rf cache-warmup && \
-    rm -rf /tmp/NuGetScratch && \
-    find ${HOME}/.nuget -name '*.cs' -exec rm '{}' \;
+    rm -rf /tmp/NuGetScratch
 
 # Switch back to root for changing dir ownership/permissions
 USER 0

--- a/1.1/Dockerfile.rhel7
+++ b/1.1/Dockerfile.rhel7
@@ -55,16 +55,12 @@ ENV NUGET_XMLDOC_MODE=skip
 #   Move to the proper command to do this once https://github.com/dotnet/cli/issues/3692 is fixed.
 # - Removal of /tmp/NuGetScratch is needed due to:
 #   https://github.com/NuGet/Home/issues/2793
-# - Work around corefx issue 12758 where some C# source files are included
-#   in nuget packages. See:
-#   https://github.com/dotnet/corefx/issues/12758
 RUN cd /opt/app-root/src && mkdir cache-warmup && \
     cd cache-warmup && \
     scl enable rh-dotnetcore11 -- dotnet new && \
     cd .. && \
     rm -rf cache-warmup && \
-    rm -rf /tmp/NuGetScratch && \
-    find ${HOME}/.nuget -name '*.cs' -exec rm '{}' \;
+    rm -rf /tmp/NuGetScratch
 
 # Switch back to root for changing dir ownership/permissions
 USER 0


### PR DESCRIPTION
After issue #31 the PWD does no longer
coincide with $HOME. Thus, a compile of
app sources no longer takes sources in
$HOME/.nuget into account. The workaround
for this can be removed.