### PR TITLE
Make all DOTNET_ envvars, build envvars only

### DIFF
--- a/1.0/Dockerfile.rhel7
+++ b/1.0/Dockerfile.rhel7
@@ -9,7 +9,9 @@ ENV DOTNET_CORE_VERSION=1.0
 ENV LANG=C.UTF-8 \
     HOME=/opt/app-root \
     PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/bin:/opt/app-root/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-    STI_SCRIPTS_PATH=/usr/libexec/s2i
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    DOTNET_PUBLISH_PATH=/opt/app-root/publish \
+    DOTNET_RUN_SCRIPT=/opt/app-root/publish/s2i_run
 
 LABEL io.k8s.description="Platform for building and running .NET Core 1.0 applications" \
       io.k8s.display-name=".NET Core 1.0" \
@@ -41,7 +43,7 @@ RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-7-server-ose-3.0-rpms && \
     yum install -y --setopt=tsflags=nodocs rh-dotnetcore10 nss_wrapper tar rh-nodejs4-npm && \
     yum clean all && \
-    mkdir -p /opt/app-root/src && \
+    mkdir -p /opt/app-root/src /opt/app-root/publish && \
     useradd -u 1001 -r -g 0 -d /opt/app-root/src -s /sbin/nologin \
       -c "Default Application User" default && \
     chown -R 1001:0 /opt/app-root

--- a/1.0/s2i/bin/assemble
+++ b/1.0/s2i/bin/assemble
@@ -31,12 +31,22 @@ export DOTNET_REFERENCE_ASSEMBLIES_PATH=/tmp/reference_assemblies
 mkdir -p $DOTNET_REFERENCE_ASSEMBLIES_PATH/.NETFramework/{v1.1,v2.0,v3.5,v4.0,v4.0.3,v4.5,v4.5.1,v4.5.2,v4.6,v4.6.1,v4.6.2}
 
 echo "---> Building application from source ..."
-dotnet publish -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" "$DOTNET_STARTUP_PROJECT"
+dotnet publish -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" "$DOTNET_STARTUP_PROJECT" -o "$DOTNET_PUBLISH_PATH"
 
 for TEST_PROJECT in $DOTNET_TEST_PROJECTS; do
     echo "---> Running test project: $TEST_PROJECT..."
     dotnet test "$TEST_PROJECT" -f "$DOTNET_FRAMEWORK"
 done
+
+rm -rf $DOTNET_REFERENCE_ASSEMBLIES_PATH
+
+# Create run script in publish folder
+APP_DLL_NAME="$(basename "$(realpath "${DOTNET_STARTUP_PROJECT}")").dll"
+cat << EOF >"$DOTNET_RUN_SCRIPT"
+#!/bin/bash
+exec dotnet ${APP_DLL_NAME} \$@
+EOF
+chmod +x "$DOTNET_RUN_SCRIPT"
 
 # Fix source directory permissions
 fix-permissions ./

--- a/1.0/s2i/bin/run
+++ b/1.0/s2i/bin/run
@@ -3,21 +3,14 @@ source /opt/app-root/etc/generate_container_user
 
 set -e
 
-# User settable environment
-DOTNET_CONFIGURATION="${DOTNET_CONFIGURATION:-Release}"
-DOTNET_STARTUP_PROJECT="${DOTNET_STARTUP_PROJECT:-.}"
-
-# Private environment
-DOTNET_FRAMEWORK="netcoreapp1.0"
-APP_DLL_NAME="$(basename "$(realpath "${DOTNET_STARTUP_PROJECT}")").dll"
-APP_DLL_DIR="${DOTNET_STARTUP_PROJECT}/bin/${DOTNET_CONFIGURATION}/${DOTNET_FRAMEWORK}/publish"
+cd $DOTNET_PUBLISH_PATH
 
 ARG_FILE="arguments.txt"
 if [[ -f "${ARG_FILE}" ]]; then
   echo "---> Running application with arguments from file '${ARG_FILE}' ..."
   PROG_ARGS="$(cat ${ARG_FILE})"
-  cd "${APP_DLL_DIR}" && exec dotnet "${APP_DLL_NAME}" ${PROG_ARGS}
+  exec "$DOTNET_RUN_SCRIPT" ${PROG_ARGS}
 else
   echo "---> Running application ..."
-  cd "${APP_DLL_DIR}" && exec dotnet "${APP_DLL_NAME}"
+  exec "$DOTNET_RUN_SCRIPT"
 fi

--- a/1.0/test/dotnetbot/project.json
+++ b/1.0/test/dotnetbot/project.json
@@ -13,5 +13,10 @@
     "netcoreapp1.0": {
       "imports": "dnxcore50"
     }
+  },
+  "publishOptions": {
+    "include": [
+      "arguments.txt"
+    ]
   }
 }

--- a/1.0/test/qotd/project.json
+++ b/1.0/test/qotd/project.json
@@ -16,7 +16,8 @@
   },
   "publishOptions": {
     "include": [
-      "quotes.txt"
+      "quotes.txt",
+      "arguments.txt"
     ]
   }
 }

--- a/1.1/Dockerfile.rhel7
+++ b/1.1/Dockerfile.rhel7
@@ -44,7 +44,7 @@ RUN yum install -y yum-utils && \
     yum install -y --setopt=tsflags=nodocs rh-dotnetcore11 nss_wrapper tar rh-nodejs4-npm && \
     yum clean all && \
     mkdir -p /opt/app-root/src /opt/app-root/publish && \
