### PR TITLE
Change default s2i_args

### DIFF
--- a/1.0/test/run
+++ b/1.0/test/run
@@ -438,7 +438,7 @@ info "Testing ${IMAGE_NAME}"
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
-s2i_args="--force-pull=false"
+s2i_args="--pull-policy=never"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
 test_s2i_usage "${sample_app_url}"

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -438,7 +438,7 @@ info "Testing ${IMAGE_NAME}"
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
-s2i_args="--force-pull=false"
+s2i_args="--pull-policy=never"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
 test_s2i_usage "${sample_app_url}"

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -570,7 +570,7 @@ info "Testing ${IMAGE_NAME}"
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
-s2i_args="--force-pull=false"
+s2i_args="--pull-policy=never"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
 test_s2i_usage "${sample_app_url}"

--- a/2.0/runtime/test/run
+++ b/2.0/runtime/test/run
@@ -81,7 +81,7 @@ curl_retry() {
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
-s2i_args="--force-pull=false"
+s2i_args="--pull-policy=never"
 
 info "Testing ${IMAGE_NAME}"
 


### PR DESCRIPTION
Since s2i v1.0.4 the '--force-pull=false' argument has been deprecated (see release 1.0.4 @ https://github.com/openshift/source-to-image/releases/tag/v1.0.4)

and since s2i v1.1.6, the '--force-pull=false' argument has been removed completely and users should now use only '--pull-policy' argument ( see release 1.1.6 @ https://github.com/openshift/source-to-image/releases/tag/v1.1.6)

These 4 commits change the args in each image version to support the newer s2i releases from 1.0.4 and later..