### PR TITLE
[README] Add a link to dotnet-example's sample usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,9 @@ oc create -f <template.json>
 
 **dotnet-example**
 
-The dotnet-example template can be used to create a new .NET Core service in OpenShift. It provides parameters for all the environment
-variables of the s2i-dotnetcore builder. It also includes a liveness and a readiness probe.
+The dotnet-example template can be used to create a new .NET Core service in
+OpenShift. It provides parameters for all the environment variables of the
+s2i-dotnetcore builder. It also includes a liveness and a readiness probe. See
+the [s2i-dotnetcore-ex
+repository](https://github.com/redhat-developer/s2i-dotnetcore-ex/tree/master#use-a-template-to-build-and-deploy-a-sample-application)
+for an example as to how the template can be used.


### PR DESCRIPTION
This depends on https://github.com/redhat-developer/s2i-dotnetcore-ex/pull/26

Rendered page here:
https://github.com/jerboaa/s2i-dotnetcore/tree/readme_reference_template_usage

[skipci]