### PR TITLE
Fix some 2.0 READMEs

### DIFF
--- a/2.0/runtime/README.md
+++ b/2.0/runtime/README.md
@@ -51,21 +51,11 @@ Repository organization
   This folder contains binary archives of [S2I](https://github.com/openshift/source-to-image)
   dotnet sample applications.
 
-  * **`helloworld/`**
-
-    .Net Core "Hello World" used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
-
-  * **`qotd/`**
-
-    .Net Core Quote of the Day example app used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
-
   * **`asp-net-hello-world/`**
 
-    ASP .Net hello world example app used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
-
-  * **`asp-net-hello-world-envvar/`**
-
-    ASP .Net hello world example app used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
+    ASP .Net hello world example app used for testing purposes. Sources are precompiled in `app.tar.gz`.
+    See [build-project.sh](test/aspnet-hello-world/build-project.sh) for as to how to produce
+    the binary.
 
 Environment variables
 ---------------------

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Usage
 ---------------------------------
 
 For information about usage of Docker image for .NET Core 2.0,
-see [2.0 usage documentation](2.0/README.md).
+see [2.0 builder usage documentation](2.0/build/README.md) and
+[2.0 runtime usage documentation](2.0/runtime/README.md).
 
 For information about usage of Docker image for .NET Core 1.1,
 see [1.1 usage documentation](1.1/README.md).


### PR DESCRIPTION
The main README had a dead link. The runtime image readme referenced some non-existent tests.