### PR TITLE
[WIP] Create a runtime image from a build image

### DIFF
--- a/2.0/build-runtime_image.sh
+++ b/2.0/build-runtime_image.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Setup initial variables
+RUNTIME_BASE_IMAGE=${RUNTIME_BASE_IMAGE:-rhel7}
+BUILD_IMAGE=$1
+BINARY_TAR=publish.tar.gz
+DOCKERFILE_TEMPLATE=${DOCKERFILE_TEMPLATE:-runtime-dockerfile-template}
+# TODO: is here a way to get this from the build image?
+DOTNET_PUBLISH_PATH=${DOTNET_PUBLISH_PATH:-/opt/app-root/publish}
+
+# Check for missing files and images to fail early
+if ! $(docker inspect ${BUILD_IMAGE} &> /dev/null); then
+	echo "Could not locate a docker image by the name of '${BUILD_IMAGE}'."
+	exit 1
+fi
+if ! $(docker inspect ${BUILD_IMAGE} &> /dev/null); then
+	echo "Could not locate a docker image by the name of '${RUNTIME_BASE_IMAGE}'."
+	exit 1
+fi
+if [ ! -e ${DOCKERFILE_TEMPLATE} ]; then
+	echo "Could not locate runtime dockerfile file template."
+	echo "It was expected to be '${DOCKERFILE_TEMPLATE}'"
+	exit 1
+fi
+
+# Create the new runtime image name
+if [[ ${BUILD_IMAGE} =~ : ]]
+then
+	RUNTIME_IMAGE_NAME=$(echo ${BUILD_IMAGE} | sed -e 's/:/-runtime:/' -)
+else
+	RUNTIME_IMAGE_NAME="${BUILD_IMAGE}-runtime"
+fi
+
+# Create a temp directory to hold our temporary files
+TMPDIR=$(mktemp -d)
+# TODO: Figure out a better way to allow access from the image /OTHER/ than 777
+chmod 777 ${TMPDIR}
+echo "Created temp directory ${TMPDIR}"
+
+# create a subroutine to cleanup our tmp files
+cleanup() {
+	if [ -n ${TMPDIR} ] && [ -e ${TMPDIR} ]; then
+		echo "Removing temp directory ${TMPDIR}"
+		rm -rf ${TMPDIR}
+	fi
+}
+
+RUNTIME_DOCKERFILE=${TMPDIR}/Dockerfile.rhel7.runtime
+
+# Grab the build artifacts from the build image
+docker run --rm --volume=${TMPDIR}:/opt/app-root/tmp:Z ${BUILD_IMAGE} tar zcvpf /opt/app-root/tmp/${BINARY_TAR} -C ${DOTNET_PUBLISH_PATH} .
+
+if [ ! -e "${TMPDIR}/${BINARY_TAR}" ] || [ ! -s "${TMPDIR}/${BINARY_TAR}" ]; then
+	echo "Failed to extract the publish directory from the build image '${BUILD_IMAGE}'."
+	cleanup
+	exit 1
+fi
+
+# We need to replace a number of 'tags' in the template
+# So we'll loop through a matched pair of arrays for that
+# TODO: Would it be worth it to see if we can make the dockerfile template
+#       version generic using these tags?
+tag_keys=(
+	__RUNTIME_BASE_IMAGE__
+	__BINARY_TAR__
+	__DOTNET_PUBLISH_PATH__
+)
+
+declare -a tag_vals=(
+	${RUNTIME_BASE_IMAGE}
+	${BINARY_TAR}
+	${DOTNET_PUBLISH_PATH}
+)
+
+cp ${DOCKERFILE_TEMPLATE} ${RUNTIME_DOCKERFILE}
+for ((i=0;i<${#tag_keys[@]};++i)); do
+	# Note the use of '|' instead of '/' as the regex separator
+	# This is done because '/' is a common character in docker image names.
+	sed -i "s|${tag_keys[$i]}|${tag_vals[$i]}|g" ${RUNTIME_DOCKERFILE}
+done
+
+# Prepare the tmp directory
+
+# Copy other necessary files
+cp -r root ${TMPDIR}/root
+cp -r s2i ${TMPDIR}/s2i
+
+# Build the runtime image
+docker build -f ${RUNTIME_DOCKERFILE} -t ${RUNTIME_IMAGE_NAME} ${TMPDIR}
+
+cleanup

--- a/2.0/runtime-dockerfile-template
+++ b/2.0/runtime-dockerfile-template
@@ -1,0 +1,87 @@
+FROM __RUNTIME_BASE_IMAGE__
+
+EXPOSE 8080
+
+ENV DOTNET_CORE_VERSION=2.0
+
+# Directory with the sources is set as the working directory. This should
+# be a folder outside $HOME as this might cause issues when compiling sources.
+# See https://github.com/redhat-developer/s2i-dotnetcore/issues/28
+WORKDIR __DOTNET_PUBLISH_PATH__
+
+# Default to UTF-8 file.encoding
+ENV LANG=C.UTF-8 \
+    HOME=__DOTNET_PUBLISH_PATH__ \
+    PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/bin:/opt/app-root/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:__DOTNET_PUBLISH_PATH__ \
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    DOTNET_PUBLISH_PATH=__DOTNET_PUBLISH_PATH__ \
+    DOTNET_RUN_SCRIPT=__DOTNET_PUBLISH_PATH__/s2i_run
+
+LABEL io.k8s.description="Platform for building and running .NET Core 2.0 applications" \
+      io.k8s.display-name=".NET Core 2.0" \
+      io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
+      io.openshift.tags="runtime,.net,dotnet,dotnetcore,rh-dotnet20" \
+      io.openshift.expose-services="8080:http" \
+      io.s2i.scripts-url=image:///usr/libexec/s2i
+
+# Labels consumed by Red Hat build service
+LABEL name="dotnet/dotnet-20-rhel7" \
+      com.redhat.component="rh-dotnet20-docker" \
+      version="2.0" \
+      release="1" \
+      architecture="x86_64"
+
+COPY __BINARY_TAR__ __BINARY_TAR__
+RUN tar xvf __BINARY_TAR__
+
+COPY ./root/usr/bin /usr/bin
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
+COPY ./s2i/bin/ /usr/libexec/s2i
+
+# Each language image can have 'contrib' a directory with extra files needed to
+# run and build the applications.
+#COPY ./contrib/ /opt/app-root
+
+# TODO: install rh-dotnet20
+RUN yum install --disablerepo=\* --enablerepo=rhel-7-server-rpms -y yum-utils && \
+    yum clean all && \
+    mkdir -p __DOTNET_PUBLISH_PATH__ && \
+    useradd -u 1001 -r -g 0 -d __DOTNET_PUBLISH_PATH__ -s /sbin/nologin \
+      -c "Default Application User" default && \
+    chown -R 1001:0 __DOTNET_PUBLISH_PATH__
+
+# TODO: remove upstream sdk
+# install upstream 2.0 sdk
+RUN yum install --disablerepo=\* --enablerepo=rhel-7-server-rpms -y libunwind libicu && \
+	yum clean all && \
+    curl https://download.microsoft.com/download/0/6/5/0656B047-5F2F-4281-A851-F30776F8616D/dotnet-dev-linux-x64.2.0.0-preview1-005977.tar.gz -o /tmp/dotnet-sdk.tar.gz && \
+    mkdir -p /opt/dotnet && \
+    tar xf /tmp/dotnet-sdk.tar.gz -C /opt/dotnet && \
+    ln -s /opt/dotnet/dotnet /usr/bin/dotnet; \
+	rm /tmp/dotnet-sdk.tar.gz; \
+	rm -rf /opt/dotnet/sdk
+
+# Switch back to root for changing dir ownership/permissions
+USER 0
+
+# In order to drop the root user, we have to make some directories world
+# writable as OpenShift default security model is to run the container under
+# random UID.
+RUN chown -R 1001:0 __DOTNET_PUBLISH_PATH__ && chmod -R og+rwx __DOTNET_PUBLISH_PATH__
+
+# Run container by default as user with id 1001 (default)
+USER 1001
+
+# By default, ASP.NET Core runs on port 5000. We configure it to match
+# the container port.
+# Don't download/extract docs for nuget packages
+# Don't initially populate the package cache
+ENV ASPNETCORE_URLS=http://*:8080 \
+	NUGET_XMLDOC_MODE=skip \
+	DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+ENTRYPOINT ["container-entrypoint"]
+
+# Set the default CMD to print the usage of the language image.
+CMD /usr/libexec/s2i/usage

--- a/build.sh
+++ b/build.sh
@@ -57,6 +57,7 @@ for v in ${VERSIONS}; do
     echo "Running tests on image ${img_name} ..."
     ./test/run
     check_result_msg $? "Tests for image ${img_name} FAILED!"
+	# TODO: Add tests for runtime images
   popd &>/dev/null
 done
 


### PR DESCRIPTION
[Bug 1430280](https://bugzilla.redhat.com/show_bug.cgi?id=1430280) relates to having a seperate runtime image that only contains the necessary runtime dependencies for a project, but the build dependencies. This is to reduce the size of the container image that actually runs the application.

With this you can point the build_runtime_image.sh script to a build image (that was built using s2i) and generate a runtime image.

Building the runtime on a rhel7 image brings the image size down from a little over 2 GB to about 380 MB. About 2/3 of what is left is the base OS image and the dotnet runtime.

Currently, there are no automated tests for it, and it needs a lot of safety checks. It also needs the correct documentation headers and updates to the project readme files related to it.