### PR TITLE
Don't do an RID specific restore to avoid downloading runtime.linux-x64.microsoft.netcore.app

### DIFF
--- a/2.0/build/s2i/bin/assemble
+++ b/2.0/build/s2i/bin/assemble
@@ -65,16 +65,16 @@ done
 # run tests
 for TEST_PROJECT in $DOTNET_TEST_PROJECTS; do
     echo "---> Restoring test project ($TEST_PROJECT) dependencies..."
-    dotnet restore "$TEST_PROJECT" -r "$DOTNET_RID" $RESTORE_OPTIONS
+    dotnet restore "$TEST_PROJECT" $RESTORE_OPTIONS
     echo "---> Running test project: $TEST_PROJECT..."
     dotnet test "$TEST_PROJECT" -f "$DOTNET_FRAMEWORK"
 done
 
 # publish application
 echo "---> Restoring application dependencies..."
-dotnet restore "$DOTNET_STARTUP_PROJECT" -r "$DOTNET_RID" $RESTORE_OPTIONS
+dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS
 echo "---> Publishing application..."
-dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" -r "$DOTNET_RID" \
+dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" \
        --self-contained false /p:PublishWithAspNetCoreTargetManifest=$DOTNET_ASPNET_STORE -o "$DOTNET_PUBLISH_PATH"
 
 # check if the assembly used by the script exists


### PR DESCRIPTION
The output of the published folder can be reduced by doing an RID specific publish.
An RID specific publish requires an RID specific restore. The RID specific restore
drags in the microsoft.netcore.app linux-x64 package. This package weighs about 28MB
and is used for self-contained deployments.

So we won't optimize the size of the published folder at the cost of increasing the
restore size.