### PR TITLE
Avoid symbolic links.

### DIFF
--- a/1.1/root/usr/bin/fix-permissions
+++ b/1.1/root/usr/bin/fix-permissions
@@ -5,4 +5,4 @@
 #       some world-writable perms :(
 chgrp -R 0 $1
 chmod -R og+rw $1
-find $1 -type d -exec chmod g+x {} +
+find $1 -type d ! -type l -exec chmod g+x {} +


### PR DESCRIPTION
When you use fix-permissions with a directory which has any symbolic link it hangs:
```
chgrp: cannot dereference './my-symbolic-link-source-dir': No such file or directory
```

Don't know if I'm doing something wrong but avoiding symbolic links seems a reasonable solution to me.