### PR TITLE
Allow tests to be run stand-alone.

### DIFF
--- a/2.0/runtime/test/run
+++ b/2.0/runtime/test/run
@@ -387,7 +387,7 @@ create_runtime_app() {
   # TODO: Figure out a better way to allow access from the image /OTHER/ than 777
   chmod 777 ${TMPDIR}
   echo "Created temp directory ${TMPDIR}"
-  cp "${app}.tar.gz" "${TMPDIR}/${app}.tar.gz"
+  cp "${test_dir}/${app}.tar.gz" "${TMPDIR}/${app}.tar.gz"
   if [ ! -e "${TMPDIR}/${app}.tar.gz" ] || [ ! -s "${TMPDIR}/${app}.tar.gz" ]; then
     echo "Failed to find the binary tar for app '${app}'."
     echo "Removing temp directory ${TMPDIR}"

--- a/build.sh
+++ b/build.sh
@@ -66,10 +66,8 @@ build_image() {
 test_images() {
   local path=$1
   echo "Running tests..."
-  pushd ${path} > /dev/null
-    ./run
-    check_result_msg $? "Tests FAILED!"
-  popd > /dev/null
+  ${path}/run
+  check_result_msg $? "Tests FAILED!"
 }
 
 # TODO: build 1.0 1.1 


### PR DESCRIPTION
This adjusts scripts so that tests can either be run
directly in the test directory of the respective image
or by calling the test/run script from any directory by
using the path to the test/run script.

The latter wasn't possible prior this patch.