-    useradd -u 1001 -r -g 0 -d /opt/app-root -s /sbin/nologin \
+    useradd -u 1001 -r -g 0 -d /opt/app-root/src -s /sbin/nologin \
       -c "Default Application User" default && \
     chown -R 1001:0 /opt/app-root
 

--- a/1.1/Dockerfile.rhel7
+++ b/1.1/Dockerfile.rhel7
@@ -9,7 +9,9 @@ ENV DOTNET_CORE_VERSION=1.1
 ENV LANG=C.UTF-8 \
     HOME=/opt/app-root \
     PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/bin:/opt/app-root/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-    STI_SCRIPTS_PATH=/usr/libexec/s2i
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    DOTNET_PUBLISH_PATH=/opt/app-root/publish \
+    DOTNET_RUN_SCRIPT=/opt/app-root/publish/s2i_run
 
 LABEL io.k8s.description="Platform for building and running .NET Core 1.1 applications" \
       io.k8s.display-name=".NET Core 1.1" \
@@ -41,8 +43,8 @@ RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-7-server-ose-3.0-rpms && \
     yum install -y --setopt=tsflags=nodocs rh-dotnetcore11 nss_wrapper tar rh-nodejs4-npm && \
     yum clean all && \
-    mkdir -p /opt/app-root/src && \
-    useradd -u 1001 -r -g 0 -d /opt/app-root/src -s /sbin/nologin \
+    mkdir -p /opt/app-root/src /opt/app-root/publish && \
+    useradd -u 1001 -r -g 0 -d /opt/app-root -s /sbin/nologin \
       -c "Default Application User" default && \
     chown -R 1001:0 /opt/app-root
 

--- a/1.1/s2i/bin/assemble
+++ b/1.1/s2i/bin/assemble
@@ -25,12 +25,20 @@ echo "---> Installing dependencies ..."
 dotnet restore $DOTNET_RESTORE_ROOT
 
 echo "---> Building application from source ..."
-dotnet publish -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" "$DOTNET_STARTUP_PROJECT"
+dotnet publish -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" "$DOTNET_STARTUP_PROJECT" -o "$DOTNET_PUBLISH_PATH"
 
 for TEST_PROJECT in $DOTNET_TEST_PROJECTS; do
     echo "---> Running test project: $TEST_PROJECT..."
     dotnet test "$TEST_PROJECT" -f "$DOTNET_FRAMEWORK"
 done
+
+# Create run script in publish folder
+APP_DLL_NAME="$(basename "$(realpath "${DOTNET_STARTUP_PROJECT}")").dll"
+cat << EOF >"$DOTNET_RUN_SCRIPT"
+#!/bin/bash
+exec dotnet ${APP_DLL_NAME} \$@
+EOF
+chmod +x "$DOTNET_RUN_SCRIPT"
 
 # Fix source directory permissions
 fix-permissions ./

--- a/1.1/s2i/bin/run
+++ b/1.1/s2i/bin/run
@@ -3,21 +3,14 @@ source /opt/app-root/etc/generate_container_user
 
 set -e
 
-# User settable environment
-DOTNET_CONFIGURATION="${DOTNET_CONFIGURATION:-Release}"
-DOTNET_STARTUP_PROJECT="${DOTNET_STARTUP_PROJECT:-.}"
-
-# Private environment
-DOTNET_FRAMEWORK="netcoreapp1.1"
-APP_DLL_NAME="$(basename "$(realpath "${DOTNET_STARTUP_PROJECT}")").dll"
-APP_DLL_DIR="${DOTNET_STARTUP_PROJECT}/bin/${DOTNET_CONFIGURATION}/${DOTNET_FRAMEWORK}/publish"
+cd $DOTNET_PUBLISH_PATH
 
 ARG_FILE="arguments.txt"
 if [[ -f "${ARG_FILE}" ]]; then
   echo "---> Running application with arguments from file '${ARG_FILE}' ..."
   PROG_ARGS="$(cat ${ARG_FILE})"
-  cd "${APP_DLL_DIR}" && exec dotnet "${APP_DLL_NAME}" ${PROG_ARGS}
+  exec "$DOTNET_RUN_SCRIPT" ${PROG_ARGS}
 else
   echo "---> Running application ..."
-  cd "${APP_DLL_DIR}" && exec dotnet "${APP_DLL_NAME}"
+  exec "$DOTNET_RUN_SCRIPT"
 fi

--- a/1.1/test/dotnetbot/project.json
+++ b/1.1/test/dotnetbot/project.json
@@ -13,5 +13,10 @@
     "netcoreapp1.1": {
       "imports": "dnxcore50"
     }
+  },
+  "publishOptions": {
+    "include": [
+      "arguments.txt"
+    ]
   }
 }

--- a/1.1/test/qotd/project.json
+++ b/1.1/test/qotd/project.json
@@ -16,7 +16,8 @@
   },
   "publishOptions": {
     "include": [
-      "quotes.txt"
+      "quotes.txt",
+      "arguments.txt"
     ]
   }
 }


### PR DESCRIPTION
Environment variables used by the assemble and run script, need to
be provided in the OpenShift build environment and deployment
environment.

We only uses the DOTNET_ environment variables in the
assemble script (build environment). The output is published
at /opt/app-root/publish including an s2i_run script to start
the .NET Core application.