### PR TITLE
Use dotnet prefix for CentOS images.

### DIFF
--- a/2.0/build/Dockerfile
+++ b/2.0/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/dotnet-20-runtime-centos7
+FROM dotnet/dotnet-20-runtime-centos7
 # This image provides a .NET Core 2.0 environment you can use to run your .NET
 # applications.
 
@@ -14,7 +14,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 2.0 applic
       io.s2i.scripts-url=image:///usr/libexec/s2i
 
 # Labels consumed by Red Hat build service
-LABEL name="centos/dotnet-20-centos7" \
+LABEL name="dotnet/dotnet-20-centos7" \
       com.redhat.component="rh-dotnet20-docker" \
       version="2.0" \
       release="1" \

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -15,8 +15,8 @@
 # Example usage: $ sudo ./test/run
 
 if [ "$BUILD_CENTOS" = "true" ]; then
-  IMAGE_NAME=${IMAGE_NAME:-centos/dotnet-20-centos7}
-  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-centos/dotnet-20-runtime-centos7}
+  IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnet-20-centos7}
+  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-dotnet/dotnet-20-runtime-centos7}
 else
   IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnet-20-rhel7}
   RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-dotnet/dotnet-20-runtime-rhel7}

--- a/2.0/runtime/Dockerfile
+++ b/2.0/runtime/Dockerfile
@@ -19,7 +19,7 @@ LABEL io.k8s.description="Platform for running .NET Core 2.0 applications" \
       io.openshift.expose-services="8080:http"
 
 # Labels consumed by Red Hat build service
-LABEL name="centos/dotnet-20-runtime-centos7" \
+LABEL name="dotnet/dotnet-20-runtime-centos7" \
       com.redhat.component="rh-dotnet20-runtime-docker" \
       version="2.0" \
       release="1" \

--- a/2.0/runtime/test/run
+++ b/2.0/runtime/test/run
@@ -12,7 +12,7 @@
 # Example usage: $ sudo ./test/run
 
 if [ "$BUILD_CENTOS" = "true" ]; then
-  IMAGE_NAME=${IMAGE_NAME:-centos/dotnet-20-runtime-centos7}
+  IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnet-20-runtime-centos7}
 else
   IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnet-20-runtime-rhel7}
 fi

--- a/build.sh
+++ b/build.sh
@@ -83,12 +83,12 @@ fi
 if [ "$BUILD_CENTOS" = "true" ]; then
   VERSIONS="${VERSIONS:-2.0}"
   image_os="centos7"
-  image_prefix="centos"
+  image_prefix="dotnet"
   docker_filename="Dockerfile"
 else
   VERSIONS="${VERSIONS:-1.0 1.1 2.0}"
-  image_prefix="dotnet"
   image_os="rhel7"
+  image_prefix="dotnet"
   docker_filename="Dockerfile.rhel7"
 fi
 


### PR DESCRIPTION
The assumption was that the prefix in the CentOS registry will be `centos`.
But it isn't. It's `dotnet` as for RHEL. The main distinction is the `centos7` suffix.