### PR TITLE
Restore and publish using the rhel7 rid.

### DIFF
--- a/2.0/s2i/bin/assemble
+++ b/2.0/s2i/bin/assemble
@@ -8,6 +8,7 @@ DOTNET_STARTUP_PROJECT="${DOTNET_STARTUP_PROJECT:-.}"
 
 # Private environment
 DOTNET_FRAMEWORK="netcoreapp2.0"
+DOTNET_RID=rhel.7-x64
 
 # npm
 if [ -n "${DOTNET_NPM_TOOLS}" ]; then
@@ -52,26 +53,25 @@ else
 fi
 
 # Build nuget sources list for when doing the restore
-RESTORE_OPTIONS=""
+# TODO: initialize RESTORE_OPTIONS to empty string
+RESTORE_OPTIONS="--source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://api.nuget.org/v3/index.json"
 for SOURCE in $DOTNET_RESTORE_SOURCES; do
   RESTORE_OPTIONS="$RESTORE_OPTIONS --source $SOURCE"
 done
 
 # run tests
 for TEST_PROJECT in $DOTNET_TEST_PROJECTS; do
+    echo "---> Restoring test project ($TEST_PROJECT) dependencies..."
+    dotnet restore "$TEST_PROJECT" -r "$DOTNET_RID" $RESTORE_OPTIONS
     echo "---> Running test project: $TEST_PROJECT..."
-    pushd "$TEST_PROJECT"
-    dotnet restore $RESTORE_OPTIONS
-    dotnet test -f "$DOTNET_FRAMEWORK"
-    popd
+    dotnet test "$TEST_PROJECT" -f "$DOTNET_FRAMEWORK"
 done
 
 # publish application
-echo "---> Publishing application ..."
-pushd "$DOTNET_STARTUP_PROJECT"
-dotnet restore $RESTORE_OPTIONS
-dotnet publish -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" -o "$DOTNET_PUBLISH_PATH"
-popd
+echo "---> Restoring application dependencies..."
+dotnet restore "$DOTNET_STARTUP_PROJECT" -r "$DOTNET_RID" $RESTORE_OPTIONS
+echo "---> Publishing application..."
+dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" -r "$DOTNET_RID" /p:SelfContained=false -o "$DOTNET_PUBLISH_PATH"
 
 # check if the assembly used by the script exists
 if [ ! -f "$DOTNET_PUBLISH_PATH/${APP_DLL_NAME}" ]; then

--- a/2.0/test/asp-net-hello-world-envvar/.s2i/environment
+++ b/2.0/test/asp-net-hello-world-envvar/.s2i/environment
@@ -1,6 +1,7 @@
 DOTNET_STARTUP_PROJECT=src/app
 DOTNET_CONFIGURATION=Debug
-TODO_DOTNET_TEST_PROJECTS=test/test1 test/test2
+DOTNET_TEST_PROJECTS=test/test1 test/test2
 DOTNET_ASSEMBLY_NAME=SampleApp
-DOTNET_RESTORE_SOURCES=https://api.nuget.org/v3/index.json https://www.myget.org/F/s2i-dotnetcore
+LANG=en_US.UTF-8
+DOTNET_RESTORE_SOURCES=https://dotnet.myget.org/F/vstest/api/v3/index.json https://api.nuget.org/v3/index.json https://www.myget.org/F/s2i-dotnetcore
 

--- a/2.0/test/asp-net-hello-world-envvar/test/test1/test1.csproj
+++ b/2.0/test/asp-net-hello-world-envvar/test/test1/test1.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.1.0-preview-20170414-10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170502-02" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/2.0/test/asp-net-hello-world-envvar/test/test2/test2.csproj
+++ b/2.0/test/asp-net-hello-world-envvar/test/test2/test2.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170502-02" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/2.0/test/run
+++ b/2.0/test/run
@@ -22,7 +22,7 @@ if [ "$DEBUG" != "" ]; then
   set -x
 fi
 
-# TODO: tests are no longer working in asp-net-hello-world-envvar (disabled in .s2i/environment)
+# TODO: vstest is broken for asp-net-hello-world-envvar (workaround in .s2i/environment: LANG and vstest feed)
 declare -a CLI_APPS=(hw_framework_config helloworld qotd)
 declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 


### PR DESCRIPTION
This publishes an app for rhel7 that uses the shared runtime and that
doesn't include dependencies needed to run on the shared runtime of
other platforms (e.g. osx, windows, ubuntu).