### PR TITLE
[dotnet-pgsql-persistent] Use Secret objects for passwords.

### DIFF
--- a/templates/dotnet-pgsql-persistent.json
+++ b/templates/dotnet-pgsql-persistent.json
@@ -19,6 +19,26 @@
     },
     "objects": [
         {
+            "kind": "Secret",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "database"
+            },
+            "stringData": {
+                "database-password": "${DATABASE_PASSWORD}"
+            }
+        },
+        {
+            "kind": "Secret",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "database-connection"
+            },
+            "stringData": {
+                "connect-string": "Host=${DATABASE_SERVICE_NAME};Database=${DATABASE_NAME};Username=${DATABASE_USER};Password=${DATABASE_PASSWORD}"
+            }
+        },
+        {
             "kind": "Service",
             "apiVersion": "v1",
             "metadata": {
@@ -209,7 +229,12 @@
                                 "env": [
                                     {
                                         "name": "ConnectionString",
-                                        "value": "Host=${DATABASE_SERVICE_NAME};Database=${DATABASE_NAME};Username=${DATABASE_USER};Password=${DATABASE_PASSWORD}"
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "name": "database-connection",
+                                                "key": "connect-string"
+                                            }
+                                        }
                                     }
                                 ],
                                 "resources": {
@@ -373,7 +398,12 @@
                                     },
                                     {
                                         "name": "POSTGRESQL_PASSWORD",
-                                        "value": "${DATABASE_PASSWORD}"
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "name": "database",
+                                                "key": "database-password"
+                                            }
+                                        }
                                     },
                                     {
                                         "name": "POSTGRESQL_DATABASE",

--- a/templates/dotnet-pgsql-persistent.json
+++ b/templates/dotnet-pgsql-persistent.json
@@ -22,19 +22,10 @@
             "kind": "Secret",
             "apiVersion": "v1",
             "metadata": {
-                "name": "database"
+                "name": "${NAME}"
             },
             "stringData": {
-                "database-password": "${DATABASE_PASSWORD}"
-            }
-        },
-        {
-            "kind": "Secret",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "database-connection"
-            },
-            "stringData": {
+                "database-password": "${DATABASE_PASSWORD}",
                 "connect-string": "Host=${DATABASE_SERVICE_NAME};Database=${DATABASE_NAME};Username=${DATABASE_USER};Password=${DATABASE_PASSWORD}"
             }
         },
@@ -231,7 +222,7 @@
                                         "name": "ConnectionString",
                                         "valueFrom": {
                                             "secretKeyRef": {
-                                                "name": "database-connection",
+                                                "name": "${NAME}",
                                                 "key": "connect-string"
                                             }
                                         }
@@ -400,7 +391,7 @@
                                         "name": "POSTGRESQL_PASSWORD",
                                         "valueFrom": {
                                             "secretKeyRef": {
-                                                "name": "database",
+                                                "name": "${NAME}",
                                                 "key": "database-password"
                                             }
                                         }


### PR DESCRIPTION
The OpenShift web console shows regular environment variables for
pods, et. al. However, for passwords or things that contain passwords
the web console should not show them by default. Using Secret objects
for secret values in the template will achieve this.

See also:
https://github.com/openshift/origin/pull/13528

Fixes RHBZ#1233513

Connect string after:
![screenshot from 2017-04-20 15-01-56](https://cloud.githubusercontent.com/assets/357222/25232799/f4991602-25dc-11e7-8e55-93083ee47495.png)
Connect string before:
![screenshot from 2017-04-20 15-03-20](https://cloud.githubusercontent.com/assets/357222/25232821/0902816e-25dd-11e7-886f-be733676cdf5.png)

PgSQL password after:
![screenshot from 2017-04-20 15-02-24](https://cloud.githubusercontent.com/assets/357222/25232887/2e8718be-25dd-11e7-87ed-63c95e2b3dea.png)
PgSQL password before:
![screenshot from 2017-04-20 15-03-47](https://cloud.githubusercontent.com/assets/357222/25232892/37f5b702-25dd-11e7-8827-10444f48ae0d.png)


