### PR TITLE
Refactor responsibilities runtime & build image

### DIFF
--- a/2.0/build/Dockerfile.rhel7
+++ b/2.0/build/Dockerfile.rhel7
@@ -4,9 +4,7 @@ FROM dotnet/dotnet-20-runtime-rhel7
 
 # Default to UTF-8 file.encoding
 ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/node_modules/.bin:${PATH} \
-    STI_SCRIPTS_PATH=/usr/libexec/s2i \
-    DOTNET_PUBLISH_PATH=/opt/app-root/publish \
-    DOTNET_RUN_SCRIPT=/opt/app-root/publish/s2i_run
+    STI_SCRIPTS_PATH=/usr/libexec/s2i
 
 LABEL io.k8s.description="Platform for building and running .NET Core 2.0 applications" \
       io.k8s.display-name=".NET Core 2.0" \
@@ -22,38 +20,28 @@ LABEL name="dotnet/dotnet-20-rhel7" \
       release="1" \
       architecture="x86_64"
 
-# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
-COPY ./s2i/bin/ /usr/libexec/s2i
-
 # Switch to root for package installs
 USER 0
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
+COPY ./s2i/bin/ /usr/libexec/s2i
 
 # TODO: remove the beta repo once RPMs reach the full release
 RUN INSTALL_PKGS="rh-nodejs6-npm rh-dotnet20-dotnet-sdk-2.0" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
-      --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms,rhel-7-server-rpms,rhel-7-server-ose-3.2-rpms,rhel-7-server-dotnet-beta-rpms,rh-dotnet20 \
+      --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms,rhel-7-server-rpms,rhel-7-server-ose-3.2-rpms,rhel-7-server-dotnet-beta-rpms \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all -y && \
-    mkdir -p /opt/app-root/{src,publish,warmup} && \
-    useradd -u 1001 -r -g 0 -d /opt/app-root/src -s /sbin/nologin \
-      -c "Default Application User" default && \
-    chown -R 1001:0 /opt/app-root
+    yum clean all -y
 
 ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs6"
 
-# In order to drop the root user, we have to make some directories world
-# writable as OpenShift default security model is to run the container under
-# random UID.
-RUN chown -R 1001:0 /opt/app-root && chmod -R og+rwx /opt/app-root
-
-# Directory with the sources is set as the working directory. This should
-# be a folder outside $HOME as this might cause issues when compiling sources.
-# See https://github.com/redhat-developer/s2i-dotnetcore/issues/28
-WORKDIR /opt/app-root/src
-
 # Run container by default as user with id 1001 (default)
 USER 1001
+
+# Directory with the sources is set as the working directory.
+RUN mkdir /opt/app-root/src
+WORKDIR /opt/app-root/src
 
 # Set the default CMD to print the usage of the language image.
 CMD /usr/libexec/s2i/usage

--- a/2.0/build/s2i/bin/assemble
+++ b/2.0/build/s2i/bin/assemble
@@ -76,21 +76,21 @@ echo "---> Restoring application dependencies..."
 dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS
 echo "---> Publishing application..."
 dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" \
-       --self-contained false /p:PublishWithAspNetCoreTargetManifest=$DOTNET_ASPNET_STORE -o "$DOTNET_PUBLISH_PATH"
+       --self-contained false /p:PublishWithAspNetCoreTargetManifest=$DOTNET_ASPNET_STORE -o "$DOTNET_APP_PATH"
 
 # check if the assembly used by the script exists
-if [ ! -f "$DOTNET_PUBLISH_PATH/${APP_DLL_NAME}" ]; then
+if [ ! -f "$DOTNET_APP_PATH/${APP_DLL_NAME}" ]; then
   echo "error: Build output does not contain entrypoint assembly: ${APP_DLL_NAME}"
   exit 1
 fi
 
 # Create run script in publish folder
-cat << EOF >"$DOTNET_RUN_SCRIPT"
+cat << EOF >"$DOTNET_APP_PATH/$DOTNET_DEFAULT_CMD"
 #!/bin/bash
-source /opt/app-root/etc/generate_container_user
+
 exec dotnet ${APP_DLL_NAME} \$@
 EOF
-chmod +x "$DOTNET_RUN_SCRIPT"
+chmod +x "$DOTNET_APP_PATH/$DOTNET_DEFAULT_CMD"
 
 # Fix source directory permissions
 fix-permissions ./

--- a/2.0/build/s2i/bin/run
+++ b/2.0/build/s2i/bin/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cd $DOTNET_PUBLISH_PATH
+cd $DOTNET_APP_PATH
 
 echo "---> Running application ..."
-exec "$DOTNET_RUN_SCRIPT"
+exec "./$DOTNET_DEFAULT_CMD"

