### PR TITLE
Review permission assignment

### DIFF
--- a/2.0/build/s2i/bin/assemble
+++ b/2.0/build/s2i/bin/assemble
@@ -96,3 +96,6 @@ chmod +x "$DOTNET_APP_PATH/$DOTNET_DEFAULT_CMD"
 fix-permissions ./
 # set permissions for any installed artifacts
 fix-permissions /opt/app-root
+
+# Don't persist the nss_wrapper passwd file
+rm -rf $NSS_WRAPPER_PASSWD

--- a/2.0/build/s2i/bin/assemble
+++ b/2.0/build/s2i/bin/assemble
@@ -96,6 +96,3 @@ chmod +x "$DOTNET_APP_PATH/$DOTNET_DEFAULT_CMD"
 fix-permissions ./
 # set permissions for any installed artifacts
 fix-permissions /opt/app-root
-
-# Don't persist the nss_wrapper passwd file
-rm -rf $NSS_WRAPPER_PASSWD

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -480,6 +480,27 @@ test_new_web_app() {
   cleanup ${app}
 }
 
+test_user() {
+  local app=helloworld
+  info "Test user"
+  prepare ${app}
+  run_s2i_build ${app}
+  check_result $?
+
+  # user to run the app (100002) is different than user that built the app (100001).
+  local actual=$(docker run --user=100002 ${CONTAINER_ARGS} -i --rm ${IMAGE_NAME}-testapp whoami)
+  local expected="default"
+  cleanup ${app}
+
+  if [ "$actual" != "$expected" ]; then
+    info "Test user FAILED."
+    echo_details "${expected}" "${actual}"
+    exit 1
+  fi
+
+  info "Test user PASSED."
+}
+
 info "Testing ${IMAGE_NAME}"
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
@@ -521,6 +542,7 @@ else
   done
 
   test_new_web_app
+  test_user
 fi
 
 info "All tests finished successfully."

--- a/2.0/runtime/Dockerfile.rhel7
+++ b/2.0/runtime/Dockerfile.rhel7
@@ -72,7 +72,7 @@ CMD "./${DOTNET_DEFAULT_CMD}"
 # In order to drop the root user, we have to make some directories world
 # writable as OpenShift default security model is to run the container under
 # random UID.
-RUN chown -R 1001:0 /opt/app-root && chmod -R og+rwx /opt/app-root
+RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
 ENTRYPOINT [ "container-entrypoint" ]
 

--- a/2.0/runtime/contrib/etc/generate_container_user
+++ b/2.0/runtime/contrib/etc/generate_container_user
@@ -2,7 +2,9 @@
 USER_ID=$(id -u)
 GROUP_ID=$(id -g)
 
-if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1001" ]; then
+# For the main process (PID 1) and children we ensure there is a known user.
+# For other processes (i.e. docker exec) the user isn't added, so it may be unknown.
+if [ $$ -eq 1 -a x"$USER_ID" != x"0" -a x"$USER_ID" != x"1001" ]; then
 
     NSS_WRAPPER_PASSWD=/opt/app-root/etc/passwd
     NSS_WRAPPER_GROUP=/etc/group

--- a/2.0/runtime/contrib/etc/generate_container_user
+++ b/2.0/runtime/contrib/etc/generate_container_user
@@ -8,6 +8,8 @@ if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1001" ]; then
     NSS_WRAPPER_GROUP=/etc/group
 
     cat /etc/passwd | sed -e 's/^default:/builder:/' > $NSS_WRAPPER_PASSWD
+    # make sure this file is writable so it can be overwritten if it is persisted in an image.
+    fix-permissions $NSS_WRAPPER_PASSWD
 
     echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> $NSS_WRAPPER_PASSWD
 

--- a/2.0/runtime/root/usr/bin/container-entrypoint
+++ b/2.0/runtime/root/usr/bin/container-entrypoint
@@ -2,11 +2,7 @@
 
 set -eu
 
-# For the main process (PID 1) and children we ensure there is a known user.
-# For other processes (i.e. docker exec) the user isn't added, so it may be unknown.
-if [ $$ -eq 1 ]; then
-  source /opt/app-root/etc/generate_container_user
-fi
+source /opt/app-root/etc/generate_container_user
 
 cmd="$1"; shift
 exec $cmd "$@"

--- a/2.0/runtime/test/run
+++ b/2.0/runtime/test/run
@@ -113,6 +113,9 @@ test_user() {
   assert_equal $(docker_run_as 100001 "whoami") "default"
   # root is 'root'
   assert_equal $(docker_run_as 0 "whoami")      "root"
+
+  # ensure the passwd file used by nss_wrapper can be overwritten
+  assert_equal $(docker_run_as 100001 "stat -c %a /opt/app-root/etc/passwd") "666"
 }
 test_user
 


### PR DESCRIPTION
- ensure the NSS_WRAPPER_PASSWD is writable
- assemble: don't persist NSS_WRAPPER_PASSWD
- runtime/Dockerfile: use fix-permissions script to update permissions
the chmod instruction in the Dockerfile would add the execute permission to every file, the fix-permissions script will only add it to directories