### PR TITLE
2.0: make DOTNET_FRAMEWORK a runtime image envvar and document runtime envvars

### DIFF
--- a/2.0/build/s2i/bin/_devmode_run
+++ b/2.0/build/s2i/bin/_devmode_run
@@ -8,7 +8,6 @@ DOTNET_CONFIGURATION="${DOTNET_CONFIGURATION:-Release}"
 if [ -z ${DOTNET_STARTUP_PROJECT+x} ]; then
   DOTNET_STARTUP_PROJECT="."
 fi
-DOTNET_FRAMEWORK="netcoreapp2.0"
 
 # Build nuget sources list for when doing the restore
 RESTORE_OPTIONS=""

--- a/2.0/build/s2i/bin/assemble
+++ b/2.0/build/s2i/bin/assemble
@@ -42,9 +42,6 @@ if [ "$DOTNET_ASPNET_STORE" != "false" ]; then
   DOTNET_ASPNET_STORE="true"
 fi
 
-# Private environment
-DOTNET_FRAMEWORK="netcoreapp2.0"
-
 # Ensure there is a project file and derive assembly name from project name.
 PROJFILES=(`find "${DOTNET_STARTUP_PROJECT}" -maxdepth 1 -name "*.??proj"`)
 if [ ${#PROJFILES[@]} -eq 1 ]; then

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -16,12 +16,11 @@
 
 if [ "$BUILD_CENTOS" = "true" ]; then
   IMAGE_NAME=${IMAGE_NAME:-centos/dotnet-20-centos7}
-  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-dotnet/dotnet-20-runtime-rhel7}
+  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-centos/dotnet-20-runtime-centos7}
 else
-  IMAGE_NAME=${IMAGE_NAME:-centos/dotnet-20-centos7}
+  IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnet-20-rhel7}
   RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-dotnet/dotnet-20-runtime-rhel7}
 fi
-
 OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -14,8 +14,14 @@
 #
 # Example usage: $ sudo ./test/run
 
-IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnet-20-rhel7}
-RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-dotnet/dotnet-20-runtime-rhel7}
+if [ "$BUILD_CENTOS" = "true" ]; then
+  IMAGE_NAME=${IMAGE_NAME:-centos/dotnet-20-centos7}
+  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-dotnet/dotnet-20-runtime-rhel7}
+else
+  IMAGE_NAME=${IMAGE_NAME:-centos/dotnet-20-centos7}
+  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-dotnet/dotnet-20-runtime-rhel7}
+fi
+
 OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"

--- a/2.0/runtime/Dockerfile
+++ b/2.0/runtime/Dockerfile
@@ -4,14 +4,14 @@ FROM centos:7
 
 EXPOSE 8080
 
-ENV DOTNET_CORE_VERSION=2.0
-
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8 \
     HOME=/opt/app-root \
     PATH=/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     DOTNET_APP_PATH=/opt/app-root/app \
-    DOTNET_DEFAULT_CMD=default-cmd.sh
+    DOTNET_DEFAULT_CMD=default-cmd.sh \
+    DOTNET_CORE_VERSION=2.0 \
+    DOTNET_FRAMEWORK=netcoreapp2.0
 
 LABEL io.k8s.description="Platform for running .NET Core 2.0 applications" \
       io.k8s.display-name=".NET Core 2.0" \

--- a/2.0/runtime/Dockerfile.rhel7
+++ b/2.0/runtime/Dockerfile.rhel7
@@ -4,14 +4,14 @@ FROM rhel7
 
 EXPOSE 8080
 
-ENV DOTNET_CORE_VERSION=2.0
-
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8 \
     HOME=/opt/app-root \
     PATH=/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     DOTNET_APP_PATH=/opt/app-root/app \
-    DOTNET_DEFAULT_CMD=default-cmd.sh
+    DOTNET_DEFAULT_CMD=default-cmd.sh \
+    DOTNET_CORE_VERSION=2.0 \
+    DOTNET_FRAMEWORK=netcoreapp2.0
 
 LABEL io.k8s.description="Platform for running .NET Core 2.0 applications" \
       io.k8s.display-name=".NET Core 2.0" \

--- a/2.0/runtime/README.md
+++ b/2.0/runtime/README.md
@@ -60,7 +60,18 @@ Repository organization
 Environment variables
 ---------------------
 