--- a/2.0/runtime/Dockerfile.rhel7
+++ b/2.0/runtime/Dockerfile.rhel7
@@ -9,7 +9,9 @@ ENV DOTNET_CORE_VERSION=2.0
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8 \
     HOME=/opt/app-root \
-    PATH=/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    PATH=/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    DOTNET_APP_PATH=/opt/app-root/app \
+    DOTNET_DEFAULT_CMD=default-cmd.sh
 
 LABEL io.k8s.description="Platform for running .NET Core 2.0 applications" \
       io.k8s.display-name=".NET Core 2.0" \
@@ -42,7 +44,7 @@ COPY ./root/usr/bin /usr/bin
 # TODO: remove the beta repo once RPMs reach the full release
 RUN INSTALL_PKGS="rh-dotnet20-dotnet-runtime-2.0 nss_wrapper tar" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
-      --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms,rhel-7-server-rpms,rhel-7-server-ose-3.2-rpms,rhel-7-server-dotnet-beta-rpms,rh-dotnet20 \
+      --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms,rhel-7-server-rpms,rhel-7-server-ose-3.2-rpms,rhel-7-server-dotnet-beta-rpms \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y
@@ -58,12 +60,21 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/etc/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/etc/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/etc/scl_enable"
 
+# Add default user
+RUN mkdir -p ${DOTNET_APP_PATH} && \
+    useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
+      -c "Default Application User" default
+
+WORKDIR ${DOTNET_APP_PATH}
+COPY default-cmd.sh ${DOTNET_DEFAULT_CMD}
+CMD "./${DOTNET_DEFAULT_CMD}"
+
 # In order to drop the root user, we have to make some directories world
 # writable as OpenShift default security model is to run the container under
 # random UID.
 RUN chown -R 1001:0 /opt/app-root && chmod -R og+rwx /opt/app-root
 
-ENTRYPOINT ["container-entrypoint"]
+ENTRYPOINT [ "container-entrypoint" ]
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.0/runtime/README.md
+++ b/2.0/runtime/README.md
@@ -33,13 +33,10 @@ $ docker build -t s2i-dotnetcore-ex .
 
 Start a container:
 ```
-$ docker run -p 8080:8080 s2i-dotnetcore-ex
+$ docker run --rm -p 8080:8080 s2i-dotnetcore-ex
 ```
 
