### PR TITLE
Fix build failure due to .NET framework target

### DIFF
--- a/1.0/s2i/bin/assemble
+++ b/1.0/s2i/bin/assemble
@@ -16,6 +16,12 @@ cp -Rf /tmp/src/. ./
 echo "---> Installing dependencies ..."
 dotnet restore $DOTNET_RESTORE_ROOT
 
+# The publish operation fails when .NET framework targets are included in project.json
+# See https://github.com/dotnet/cli/issues/3636
+# This bug won't be fixed for project.json, workaround:
+export DOTNET_REFERENCE_ASSEMBLIES_PATH=/tmp/reference_assemblies
+mkdir -p $DOTNET_REFERENCE_ASSEMBLIES_PATH/.NETFramework/{v3.5,v4.0,v4.5,v4.5.1,v4.5.2,v4.6,v4.6.1,v4.6.2}
+
 echo "---> Building application from source ..."
 dotnet publish -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" "$DOTNET_STARTUP_PROJECT"
 

--- a/1.0/s2i/bin/assemble
+++ b/1.0/s2i/bin/assemble
@@ -20,7 +20,7 @@ dotnet restore $DOTNET_RESTORE_ROOT
 # See https://github.com/dotnet/cli/issues/3636
 # This bug won't be fixed for project.json, workaround:
 export DOTNET_REFERENCE_ASSEMBLIES_PATH=/tmp/reference_assemblies
-mkdir -p $DOTNET_REFERENCE_ASSEMBLIES_PATH/.NETFramework/{v3.5,v4.0,v4.5,v4.5.1,v4.5.2,v4.6,v4.6.1,v4.6.2}
+mkdir -p $DOTNET_REFERENCE_ASSEMBLIES_PATH/.NETFramework/{v1.1,v2.0,v3.5,v4.0,v4.0.3,v4.5,v4.5.1,v4.5.2,v4.6,v4.6.1,v4.6.2}
 
 echo "---> Building application from source ..."
 dotnet publish -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" "$DOTNET_STARTUP_PROJECT"

--- a/1.0/test/hw_framework_config/project.json
+++ b/1.0/test/hw_framework_config/project.json
@@ -3,6 +3,9 @@
   "buildOptions": {
     "emitEntryPoint": true
   },
+  "dependencies":{
+    "Microsoft.AspNetCore": "1.0.3"
+  },
   "frameworks": {
     "net451": {},
     "netcoreapp1.0": {

--- a/1.1/s2i/bin/assemble
+++ b/1.1/s2i/bin/assemble
@@ -16,6 +16,12 @@ cp -Rf /tmp/src/. ./
 echo "---> Installing dependencies ..."
 dotnet restore $DOTNET_RESTORE_ROOT
 
+# The publish operation fails when .NET framework targets are included in project.json
+# See https://github.com/dotnet/cli/issues/3636
+# This bug won't be fixed for project.json, workaround:
+export DOTNET_REFERENCE_ASSEMBLIES_PATH=/tmp/reference_assemblies
+mkdir -p $DOTNET_REFERENCE_ASSEMBLIES_PATH/.NETFramework/{v3.5,v4.0,v4.5,v4.5.1,v4.5.2,v4.6,v4.6.1,v4.6.2}
+
 echo "---> Building application from source ..."
 dotnet publish -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" "$DOTNET_STARTUP_PROJECT"
 

--- a/1.1/s2i/bin/assemble
+++ b/1.1/s2i/bin/assemble
@@ -30,6 +30,8 @@ for TEST_PROJECT in $DOTNET_TEST_PROJECTS; do
     dotnet test "$TEST_PROJECT" -f "$DOTNET_FRAMEWORK"
 done
 
+rm -rf $DOTNET_REFERENCE_ASSEMBLIES_PATH
+
 # Fix source directory permissions
 fix-permissions ./
 # set permissions for any installed artifacts

--- a/1.1/s2i/bin/assemble
+++ b/1.1/s2i/bin/assemble
@@ -20,7 +20,7 @@ dotnet restore $DOTNET_RESTORE_ROOT
 # See https://github.com/dotnet/cli/issues/3636
 # This bug won't be fixed for project.json, workaround:
 export DOTNET_REFERENCE_ASSEMBLIES_PATH=/tmp/reference_assemblies
-mkdir -p $DOTNET_REFERENCE_ASSEMBLIES_PATH/.NETFramework/{v3.5,v4.0,v4.5,v4.5.1,v4.5.2,v4.6,v4.6.1,v4.6.2}
+mkdir -p $DOTNET_REFERENCE_ASSEMBLIES_PATH/.NETFramework/{v1.1,v2.0,v3.5,v4.0,v4.0.3,v4.5,v4.5.1,v4.5.2,v4.6,v4.6.1,v4.6.2}
 
 echo "---> Building application from source ..."
 dotnet publish -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" "$DOTNET_STARTUP_PROJECT"

--- a/1.1/test/hw_framework_config/project.json
+++ b/1.1/test/hw_framework_config/project.json
@@ -3,6 +3,9 @@
   "buildOptions": {
     "emitEntryPoint": true
   },
+  "dependencies":{
+    "Microsoft.AspNetCore": "1.1.0"
+  },
   "frameworks": {
     "net451": {},
     "netcoreapp1.1": {


### PR DESCRIPTION
The hw_framework_config test includes a .NET framework target. When a dependency is added to the test project, the publish will fail with this message:

error DOTNET1012: The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.