### PR TITLE
Fix sample app for released images.

### DIFF
--- a/1.0/test/asp-net-hello-world/.s2i/environment
+++ b/1.0/test/asp-net-hello-world/.s2i/environment
@@ -1,1 +1,0 @@
-DOTNET_ASSEMBLY_NAME=SampleApp

--- a/1.0/test/asp-net-hello-world/Startup.cs
+++ b/1.0/test/asp-net-hello-world/Startup.cs
@@ -51,9 +51,7 @@ namespace SampleApp
                 })
                 .UseUrls("http://0.0.0.0:8080")
                 .UseContentRoot(Directory.GetCurrentDirectory())
-                // Specify the startup class by Assembly name
-                // The assembly is named correctly by setting DOTNET_ASSEMBLY_NAME
-                .UseStartup("SampleApp")
+                .UseStartup<Startup>()
                 .Build();
 
             // The following section should be used to demo sockets

--- a/1.1/test/asp-net-hello-world/.s2i/environment
+++ b/1.1/test/asp-net-hello-world/.s2i/environment
@@ -1,1 +1,0 @@
-DOTNET_ASSEMBLY_NAME=SampleApp

--- a/1.1/test/asp-net-hello-world/Startup.cs
+++ b/1.1/test/asp-net-hello-world/Startup.cs
@@ -51,9 +51,7 @@ namespace SampleApp
                 })
                 .UseUrls("http://0.0.0.0:8080")
                 .UseContentRoot(Directory.GetCurrentDirectory())
-                // Specify the startup class by Assembly name
-                // The assembly is named correctly by setting DOTNET_ASSEMBLY_NAME
-                .UseStartup("SampleApp")
+                .UseStartup<Startup>()
                 .Build();
 
             // The following section should be used to demo sockets


### PR DESCRIPTION
Reverts part of 0f7a0e399b19721f240fed1183e8f46d5a2564bb. The
sample app after 0f7a0e399 expected the assembly to be
"SampleApp.dll", but the released images build "src.dll", thus
the app doesn't boot.

Also remove the environment variable as this is only needed for
unreleased images to build "SampleApp.dll" assemblies.

Closes #49