### PR TITLE
Added rsync to the 2.0 runtime image

### DIFF
--- a/2.0/runtime/Dockerfile.rhel7
+++ b/2.0/runtime/Dockerfile.rhel7
@@ -41,7 +41,7 @@ COPY ./contrib/ /opt/app-root
 
 COPY ./root/usr/bin /usr/bin
 
-RUN INSTALL_PKGS="rh-dotnet20-dotnet-runtime-2.0 nss_wrapper tar" && \
+RUN INSTALL_PKGS="rh-dotnet20-dotnet-runtime-2.0 nss_wrapper tar rsync" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms,rhel-7-server-ose-3.2-rpms \
       $INSTALL_PKGS && \


### PR DESCRIPTION
I'm adding this in response to Issue #118.

In that issue there was a question of how much faster rsync was and how much it would increase the size of the image.

I can't speak to the speed increase, but the size increase is .5 MB to the image.

In my opinion, if adding this would make using the images more convenient to users, that is an insignificant trade-off in return.