### PR TITLE
Move rsync from runtime image to build image.

### DIFF
--- a/2.0/build/Dockerfile.rhel7
+++ b/2.0/build/Dockerfile.rhel7
@@ -26,7 +26,7 @@ USER 0
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
 COPY ./s2i/bin/ /usr/libexec/s2i
 
-RUN INSTALL_PKGS="rh-nodejs6-npm rh-dotnet20-dotnet-sdk-2.0" && \
+RUN INSTALL_PKGS="rh-nodejs6-npm rh-dotnet20-dotnet-sdk-2.0 rsync" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms,rhel-7-server-ose-3.2-rpms \
       $INSTALL_PKGS && \

--- a/2.0/runtime/Dockerfile.rhel7
+++ b/2.0/runtime/Dockerfile.rhel7
@@ -41,7 +41,7 @@ COPY ./contrib/ /opt/app-root
 
 COPY ./root/usr/bin /usr/bin
 
-RUN INSTALL_PKGS="rh-dotnet20-dotnet-runtime-2.0 nss_wrapper tar unzip rsync" && \
+RUN INSTALL_PKGS="rh-dotnet20-dotnet-runtime-2.0 nss_wrapper tar unzip" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms,rhel-7-server-ose-3.2-rpms \
       $INSTALL_PKGS && \


### PR DESCRIPTION
After the merge of PR #119 there was expressed some more concern that the addition of the rsync package to the runtime had not been asked for yet, which would make the additional size unnecessary. So this moves it to the build image until such a time as more users express a need for it.