### PR TITLE
Set the ASPNETCORE_URLS to match the container port.

### DIFF
--- a/1.0/Dockerfile.rhel7
+++ b/1.0/Dockerfile.rhel7
@@ -89,6 +89,10 @@ WORKDIR /opt/app-root/src
 # Run container by default as user with id 1001 (default)
 USER 1001
 
+# By default, ASP.NET Core runs on port 5000. We configure it to match
+# the container port.
+ENV ASPNETCORE_URLS=http://*:8080
+
 ENTRYPOINT ["container-entrypoint"]
 
 # Set the default CMD to print the usage of the language image.

--- a/1.0/README.md
+++ b/1.0/README.md
@@ -112,3 +112,8 @@ a `.s2i/environment` file inside your source code repository.
 
     Used to specify the list of projects or project folders to restore. This is
     passed to the `dotnet restore` invocation. Defaults to `.`.
+
+* **ASPNETCORE_URLS**
+
+    This variable is set to `http://*:8080` to configure ASP.NET Core to use the
+    port exposed by the image.

--- a/1.0/test/asp-net-hello-world-envvar/src/app/Program.cs
+++ b/1.0/test/asp-net-hello-world-envvar/src/app/Program.cs
@@ -49,7 +49,6 @@ namespace SampleApp
             // Launch webserver
             var host = new WebHostBuilder()
                 .UseKestrel()
-                .UseUrls("http://0.0.0.0:8080")
                 .UseStartup<Startup>()
                 .Build();
 

--- a/1.0/test/asp-net-hello-world/Startup.cs
+++ b/1.0/test/asp-net-hello-world/Startup.cs
@@ -49,7 +49,6 @@ namespace SampleApp
                     options.NoDelay = true;
                     options.UseConnectionLogging();
                 })
-                .UseUrls("http://0.0.0.0:8080")
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseStartup<Startup>()
                 .Build();

--- a/1.1/Dockerfile.rhel7
+++ b/1.1/Dockerfile.rhel7
@@ -89,6 +89,10 @@ WORKDIR /opt/app-root/src
 # Run container by default as user with id 1001 (default)
 USER 1001
 
+# By default, ASP.NET Core runs on port 5000. We configure it to match
+# the container port.
+ENV ASPNETCORE_URLS=http://*:8080
+
 ENTRYPOINT ["container-entrypoint"]
 
 # Set the default CMD to print the usage of the language image.

--- a/1.1/README.md
+++ b/1.1/README.md
@@ -112,3 +112,8 @@ a `.s2i/environment` file inside your source code repository.
 
     Used to specify the list of projects or project folders to restore. This is
     passed to the `dotnet restore` invocation. Defaults to `.`.
+
+* **ASPNETCORE_URLS**
+
+    This variable is set to `http://*:8080` to configure ASP.NET Core to use the
+    port exposed by the image.

--- a/1.1/test/asp-net-hello-world-envvar/src/app/Program.cs
+++ b/1.1/test/asp-net-hello-world-envvar/src/app/Program.cs
@@ -49,7 +49,6 @@ namespace SampleApp
             // Launch webserver
             var host = new WebHostBuilder()
                 .UseKestrel()
-                .UseUrls("http://0.0.0.0:8080")
                 .UseStartup<Startup>()
                 .Build();
 

--- a/1.1/test/asp-net-hello-world/Startup.cs
+++ b/1.1/test/asp-net-hello-world/Startup.cs
@@ -49,7 +49,6 @@ namespace SampleApp
                     options.NoDelay = true;
                     options.UseConnectionLogging();
                 })
-                .UseUrls("http://0.0.0.0:8080")
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseStartup<Startup>()
                 .Build();


### PR DESCRIPTION
ASP.NET Core uses port 5000 by default while the image is exposing port 8080.
We set the ASPNETCORE_URLS environment variable to make ASP.NET Core use the port exposed by the container.
We can't change the port exposed by the container since this would break applications that explicitly force their port to 8080 using `WebHostBuilder.UseUrls`.