### PR TITLE
Fix openshift s2i tests after 1.0.4/1.1.1 releases.

### DIFF
--- a/1.0/test/run
+++ b/1.0/test/run
@@ -28,6 +28,7 @@ declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
 dotnet_version="1.0.0-preview2-003157"
+sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 
 test_port=8080
 
@@ -49,7 +50,12 @@ container_ip() {
 
 run_s2i_build() {
   info "Building the ${1} application image ..."
-  s2i build ${s2i_args} file://${test_dir}/${1} ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+  run_s2i_build_from_url "file://${test_dir}/${1}"
+}
+
+run_s2i_build_from_url() {
+  local url="$1"
+  s2i build ${s2i_args} "${url}" ${IMAGE_NAME} ${IMAGE_NAME}-testapp
 }
 
 prepare() {
@@ -175,9 +181,17 @@ test_scl_usage() {
   fi
 }
 
+# Usage:
+#   test_http <path> <expected> [<filter_cmd>]
+#
+# Issues a HTTP GET request with path <path> and matches it against
+# <expected>. The match is an *exact*, character by character, match
+# unless <filter_cmd> is also specified. In that case, the output of
+# the HTTP GET request at <path> is filtered through <filter_cmd>.
 test_http() {
   local path=$1
   local expected=$2
+  local filter_cmd="$3"
   local output_file=$(mktemp --suffix=.dotnet_out)
   local max_attempts=30
   local sleep_time=1
@@ -190,8 +204,13 @@ test_http() {
     status=$?
     if [ $status -eq 0 ]; then
       if [ $response_code -eq 200 ]; then
-        if [ $# -gt 1 ]; then
+        if [ $# -eq 2 ]; then
           output=$(cat ${output_file})
+          if [ "${output}_" == "${expected}_" ]; then
+            result=0
+          fi
+        elif [ $# -eq 3 ]; then
+          output=$(cat ${output_file} | eval ${filter_cmd})
           if [ "${output}_" == "${expected}_" ]; then
             result=0
           fi
@@ -239,7 +258,7 @@ test_web_application() {
   cleanup_app
 }
 
-test_web_application_basic() {
+test_openshift_sample_app() {
   local cid_file=$(mktemp -u --suffix=.cid)
   # Verify that the HTTP connection can be established to test application container
   run_test_application &
@@ -250,7 +269,7 @@ test_web_application_basic() {
   test_scl_usage "dotnet --version" "${dotnet_version}" "${cid_file}"
   check_result $?
 
-  test_http "/" "Hello world"
+  test_http "/" "Sample pages using ASP.NET Core MVC" "grep \"ASP.NET Core MVC\" | sed -e 's#<li>##g' -e 's#</li>##g' -e 's#^ \\+##g'"
   check_result $?
 
   cleanup_app
@@ -394,33 +413,29 @@ info "Testing ${IMAGE_NAME}"
 s2i_args="--force-pull=false"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
-exp="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
-if [ ${OPENSHIFT_ONLY} = true ]; then
-  # Old released images still have s2i-dotnetcore's Hello World app.
-  exp="https://github.com/redhat-developer/s2i-dotnetcore.git"
-fi
-test_s2i_usage "${exp}"
+test_s2i_usage "${sample_app_url}"
 check_result $?
 
 # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
-test_docker_run_usage "${exp}"
+test_docker_run_usage "${sample_app_url}"
 check_result $?
 
-# Verify OpenShift's hello-world runs
+# Verify OpenShift's s2i-dotnetcore-ex runs
 if [ ${OPENSHIFT_ONLY} = true ]; then
-  app=asp-net-hello-world
-  prepare ${app}
-  run_s2i_build ${app}
+  old_s2i_args="${s2i_args}"
+  s2i_args="${s2i_args} --context-dir=app --ref=dotnetcore-1.0"
+  run_s2i_build_from_url ${sample_app_url}
   check_result $?
 
   # test application with default user
-  test_web_application_basic
+  test_openshift_sample_app
 
   # test application with random user
-  CONTAINER_ARGS="-u 12345" test_web_application_basic
+  CONTAINER_ARGS="-u 12345" test_openshift_sample_app
 
-  info "All tests for the ${app} finished successfully."
-  cleanup ${app}
+  info "All tests for the ${sample_app_url} finished successfully."
+  cleanup "ignore-me"
+  s2i_args="${old_s2i_args}"
 else
   # Verify that some CLI s2i apps build and run properly
   for app in ${CLI_APPS[@]}; do

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -28,6 +28,7 @@ declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
 dotnet_version="1.0.0-preview2-1-003176"
+sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 
 test_port=8080
 
@@ -49,7 +50,12 @@ container_ip() {
 
 run_s2i_build() {
   info "Building the ${1} application image ..."
-  s2i build ${s2i_args} file://${test_dir}/${1} ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+  run_s2i_build_from_url "file://${test_dir}/${1}"
+}
+
+run_s2i_build_from_url() {
+  local url="$1"
+  s2i build ${s2i_args} "${url}" ${IMAGE_NAME} ${IMAGE_NAME}-testapp
 }
 
 prepare() {
@@ -175,9 +181,17 @@ test_scl_usage() {
   fi
 }
 
+# Usage:
+#   test_http <path> <expected> [<filter_cmd>]
+#
+# Issues a HTTP GET request with path <path> and matches it against
+# <expected>. The match is an *exact*, character by character, match
+# unless <filter_cmd> is also specified. In that case, the output of
+# the HTTP GET request at <path> is filtered through <filter_cmd>.
 test_http() {
   local path=$1
   local expected=$2
+  local filter_cmd="$3"
   local output_file=$(mktemp --suffix=.dotnet_out)
   local max_attempts=30
   local sleep_time=1
@@ -190,8 +204,13 @@ test_http() {
     status=$?
     if [ $status -eq 0 ]; then
       if [ $response_code -eq 200 ]; then
-        if [ $# -gt 1 ]; then
+        if [ $# -eq 2 ]; then
           output=$(cat ${output_file})
+          if [ "${output}_" == "${expected}_" ]; then
+            result=0
+          fi
+        elif [ $# -eq 3 ]; then
+          output=$(cat ${output_file} | eval ${filter_cmd})
           if [ "${output}_" == "${expected}_" ]; then
             result=0
           fi
@@ -239,7 +258,7 @@ test_web_application() {
   cleanup_app
 }
 
-test_web_application_basic() {
+test_openshift_sample_app() {
   local cid_file=$(mktemp -u --suffix=.cid)
   # Verify that the HTTP connection can be established to test application container
   run_test_application &
@@ -250,7 +269,7 @@ test_web_application_basic() {
   test_scl_usage "dotnet --version" "${dotnet_version}" "${cid_file}"
   check_result $?
 
-  test_http "/" "Hello world"
+  test_http "/" "Sample pages using ASP.NET Core MVC" "grep \"ASP.NET Core MVC\" | sed -e 's#<li>##g' -e 's#</li>##g' -e 's#^ \\+##g'"
   check_result $?
 
   cleanup_app
@@ -394,33 +413,29 @@ info "Testing ${IMAGE_NAME}"
 s2i_args="--force-pull=false"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
-exp="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
-if [ ${OPENSHIFT_ONLY} = true ]; then
-  # Old released images still have s2i-dotnetcore's Hello World app.
-  exp="https://github.com/redhat-developer/s2i-dotnetcore.git"
-fi
-test_s2i_usage "${exp}"
+test_s2i_usage "${sample_app_url}"
 check_result $?
 
 # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
-test_docker_run_usage "${exp}"
+test_docker_run_usage "${sample_app_url}"
 check_result $?
 
-# Verify OpenShift's hello-world runs
+# Verify OpenShift's s2i-dotnetcore-ex runs
 if [ ${OPENSHIFT_ONLY} = true ]; then
-  app=asp-net-hello-world
-  prepare ${app}
-  run_s2i_build ${app}
+  old_s2i_args="${s2i_args}"
+  s2i_args="${s2i_args} --context-dir=app --ref=dotnetcore-1.1"
+  run_s2i_build_from_url ${sample_app_url}
   check_result $?
 
   # test application with default user
-  test_web_application_basic
+  test_openshift_sample_app
 
   # test application with random user
-  CONTAINER_ARGS="-u 12345" test_web_application_basic
+  CONTAINER_ARGS="-u 12345" test_openshift_sample_app
 
-  info "All tests for the ${app} finished successfully."
-  cleanup ${app}
+  info "All tests for the ${sample_app_url} finished successfully."
+  cleanup "ignore-me"
+  s2i_args="${old_s2i_args}"
 else
   # Verify that some CLI s2i apps build and run properly
   for app in ${CLI_APPS[@]}; do


### PR DESCRIPTION
The tests for the OpenShift sample app were broken. The old images used the Hello World test app in s2i-dotnetcore. The new images that went out use s2i-dotnetcore-ex. Thus, `s2i usage` was failing for the new images in the Red Hat registry.

With this patch OpenShift sample app tests (via `OPENSHIFT_ONLY=true`) can get re-enabled. Thoughts?