### PR TITLE
Use s2i-dotnetcore-ex as primary sample app.

### DIFF
--- a/1.0/s2i/bin/usage
+++ b/1.0/s2i/bin/usage
@@ -9,7 +9,7 @@ To use it, install S2I: https://github.com/openshift/source-to-image
 
 Sample invocation:
 
-sudo s2i build https://github.com/redhat-developer/s2i-dotnetcore.git --context-dir=1.0/test/asp-net-hello-world/ ${NAMESPACE}/dotnetcore-10-${DISTRO}7 dotnet-sample-app
+sudo s2i build https://github.com/redhat-developer/s2i-dotnetcore-ex.git --context-dir=app --ref=dotnetcore-1.0 ${NAMESPACE}/dotnetcore-10-${DISTRO}7 dotnet-sample-app
 
 You can then run the resulting image via:
 sudo docker run -p 8080:8080 dotnet-sample-app

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -128,13 +128,15 @@ wait_for_cid() {
 }
 
 test_s2i_usage() {
-  info "Testing 's2i usage' ..."
-  s2i usage ${s2i_args} ${IMAGE_NAME} 2>&1 | grep https://github.com/redhat-developer/s2i-dotnetcore.git 2>&1 > /dev/null
+  local expected="$1"
+  info "Testing 's2i usage (${expected})' ..."
+  s2i usage ${s2i_args} ${IMAGE_NAME} 2>&1 | grep "${expected}" 2>&1 > /dev/null
 }
 
 test_docker_run_usage() {
-  info "Testing 'docker run' usage ..."
-  docker run ${IMAGE_NAME} 2>&1 | grep https://github.com/redhat-developer/s2i-dotnetcore.git 2>&1 >/dev/null
+  local expected="$1"
+  info "Testing 'docker run' usage (${expected}) ..."
+  docker run ${IMAGE_NAME} 2>&1 | grep "${expected}" 2>&1 >/dev/null
 }
 
 test_pid_1() {
@@ -392,11 +394,16 @@ info "Testing ${IMAGE_NAME}"
 s2i_args="--force-pull=false"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
-test_s2i_usage
+exp="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
+if [ ${OPENSHIFT_ONLY} = true ]; then
+  # Old released images still have s2i-dotnetcore's Hello World app.
+  exp="https://github.com/redhat-developer/s2i-dotnetcore.git"
+fi
+test_s2i_usage "${exp}"
 check_result $?
 
 # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
-test_docker_run_usage
+test_docker_run_usage "${exp}"
 check_result $?
 
 # Verify OpenShift's hello-world runs

--- a/1.1/s2i/bin/usage
+++ b/1.1/s2i/bin/usage
@@ -9,7 +9,7 @@ To use it, install S2I: https://github.com/openshift/source-to-image
 
 Sample invocation:
 
-sudo s2i build https://github.com/redhat-developer/s2i-dotnetcore.git --context-dir=1.1/test/asp-net-hello-world/ ${NAMESPACE}/dotnetcore-11-${DISTRO}7 dotnet-sample-app
+sudo s2i build https://github.com/redhat-developer/s2i-dotnetcore-ex.git --context-dir=app --ref=dotnetcore-1.1 ${NAMESPACE}/dotnetcore-11-${DISTRO}7 dotnet-sample-app
 
 You can then run the resulting image via:
 sudo docker run -p 8080:8080 dotnet-sample-app

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -128,13 +128,15 @@ wait_for_cid() {
 }
 
 test_s2i_usage() {
-  info "Testing 's2i usage' ..."
-  s2i usage ${s2i_args} ${IMAGE_NAME} 2>&1 | grep https://github.com/redhat-developer/s2i-dotnetcore.git 2>&1 > /dev/null
+  local expected="$1"
+  info "Testing 's2i usage (${expected})' ..."
+  s2i usage ${s2i_args} ${IMAGE_NAME} 2>&1 | grep "${expected}" 2>&1 > /dev/null
 }
 
 test_docker_run_usage() {
-  info "Testing 'docker run' usage ..."
-  docker run ${IMAGE_NAME} 2>&1 | grep https://github.com/redhat-developer/s2i-dotnetcore.git 2>&1 >/dev/null
+  local expected="$1"
+  info "Testing 'docker run' usage (${expected}) ..."
+  docker run ${IMAGE_NAME} 2>&1 | grep "${expected}" 2>&1 >/dev/null
 }
 
 test_pid_1() {
@@ -392,11 +394,16 @@ info "Testing ${IMAGE_NAME}"
 s2i_args="--force-pull=false"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
-test_s2i_usage
+exp="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
+if [ ${OPENSHIFT_ONLY} = true ]; then
+  # Old released images still have s2i-dotnetcore's Hello World app.
+  exp="https://github.com/redhat-developer/s2i-dotnetcore.git"
+fi
+test_s2i_usage "${exp}"
 check_result $?
 
 # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
-test_docker_run_usage
+test_docker_run_usage "${exp}"
 check_result $?
 
 # Verify OpenShift's hello-world runs


### PR DESCRIPTION
Switch to redhat-developer/s2i-dotnetcore-ex as the primary sample
application shown in s2i-usage. The new sample app is a more exciting
example than then simple "Hello World" app we've used previously.

Updates to the image stream will happen later once the new images have
been released.