### PR TITLE
Add npm for front-end development

### DIFF
--- a/1.0/Dockerfile.rhel7
+++ b/1.0/Dockerfile.rhel7
@@ -35,6 +35,7 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 COPY ./contrib/ /opt/app-root
 
 RUN yum install -y yum-utils && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-dotnet-rpms && \
     yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.0-rpms && \

--- a/1.0/Dockerfile.rhel7
+++ b/1.0/Dockerfile.rhel7
@@ -72,7 +72,7 @@ RUN chown -R 1001:0 /opt/app-root && chmod -R og+rwx /opt/app-root
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/opt/app-root \
-    ENABLED_COLLECTIONS="rh-dotnetcore11 rh-nodejs4"
+    ENABLED_COLLECTIONS="rh-dotnetcore10 rh-nodejs4"
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/1.0/Dockerfile.rhel7
+++ b/1.0/Dockerfile.rhel7
@@ -8,7 +8,7 @@ ENV DOTNET_CORE_VERSION=1.0
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8 \
     HOME=/opt/app-root \
-    PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/bin:/opt/app-root/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     STI_SCRIPTS_PATH=/usr/libexec/s2i
 
 LABEL io.k8s.description="Platform for building and running .NET Core 1.0 applications" \
@@ -38,7 +38,7 @@ RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-7-server-dotnet-rpms && \
     yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.0-rpms && \
-    yum install -y --setopt=tsflags=nodocs rh-dotnetcore10 nss_wrapper tar && \
+    yum install -y --setopt=tsflags=nodocs rh-dotnetcore10 nss_wrapper tar rh-nodejs4-npm && \
     yum clean all && \
     mkdir -p /opt/app-root/src && \
     useradd -u 1001 -r -g 0 -d /opt/app-root/src -s /sbin/nologin \
@@ -72,7 +72,7 @@ RUN chown -R 1001:0 /opt/app-root && chmod -R og+rwx /opt/app-root
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/opt/app-root \
-    ENABLED_COLLECTIONS=rh-dotnetcore10
+    ENABLED_COLLECTIONS="rh-dotnetcore11 rh-nodejs4"
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/1.0/README.md
+++ b/1.0/README.md
@@ -96,6 +96,12 @@ a `.s2i/environment` file inside your source code repository.
 
     Used to select the project to run. This must be the folder containing
     `project.json`. Defaults to `.`.
+    The application is built using the `dotnet publish` command.
+
+* **DOTNET_NPM_TOOLS**
+
+    Used to specify a list of npm packages to install before building the app.
+    Defaults to ``.
 
 * **DOTNET_TEST_PROJECTS**
 
@@ -105,7 +111,7 @@ a `.s2i/environment` file inside your source code repository.
 * **DOTNET_CONFIGURATION**
 
     Used to run the application in Debug or Release mode. This should be either
-    `Release` or `Debug`.  This is passed to the `dotnet build` invocation.
+    `Release` or `Debug`.  This is passed to the `dotnet publish` invocation.
     Defaults to `Release`.
 
 * **DOTNET_RESTORE_ROOT**
@@ -117,3 +123,10 @@ a `.s2i/environment` file inside your source code repository.
 
     This variable is set to `http://*:8080` to configure ASP.NET Core to use the
     port exposed by the image.
+
+NPM
+---
+
+Typical modern web applications rely on javascript tools to build the front-end.
+The image includes npm (node package manager) to install these tools. Packages can be
+installed by setting `DOTNET_NPM_TOOLS` and by calling `npm install` in the build process.

--- a/1.0/s2i/bin/assemble
+++ b/1.0/s2i/bin/assemble
@@ -10,6 +10,14 @@ DOTNET_RESTORE_ROOT="${DOTNET_RESTORE_ROOT:-.}"
 # Private environment
 DOTNET_FRAMEWORK="netcoreapp1.0"
 
+# npm
+if [ -n "${DOTNET_NPM_TOOLS}" ]; then
+  echo "---> Installing npm tools ..."
+  pushd $HOME
+  npm install ${DOTNET_NPM_TOOLS}
+  popd
+fi
+
 echo "---> Copying application source ..."
 cp -Rf /tmp/src/. ./
 

--- a/1.0/test/newweb/.s2i/bin/assemble
+++ b/1.0/test/newweb/.s2i/bin/assemble
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# generate the project
+pushd /tmp/src
+dotnet new -t web
+popd
+
+# call base assemble script
+$STI_SCRIPTS_PATH/assemble

--- a/1.0/test/newweb/.s2i/environment
+++ b/1.0/test/newweb/.s2i/environment
@@ -1,0 +1,1 @@
+DOTNET_NPM_TOOLS=bower gulp

