### PR TITLE
Add a simple set of tests for released images

### DIFF
--- a/1.0/test/run
+++ b/1.0/test/run
@@ -6,11 +6,17 @@
 # IMAGE_NAME specifies a name of the candidate image used for testing.
 # The image has to be available before this script is executed.
 #
+# OPENSHIFT_ONLY environment variable, if 'true', only tests features used by
+# OpenShift's try-it feature.
+#
 # DEBUG environment variable, if not empty, makes 'run' to log every step
 # of testing.
 #
 # Example usage: $ sudo ./test/run
+
 IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnetcore-10-rhel7}
+
+OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 
 if [ "$DEBUG" != "" ]; then
   set -x
@@ -21,6 +27,7 @@ declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
+dotnet_version="1.0.0-preview2-003156"
 
 test_port=8080
 
@@ -207,7 +214,7 @@ test_web_application() {
   # Wait for the container to write it's CID file
   wait_for_cid
 
-  test_scl_usage "dotnet --version" "1.0.0-preview2-003156" "${cid_file}"
+  test_scl_usage "dotnet --version" "${dotnet_version}" "${cid_file}"
   check_result $?
 
   # Verify $HOME != $CWD. See https://github.com/redhat-developer/s2i-dotnetcore/issues/28
@@ -225,6 +232,23 @@ test_web_application() {
   check_result $?
 
   test_pid_1 "${cid_file}"
+  check_result $?
+
+  cleanup_app
+}
+
+test_web_application_basic() {
+  local cid_file=$(mktemp -u --suffix=.cid)
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+
+  test_scl_usage "dotnet --version" "${dotnet_version}" "${cid_file}"
+  check_result $?
+
+  test_http "/" "Hello world"
   check_result $?
 
   cleanup_app
@@ -361,6 +385,8 @@ test_new_web_app() {
   cleanup ${app}
 }
 
+info "Testing ${IMAGE_NAME}"
+
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
 s2i_args="--force-pull=false"
@@ -373,26 +399,43 @@ check_result $?
 test_docker_run_usage
 check_result $?
 
-# Verify that some CLI s2i apps build and run properly
-for app in ${CLI_APPS[@]}; do
-  test_cli_app "${app}"
-done
-
-for app in ${WEB_APPS[@]}; do
+# Verify OpenShift's hello-world runs
+if [ ${OPENSHIFT_ONLY} = true ]; then
+  app=asp-net-hello-world
   prepare ${app}
   run_s2i_build ${app}
   check_result $?
 
   # test application with default user
-  test_web_application
+  test_web_application_basic
 
   # test application with random user
-  CONTAINER_ARGS="-u 12345" test_web_application
+  CONTAINER_ARGS="-u 12345" test_web_application_basic
 
   info "All tests for the ${app} finished successfully."
   cleanup ${app}
-done
+else
+  # Verify that some CLI s2i apps build and run properly
+  for app in ${CLI_APPS[@]}; do
+    test_cli_app "${app}"
+  done
 
-test_new_web_app
+  for app in ${WEB_APPS[@]}; do
+    prepare ${app}
+    run_s2i_build ${app}
+    check_result $?
+
+    # test application with default user
+    test_web_application
+
+    # test application with random user
+    CONTAINER_ARGS="-u 12345" test_web_application
+
+    info "All tests for the ${app} finished successfully."
+    cleanup ${app}
+  done
+
+  test_new_web_app
+fi
 
 info "All tests finished successfully."

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -6,11 +6,17 @@
 # IMAGE_NAME specifies a name of the candidate image used for testing.
 # The image has to be available before this script is executed.
 #
+# OPENSHIFT_ONLY environment variable, if 'true', only tests features used by
+# OpenShift's try-it feature.
+#
 # DEBUG environment variable, if not empty, makes 'run' to log every step
 # of testing.
 #
 # Example usage: $ sudo ./test/run
+
 IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnetcore-11-rhel7}
+
+OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 
 if [ "$DEBUG" != "" ]; then
   set -x
@@ -21,6 +27,7 @@ declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
+dotnet_version="1.0.0-preview2-1-003175"
 
 test_port=8080
 
@@ -207,7 +214,7 @@ test_web_application() {
   # Wait for the container to write it's CID file
   wait_for_cid
 
-  test_scl_usage "dotnet --version" "1.0.0-preview2-1-003175" "${cid_file}"
+  test_scl_usage "dotnet --version" "${dotnet_version}" "${cid_file}"
   check_result $?
 
   # Verify $HOME != $CWD. See https://github.com/redhat-developer/s2i-dotnetcore/issues/28
@@ -225,6 +232,23 @@ test_web_application() {
   check_result $?
 
   test_pid_1 "${cid_file}"
+  check_result $?
+
+  cleanup_app
+}
+
+test_web_application_basic() {
+  local cid_file=$(mktemp -u --suffix=.cid)
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+
+  test_scl_usage "dotnet --version" "${dotnet_version}" "${cid_file}"
+  check_result $?
+
+  test_http "/" "Hello world"
   check_result $?
 
   cleanup_app
@@ -361,6 +385,8 @@ test_new_web_app() {
   cleanup ${app}
 }
 
+info "Testing ${IMAGE_NAME}"
+
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
 s2i_args="--force-pull=false"
@@ -373,26 +399,43 @@ check_result $?
 test_docker_run_usage
 check_result $?
 
-# Verify that some CLI s2i apps build and run properly
-for app in ${CLI_APPS[@]}; do
-  test_cli_app "${app}"
-done
-
-for app in ${WEB_APPS[@]}; do
+# Verify OpenShift's hello-world runs
+if [ ${OPENSHIFT_ONLY} = true ]; then
+  app=asp-net-hello-world
   prepare ${app}
   run_s2i_build ${app}
   check_result $?
 
   # test application with default user
-  test_web_application
+  test_web_application_basic
 
   # test application with random user
-  CONTAINER_ARGS="-u 12345" test_web_application
+  CONTAINER_ARGS="-u 12345" test_web_application_basic
 
   info "All tests for the ${app} finished successfully."
   cleanup ${app}
-done
+else
+  # Verify that some CLI s2i apps build and run properly
+  for app in ${CLI_APPS[@]}; do
+    test_cli_app "${app}"
+  done
 
-test_new_web_app
+  for app in ${WEB_APPS[@]}; do
+    prepare ${app}
+    run_s2i_build ${app}
+    check_result $?
+
+    # test application with default user
+    test_web_application
+
+    # test application with random user
+    CONTAINER_ARGS="-u 12345" test_web_application
+
+    info "All tests for the ${app} finished successfully."
+    cleanup ${app}
+  done
+
+  test_new_web_app
+fi
 
 info "All tests finished successfully."

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,10 @@
 # Supported environment variables:
 #
 # -----------------------------------------------------
+# TEST_OPENSHIFT  If 'true' run tests to make sure
+#                 released images work against the
+#                 test application used in OpenShift
+#
 # VERSIONS     The list of versions to build/test.
 #              Defaults to all versions. i.e "1.0 1.1".
 # -----------------------------------------------------
@@ -50,6 +54,18 @@ for v in ${VERSIONS}; do
     check_result_msg $? "Tests for image ${img_name} FAILED!"
   popd &>/dev/null
 done
+
+if [ "$TEST_OPENSHIFT" = "true" ]; then
+  for v in ${VERSIONS}; do
+    v_no_dot="$( version_no_dot ${v} )"
+    img_name="registry.access.redhat.com/dotnet/dotnetcore-${v_no_dot}-rhel7:latest"
+    pushd ${v} &>/dev/null
+      echo "Running tests on image ${img_name} ..."
+      IMAGE_NAME="${img_name}" OPENSHIFT_ONLY=true ./test/run
+      check_result_msg $? "Tests for image ${img_name} FAILED!"
+    popd &>/dev/null
+  done
+fi
 
 echo "ALL builds and tests were successful!"
 exit 0


### PR DESCRIPTION
The asp-net-hello-world application is used as a sample application by OpenShift for released versions of this image. We need a smaller set of tests to ensure that the released versions of this image continue working with asp-net-hello-world application.

Unlike the existing tests, this test should just check that the image 'works'. It doesn't have to be exhaustive and shouldn't test all applications, just the one that will be used by OpenShift. Newer
features like 'npm' are obviously not going to be supported on older released images.

Sample invocation:

    # docker stop $(docker ps -a -q)
    # docker rmi $(docker images -q)
    # IMAGE_NAME=registry.access.redhat.com/dotnet/dotnetcore-10-rhel7:latest OPENSHIFT_ONLY=true 1.0/test/run

~~If the changes look okay for 1.0, I will make similar changes to 1.1.~~ Changes for 1.1 are done.