-Fetch a webpage:
-```
-$ curl http://127.0.0.1:8080
-```
+Visit the web application that is running in the docker container with a browser at [http://localhost:8080].
 
 Repository organization
 ------------------------

--- a/2.0/runtime/README.md
+++ b/2.0/runtime/README.md
@@ -9,38 +9,34 @@ The image can be run using [Docker](http://docker.io).
 Usage
 ---------------------
 The distributale binaries of an application should be copied to this image and
-a new docker image should be created using this image as the base. As an
-example, given an archive of the binaries of a simple [dotnet-sample-app](test/asp-net-hello-world)
-application, the following Dockerfile could be used.
+a new docker image should be created using this image as the base.
 
-**Sample Dockerfile**
+For example to create a Docker image for [s2i-dotnetcore-ex](https://github.com/redhat-developer/s2i-dotnetcore-ex) 
+
+Publish the application:
 ```
-FROM dotnet-20-rhel7-runtime
-RUN mkdir -p '/opt/app-root/publish'
-WORKDIR /opt/app-root/publish
-COPY asp-net-hello-world.tar.gz asp-net-hello-world.tar.gz
-RUN tar xvf asp-net-hello-world.tar.gz
-CMD /opt/app-root/publish/s2i_run
+$ git clone -b dotnetcore-2.0 https://github.com/redhat-developer/s2i-dotnetcore-ex.git
+$ cd s2i-dotnetcore-ex/app
+$ dotnet restore -r rhel.7-x64
+$ dotnet publish -f netcoreapp2.0 -c Release -r rhel.7-x64 --self-contained false /p:PublishWithAspNetCoreTargetManifest=false
 ```
 
-As for generating the binary archives in the first place, often this can be
-accomplished by running a dotnet restore and a dotnet publish to a single
-directory and then archiving that directories contents.
-
-**Example Binary Archive Creation**
-``` sh
-cd asp-net-hello-world
-dotnet restore "." -r "rhel.7-x64"
-dotnet publish "." -f "netcoreapp2.0" -c "Release" -r "rhel.7-x64" --self-contained false /p:TargetManifestFiles= -o "./publish"
-tar zcvpf "./asp-net-hello-world.tar.gz" -C ./publish .
+Create the Docker image:
+```
+$ cat > Dockerfile <<EOF
+FROM dotnet/dotnet-20-runtime-rhel7
+ADD bin/Release/netcoreapp2.0/rhel.7-x64/publish/. .
+CMD [ "dotnet", "app.dll" ]
+EOF
+$ docker build -t s2i-dotnetcore-ex .
 ```
 
-This example cds into the project's directory, restores the projects NuGet dependencies, and then publishes the project to a publish directory. Finally, a tar command is used to create a gzipped tar file containing the content of the publish directory. This tar file is what is copied and extracted to create the apps runtime image, using the sample dockerfile given above.
+Start a container:
+```
+$ docker run -p 8080:8080 s2i-dotnetcore-ex
+```
 
-**Accessing the application:**
-
-HTTP:
-
+Fetch a webpage:
 ```
 $ curl http://127.0.0.1:8080
 ```

--- a/2.0/runtime/default-cmd.sh
+++ b/2.0/runtime/default-cmd.sh
@@ -3,5 +3,5 @@
 cat <<EOF
 This is a runtime image for .NET Core ${DOTNET_CORE_VERSION}.
 
-See the documentation at https://github.com/redhat-developer/s2i-dotnetcore.
+See the documentation at https://github.com/redhat-developer/s2i-dotnetcore/tree/master/${DOTNET_CORE_VERSION}/runtime.
 EOF

--- a/2.0/runtime/default-cmd.sh
+++ b/2.0/runtime/default-cmd.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cat <<EOF
+This is a runtime image for .NET Core ${DOTNET_CORE_VERSION}.
+
+See the documentation at https://github.com/redhat-developer/s2i-dotnetcore.
+EOF

--- a/2.0/runtime/root/usr/bin/container-entrypoint
+++ b/2.0/runtime/root/usr/bin/container-entrypoint
@@ -2,6 +2,8 @@
 
 set -eu
 
+# For the main process (PID 1) and children we ensure there is a known user.
+# For other processes (i.e. docker exec) the user isn't added, so it may be unknown.
 if [ $$ -eq 1 ]; then
   source /opt/app-root/etc/generate_container_user
 fi

--- a/2.0/runtime/root/usr/bin/container-entrypoint
+++ b/2.0/runtime/root/usr/bin/container-entrypoint
@@ -1,12 +1,10 @@
 #!/bin/bash
 
 set -eu
-if [ $# -eq 0 ]; then
-	# No arguments given. Try to use s2i_run, if it exists.
-	if [ -f /opt/app-root/publish/s2i_run ]; then
-		exec /opt/app-root/publish/s2i_run
-	fi
-else
-	cmd="$1"; shift
-	exec $cmd "$@"
+
+if [ $$ -eq 1 ]; then
+  source /opt/app-root/etc/generate_container_user
 fi
+
+cmd="$1"; shift
+exec $cmd "$@"

--- a/2.0/runtime/test/run
+++ b/2.0/runtime/test/run
@@ -24,9 +24,18 @@ info() {
 test_cmd() {
   local run_cmd="$1"
   local expected="$2"
+  local user="$3"
 
   info "Running command '${run_cmd}'"
-  out=$(docker run --rm ${IMAGE_NAME} "${run_cmd}" 2>&1)
+  local docker_arg=""
+  if [ -n "${user}" ]; then
+    docker_arg="${docker_arg} --user=${user}"
+  fi
+  if [ -n "${run_cmd}" ]; then
+    out=$(docker run --rm ${docker_arg} ${IMAGE_NAME} "${run_cmd}" 2>&1)
+  else
+    out=$(docker run --rm ${docker_arg} ${IMAGE_NAME} 2>&1)
+  fi
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
     exit 1
@@ -39,7 +48,18 @@ info "Testing ${IMAGE_NAME}"
 # it from Docker hub
 s2i_args="--force-pull=false"
 
+# ENTRYPOINT enables scl so dotnet is available
 test_cmd "dotnet --info" "Microsoft .NET Core Shared Framework Host"
 test_cmd "dotnet" "Usage: dotnet"
+
+# default CMD
+test_cmd "" "This is a runtime image for .NET Core"
+
+# we run as user 'default'
+test_cmd "whoami" "default"
+# other users are mapped to 'default'
+test_cmd "whoami" "default" 100001
+# root is 'root'
+test_cmd "whoami" "root" 0
 
 info "All tests finished successfully."


### PR DESCRIPTION
* replace DOTNET_PUBLISH_PATH and DOTNET_RUN_SCRIPT of builder with DOTNET_APP_PATH and DOTNET_DEFAULT_CMD in runtime.
DOTNET_APP_PATH is at app-root/app and is the WORKDIR for the runtime image.
DOTNET_DEFAULT_CMD is default-cmd.sh and has a default implementation which echos some info
* add user in runtime instead of build
* call generate_container_user in runtime entrypoint when PID == 1
note: generate_container_user creates a new user file for each invocation, it doesn't append
* Update runtime README example to show how to create a Dockerfile from a published app output.
* runtime/test: test nss_wrapper and default-cmd.sh