--- a/1.0/test/newweb/placeholder
+++ b/1.0/test/newweb/placeholder
@@ -1,0 +1,3 @@
+This folder contains the 'new web template'.
+Instead of generating it once and storing it in the repo, we generate it in '.s2i/bin/assemble'.
+This ensures it is always up-to-date with the template provided by the sdk.

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -87,6 +87,19 @@ check_result() {
   fi
 }
 
+check_command_exists_at()
+{
+  local command=$1
+  local at=$2
+  info "Testing if ${command} is at ${at}"
+  local actual=$(docker run ${IMAGE_NAME}-testapp bash -c "command -v ${command}")
+  if [[ "${at}_" != "${actual}_" ]]; then
+    info "TEST FAILED (${command} is at ${actual}, expected ${at})"
+    cleanup
+    exit $result
+  fi
+}
+
 wait_for_cid() {
   local max_attempts=10
   local sleep_time=1
@@ -161,8 +174,12 @@ test_http() {
     status=$?
     if [ $status -eq 0 ]; then
       if [ $response_code -eq 200 ]; then
-        output=$(cat ${output_file})
-        if [ "${output}_" == "${expected}_" ]; then
+        if [ $# -gt 1 ]; then
+          output=$(cat ${output_file})
+          if [ "${output}_" == "${expected}_" ]; then
+            result=0
+          fi
+        else
           result=0
         fi
       fi
@@ -191,6 +208,9 @@ test_web_application() {
   check_result $?
   test_scl_usage "echo \$HOME" "/opt/app-root" "${cid_file}"
   check_result $?
+
+  # Verify npm is enabled in the container
+  test_scl_usage "npm --version" "2.15.1" "${cid_file}"
 
   test_http "/" "Hello world"
   check_result $?
@@ -329,6 +349,28 @@ test_cli_app() {
   cleanup ${app}
 }
 
+test_new_web_app() {
+  app=newweb
+  prepare ${app}
+  run_s2i_build ${app}
+  check_result $?
+
+  local cid_file=$(mktemp -u --suffix=.cid)
+  run_test_application &
+  wait_for_cid
+
+  # installed via DOTNET_NPM_TOOLS
+  check_command_exists_at bower /opt/app-root/node_modules/.bin/bower
+
+  # minified using npm tools
+  test_http "/js/site.min.js"
+  check_result $?
+
+  cleanup_app
+  info "All tests for the ${app} finished successfully."
+  cleanup ${app}
+}
+
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
 s2i_args="--force-pull=false"
@@ -360,5 +402,7 @@ for app in ${WEB_APPS[@]}; do
   info "All tests for the ${app} finished successfully."
   cleanup ${app}
 done
+
+test_new_web_app
 
 info "All tests finished successfully."

--- a/1.1/Dockerfile.rhel7
+++ b/1.1/Dockerfile.rhel7
@@ -8,7 +8,7 @@ ENV DOTNET_CORE_VERSION=1.1
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8 \
     HOME=/opt/app-root \
-    PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/bin:/opt/app-root/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     STI_SCRIPTS_PATH=/usr/libexec/s2i
 
 LABEL io.k8s.description="Platform for building and running .NET Core 1.1 applications" \
@@ -35,10 +35,11 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 COPY ./contrib/ /opt/app-root
 
 RUN yum install -y yum-utils && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-dotnet-rpms && \
     yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.0-rpms && \
-    yum install -y --setopt=tsflags=nodocs rh-dotnetcore11 nss_wrapper tar && \
+    yum install -y --setopt=tsflags=nodocs rh-dotnetcore11 nss_wrapper tar rh-nodejs4-npm && \
     yum clean all && \
     mkdir -p /opt/app-root/src && \
     useradd -u 1001 -r -g 0 -d /opt/app-root/src -s /sbin/nologin \
@@ -72,7 +73,7 @@ RUN chown -R 1001:0 /opt/app-root && chmod -R og+rwx /opt/app-root
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/opt/app-root \
-    ENABLED_COLLECTIONS=rh-dotnetcore11
+    ENABLED_COLLECTIONS="rh-dotnetcore11 rh-nodejs4"
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/1.1/README.md
+++ b/1.1/README.md
@@ -96,6 +96,12 @@ a `.s2i/environment` file inside your source code repository.
 
     Used to select the project to run. This must be the folder containing
     `project.json`. Defaults to `.`.
+    The application is built using the `dotnet publish` command.
+
+* **DOTNET_NPM_TOOLS**
+
+    Used to specify a list of npm packages to install before building the app.
+    Defaults to ``.
 
 * **DOTNET_TEST_PROJECTS**
 
@@ -105,7 +111,7 @@ a `.s2i/environment` file inside your source code repository.
 * **DOTNET_CONFIGURATION**
 
     Used to run the application in Debug or Release mode. This should be either
-    `Release` or `Debug`.  This is passed to the `dotnet build` invocation.
+    `Release` or `Debug`.  This is passed to the `dotnet publish` invocation.
     Defaults to `Release`.
 
 * **DOTNET_RESTORE_ROOT**
@@ -117,3 +123,10 @@ a `.s2i/environment` file inside your source code repository.
 
     This variable is set to `http://*:8080` to configure ASP.NET Core to use the
     port exposed by the image.
+
+NPM
+---
+
+Typical modern web applications rely on javascript tools to build the front-end.
+The image includes npm (node package manager) to install these tools. Packages can be
+installed by setting `DOTNET_NPM_TOOLS` and by calling `npm install` in the build process.

--- a/1.1/s2i/bin/assemble
+++ b/1.1/s2i/bin/assemble
@@ -10,6 +10,14 @@ DOTNET_RESTORE_ROOT="${DOTNET_RESTORE_ROOT:-.}"
 # Private environment
 DOTNET_FRAMEWORK="netcoreapp1.1"
 
+# npm
+if [ -n "${DOTNET_NPM_TOOLS}" ]; then
+  echo "---> Installing npm tools ..."
+  pushd $HOME
+  npm install ${DOTNET_NPM_TOOLS}
+  popd
+fi
+
 echo "---> Copying application source ..."
 cp -Rf /tmp/src/. ./
 

--- a/1.1/test/newweb/.s2i/bin/assemble
+++ b/1.1/test/newweb/.s2i/bin/assemble
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# generate the project
+pushd /tmp/src
+dotnet new -t web
+popd
+
+# call base assemble script
+$STI_SCRIPTS_PATH/assemble

--- a/1.1/test/newweb/.s2i/environment
+++ b/1.1/test/newweb/.s2i/environment
@@ -1,0 +1,1 @@
+DOTNET_NPM_TOOLS=bower gulp

--- a/1.1/test/newweb/placeholder
+++ b/1.1/test/newweb/placeholder
@@ -1,0 +1,3 @@
+This folder contains the 'new web template'.
+Instead of generating it once and storing it in the repo, we generate it in '.s2i/bin/assemble'.
+This ensures it is always up-to-date with the template provided by the sdk.

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -87,6 +87,19 @@ check_result() {
   fi
 }
 
+check_command_exists_at()
+{
+  local command=$1
+  local at=$2
+  info "Testing if ${command} is at ${at}"
+  local actual=$(docker run ${IMAGE_NAME}-testapp bash -c "command -v ${command}")
+  if [[ "${at}_" != "${actual}_" ]]; then
+    info "TEST FAILED (${command} is at ${actual}, expected ${at})"
+    cleanup
+    exit $result
+  fi
+}
+
 wait_for_cid() {
   local max_attempts=10
   local sleep_time=1
@@ -161,8 +174,12 @@ test_http() {
     status=$?
     if [ $status -eq 0 ]; then
       if [ $response_code -eq 200 ]; then
-        output=$(cat ${output_file})
-        if [ "${output}_" == "${expected}_" ]; then
+        if [ $# -gt 1 ]; then
+          output=$(cat ${output_file})
+          if [ "${output}_" == "${expected}_" ]; then
+            result=0
+          fi
+        else
           result=0
         fi
       fi
@@ -329,6 +346,28 @@ test_cli_app() {
   cleanup ${app}
 }
 
+test_new_web_app() {
+  app=newweb
+  prepare ${app}
+  run_s2i_build ${app}
+  check_result $?
+
+  local cid_file=$(mktemp -u --suffix=.cid)
+  run_test_application &
+  wait_for_cid
+
+  # installed via DOTNET_NPM_TOOLS
+  check_command_exists_at bower /opt/app-root/node_modules/.bin/bower
+
+  # minified using npm tools
+  test_http "/js/site.min.js"
+  check_result $?
+
+  cleanup_app
+  info "All tests for the ${app} finished successfully."
+  cleanup ${app}
+}
+
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
 s2i_args="--force-pull=false"
@@ -360,5 +399,7 @@ for app in ${WEB_APPS[@]}; do
   info "All tests for the ${app} finished successfully."
   cleanup ${app}
 done
+
+test_new_web_app
 
 info "All tests finished successfully."

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -209,6 +209,9 @@ test_web_application() {
   test_scl_usage "echo \$HOME" "/opt/app-root" "${cid_file}"
   check_result $?
 
+  # Verify npm is enabled in the container
+  test_scl_usage "npm --version" "2.15.1" "${cid_file}"
+
   test_http "/" "Hello world"
   check_result $?
   test_http "/TextFile.txt" "A text file."


### PR DESCRIPTION
Typical modern web applications rely on javascript tools to build the front-end.
The image includes npm (node package manager) to install these tools. Packages can be
installed by setting `DOTNET_NPM_TOOLS` and by calling `npm install` in the build process.