+The following variables are set so they can be used from scripts.
+They must not to be overridden.
+
 * **ASPNETCORE_URLS**
 
     This variable is set to `http://*:8080` to configure ASP.NET Core to use the
     port exposed by the image.
+
+* **DOTNET_APP_PATH,DOTNET_DEFAULT_CMD**
+
+    These variables contain the working directory (`/opt/app-root/app`) and default CMD of the runtime image (`default-cmd.sh`).
+
+* **DOTNET_FRAMEWORK,DOTNET_CORE_VERSION**
+
+    These variables contain the framework (`netcoreapp2.0`) and .NET Core version (`2.0`) respectively.

--- a/2.0/runtime/test/run
+++ b/2.0/runtime/test/run
@@ -21,9 +21,9 @@ OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
-dotnet_version_serie="2.0"
+dotnet_version_series="2.0"
 dotnet_version_suffix="0"
-dotnet_version="${dotnet_version_serie}.${dotnet_version_suffix}"
+dotnet_version="${dotnet_version_series}.${dotnet_version_suffix}"
 
 test_dotnet() {
   test_start
@@ -44,9 +44,9 @@ test_envvars() {
   assert_equal $(docker_get_env $IMAGE_NAME DOTNET_DEFAULT_CMD) "default-cmd.sh"
 
   # DOTNET_CORE_VERSION
-  assert_equal $(docker_get_env $IMAGE_NAME DOTNET_CORE_VERSION) "${dotnet_version_serie}"
+  assert_equal $(docker_get_env $IMAGE_NAME DOTNET_CORE_VERSION) "${dotnet_version_series}"
   # DOTNET_FRAMEWORK
-  assert_equal $(docker_get_env $IMAGE_NAME DOTNET_FRAMEWORK) "netcoreapp${dotnet_version_serie}"
+  assert_equal $(docker_get_env $IMAGE_NAME DOTNET_FRAMEWORK) "netcoreapp${dotnet_version_series}"
 }
 
 test_debuggable() {

--- a/2.0/runtime/test/run
+++ b/2.0/runtime/test/run
@@ -11,21 +11,42 @@
 #
 # Example usage: $ sudo ./test/run
 
-IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnet-20-runtime-rhel7}
+if [ "$BUILD_CENTOS" = "true" ]; then
+  IMAGE_NAME=${IMAGE_NAME:-centos/dotnet-20-runtime-centos7}
+else
+  IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnet-20-runtime-rhel7}
+fi
 OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
+dotnet_version_serie="2.0"
+dotnet_version_suffix="0"
+dotnet_version="${dotnet_version_serie}.${dotnet_version_suffix}"
+
 test_dotnet() {
   test_start
-  local dotnet_version="2.0.0"
 
   # ENTRYPOINT enables scl so dotnet is available
   assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Microsoft .NET Core Shared Framework Host"
   assert_contains "$(docker run --rm ${IMAGE_NAME} dotnet)" "Usage: dotnet"
   # Check version
   assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version  : ${dotnet_version}"$'\r\n'
+}
+
+test_envvars() {
+  test_start
+
+  # DOTNET_APP_PATH
+  assert_equal $(docker_get_env $IMAGE_NAME DOTNET_APP_PATH) "/opt/app-root/app"
+  # DOTNET_DEFAULT_CMD
+  assert_equal $(docker_get_env $IMAGE_NAME DOTNET_DEFAULT_CMD) "default-cmd.sh"
+
+  # DOTNET_CORE_VERSION
+  assert_equal $(docker_get_env $IMAGE_NAME DOTNET_CORE_VERSION) "${dotnet_version_serie}"
+  # DOTNET_FRAMEWORK
+  assert_equal $(docker_get_env $IMAGE_NAME DOTNET_FRAMEWORK) "netcoreapp${dotnet_version_serie}"
 }
 
 test_debuggable() {
@@ -99,6 +120,7 @@ info "Testing ${IMAGE_NAME}"
 
 if [ ${OPENSHIFT_ONLY} != true ]; then
   test_dotnet
+  test_envvars
   test_default_cmd
   test_debuggable
   test_user


### PR DESCRIPTION
These envvars are interesting for anyone doing their own .s2i scripts.