### PR TITLE
Update bits following 1.0.4/1.1.1 releases.

### DIFF
--- a/1.0/Dockerfile.rhel7
+++ b/1.0/Dockerfile.rhel7
@@ -24,7 +24,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 1.0 applic
 LABEL name="dotnet/dotnetcore-10-rhel7" \
       com.redhat.component="rh-dotnetcore10-docker" \
       version="1.0" \
-      release="12" \
+      release="14" \
       architecture="x86_64"
 
 COPY ./root/usr/bin /usr/bin

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -27,7 +27,7 @@ declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
-dotnet_version="1.0.0-preview2-003156"
+dotnet_version="1.0.0-preview2-003157"
 
 test_port=8080
 

--- a/1.1/Dockerfile.rhel7
+++ b/1.1/Dockerfile.rhel7
@@ -24,7 +24,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 1.1 applic
 LABEL name="dotnet/dotnetcore-11-rhel7" \
       com.redhat.component="rh-dotnetcore11-docker" \
       version="1.1" \
-      release="2" \
+      release="5" \
       architecture="x86_64"
 
 COPY ./root/usr/bin /usr/bin

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -27,7 +27,7 @@ declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
-dotnet_version="1.0.0-preview2-1-003175"
+dotnet_version="1.0.0-preview2-1-003176"
 
 test_port=8080
 


### PR DESCRIPTION
- Update the release tag (latest tags available in RH registry)
- Update 'dotnet --version' expected output in tests.