### PR TITLE
Switch to OSE 3.2 RPMs repo.

### DIFF
--- a/1.0/Dockerfile.rhel7
+++ b/1.0/Dockerfile.rhel7
@@ -40,7 +40,7 @@ RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-dotnet-rpms && \
     yum-config-manager --enable rhel-7-server-rpms && \
-    yum-config-manager --enable rhel-7-server-ose-3.0-rpms && \
+    yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum install -y --setopt=tsflags=nodocs rh-dotnetcore10 nss_wrapper tar rh-nodejs4-npm && \
     yum clean all && \
     mkdir -p /opt/app-root/src /opt/app-root/publish && \

--- a/1.1/Dockerfile.rhel7
+++ b/1.1/Dockerfile.rhel7
@@ -40,7 +40,7 @@ RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-dotnet-rpms && \
     yum-config-manager --enable rhel-7-server-rpms && \
-    yum-config-manager --enable rhel-7-server-ose-3.0-rpms && \
+    yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum install -y --setopt=tsflags=nodocs rh-dotnetcore11 nss_wrapper tar rh-nodejs4-npm && \
     yum clean all && \
     mkdir -p /opt/app-root/src /opt/app-root/publish && \


### PR DESCRIPTION
OSE 3.0 is fairly outdated. sclorg[1] is using 3.2
as well. This makes us more consistent.

[1] https://github.com/sclorg/s2i-python-container/blob/master/3.5/Dockerfile.rhel7#L30