### PR TITLE
Cleanup NuGet development artifacts

### DIFF
--- a/2.0/build/s2i/bin/assemble
+++ b/2.0/build/s2i/bin/assemble
@@ -97,13 +97,14 @@ exec dotnet ${APP_DLL_NAME} \$@
 EOF
 chmod +x "$DOTNET_APP_PATH/$DOTNET_DEFAULT_CMD"
 
-# Fix source directory permissions
-fix-permissions ./
-# set permissions for any installed artifacts
-fix-permissions /opt/app-root
-
 if [ "$DOTNET_PACK" == "true" ]; then
   echo "---> Packing application..."
+  fix-permissions $DOTNET_APP_PATH
   tar -czf /opt/app-root/app.tar.gz -C $DOTNET_APP_PATH .
-  fix-permissions /opt/app-root/app.tar.gz
 fi
+
+# cleanup NuGet artifacts
+rm -rf ~/{.local,.nuget}
+
+# fix permissions
+fix-permissions /opt/app-root


### PR DESCRIPTION
For a standard ASP.NET Core webapp we are pushing almost 500MB of downloaded artifacts into the deployment image.

```
$ du -hs .local .nuget                                                                                                                                                                                                       
133M    .local                                                                                                                                                                                                                     
349M    .nuget
```