### PR TITLE
Remove old disable repo code.

### DIFF
--- a/2.0/Dockerfile.rhel7
+++ b/2.0/Dockerfile.rhel7
@@ -42,7 +42,8 @@ RUN yum repolist --disablerepo=* && \
     yum-config-manager --enable rhel-7-server-rpms > /dev/null
 
 # TODO: install rh-dotnet20
-RUN yum install -y yum-utils && \
+RUN yum install --disablerepo=\* --enablerepo=rhel-7-server-rpms -y yum-utils && \
+    yum-config-manager --disable \* && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-dotnet-rpms && \
     yum-config-manager --enable rhel-7-server-rpms && \

--- a/2.0/Dockerfile.rhel7
+++ b/2.0/Dockerfile.rhel7
@@ -36,11 +36,6 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 # run and build the applications.
 COPY ./contrib/ /opt/app-root
 
-# TODO: remove this (https://access.redhat.com/solutions/1443553: Permanently Enabling/Disabling repositories from a Dockerfile)
-RUN yum repolist --disablerepo=* && \
-    yum-config-manager --disable \* > /dev/null && \
-    yum-config-manager --enable rhel-7-server-rpms > /dev/null
-
 # TODO: install rh-dotnet20
 RUN yum install --disablerepo=\* --enablerepo=rhel-7-server-rpms -y yum-utils && \
     yum-config-manager --disable \* && \


### PR DESCRIPTION
The code in PR #81  brings this in line with the 1.0 and 1.1 releases.
Also, it seems like this is going to become a long-term fix, so the TODO about removal is no longer valid.
