### PR TITLE
Use HTTP_PROXY in .NET Core

### DIFF
--- a/1.0/root/usr/bin/container-entrypoint
+++ b/1.0/root/usr/bin/container-entrypoint
@@ -1,5 +1,14 @@
 #!/bin/bash
 
-set -eu
+set -e
+
+# .NET Core uses libcurl for HTTP handling. libcurl doesn't use 'HTTP_PROXY', but uses 'http_proxy'.
+# libcurl is not using the upper-case to avoid exploiting httpoxy in CGI-like environments (https://httpoxy.org/).
+# CGI-like environments must be fixed for this exploit (https://access.redhat.com/security/vulnerabilities/httpoxy).
+# In an OpenShift context, it is common to use the upper-case 'HTTP_PROXY'.
+if [ -z "$http_proxy" ] && [ ! -z "$HTTP_PROXY" ]; then
+  export http_proxy="${HTTP_PROXY}"
+fi
+
 cmd="$1"; shift
 exec $cmd "$@"

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -434,6 +434,24 @@ test_new_web_app() {
   cleanup ${app}
 }
 
+test_http_proxy() {
+  info "Testing http_proxy ..."
+
+  # When HTTP_PROXY is set, we set http_proxy to match (unless it's already set).
+  local expected="proxy0"
+  local out=$(docker run --rm -e HTTP_PROXY=proxy0 ${IMAGE_NAME} bash -c 'echo $http_proxy')
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[http_proxy] Expected '${expected}', got '${out}'"
+    exit 1
+  fi
+  expected="proxy1"
+  out=$(docker run --rm -e HTTP_PROXY=proxy0 -e http_proxy=proxy1 ${IMAGE_NAME} bash -c 'echo $http_proxy')
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[http_proxy] Expected '${expected}', got '${out}'"
+    exit 1
+  fi
+}
+
 info "Testing ${IMAGE_NAME}"
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
@@ -447,6 +465,8 @@ check_result $?
 # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
 test_docker_run_usage "${sample_app_url}"
 check_result $?
+
+test_http_proxy
 
 # Verify OpenShift's s2i-dotnetcore-ex runs
 if [ ${OPENSHIFT_ONLY} = true ]; then

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -466,8 +466,6 @@ check_result $?
 test_docker_run_usage "${sample_app_url}"
 check_result $?
 
-test_http_proxy
-
 # Verify OpenShift's s2i-dotnetcore-ex runs
 if [ ${OPENSHIFT_ONLY} = true ]; then
   old_s2i_args="${s2i_args}"
@@ -506,6 +504,8 @@ else
   done
 
   test_new_web_app
+
+  test_http_proxy
 fi
 
 info "All tests finished successfully."

--- a/1.1/root/usr/bin/container-entrypoint
+++ b/1.1/root/usr/bin/container-entrypoint
@@ -1,5 +1,14 @@
 #!/bin/bash
 
-set -eu
+set -e
+
+# .NET Core uses libcurl for HTTP handling. libcurl doesn't use 'HTTP_PROXY', but uses 'http_proxy'.
+# libcurl is not using the upper-case to avoid exploiting httpoxy in CGI-like environments (https://httpoxy.org/).
+# CGI-like environments must be fixed for this exploit (https://access.redhat.com/security/vulnerabilities/httpoxy).
+# In an OpenShift context, it is common to use the upper-case 'HTTP_PROXY'.
+if [ -z "$http_proxy" ] && [ ! -z "$HTTP_PROXY" ]; then
+  export http_proxy="${HTTP_PROXY}"
+fi
+
 cmd="$1"; shift
 exec $cmd "$@"

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -434,6 +434,24 @@ test_new_web_app() {
   cleanup ${app}
 }
 
+test_http_proxy() {
+  info "Testing http_proxy ..."
+
+  # When HTTP_PROXY is set, we set http_proxy to match (unless it's already set).
+  local expected="proxy0"
+  local out=$(docker run --rm -e HTTP_PROXY=proxy0 ${IMAGE_NAME} bash -c 'echo $http_proxy')
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[http_proxy] Expected '${expected}', got '${out}'"
+    exit 1
+  fi
+  expected="proxy1"
+  out=$(docker run --rm -e HTTP_PROXY=proxy0 -e http_proxy=proxy1 ${IMAGE_NAME} bash -c 'echo $http_proxy')
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[http_proxy] Expected '${expected}', got '${out}'"
+    exit 1
+  fi
+}
+
 info "Testing ${IMAGE_NAME}"
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
@@ -447,6 +465,8 @@ check_result $?
 # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
 test_docker_run_usage "${sample_app_url}"
 check_result $?
+
+test_http_proxy
 
 # Verify OpenShift's s2i-dotnetcore-ex runs
 if [ ${OPENSHIFT_ONLY} = true ]; then

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -466,8 +466,6 @@ check_result $?
 test_docker_run_usage "${sample_app_url}"
 check_result $?
 
-test_http_proxy
-
 # Verify OpenShift's s2i-dotnetcore-ex runs
 if [ ${OPENSHIFT_ONLY} = true ]; then
   old_s2i_args="${s2i_args}"
@@ -506,6 +504,8 @@ else
   done
 
   test_new_web_app
+
+  test_http_proxy
 fi
 
 info "All tests finished successfully."

--- a/2.0/build/test/testcommon
+++ b/2.0/build/test/testcommon
@@ -47,8 +47,16 @@ docker_run() {
   local image="$1"
   shift
 
+  docker_run_withargs "${image}" "" "$@"
+}
+
+docker_run_withargs() {
+  local image="$1"
+  local args="$2"
+  shift 2
+
   local output;
-  output=$(docker run --rm ${image} "$@" 2>&1)
+  output=$(docker run --rm ${args} ${image} "$@" 2>&1)
   if [ $? -ne 0 ]; then
     error "$output"
   else

--- a/2.0/runtime/root/usr/bin/container-entrypoint
+++ b/2.0/runtime/root/usr/bin/container-entrypoint
@@ -1,8 +1,16 @@
 #!/bin/bash
 
-set -eu
+set -e
 
 source /opt/app-root/etc/generate_container_user
+
+# .NET Core uses libcurl for HTTP handling. libcurl doesn't use 'HTTP_PROXY', but uses 'http_proxy'.
+# libcurl is not using the upper-case to avoid exploiting httpoxy in CGI-like environments (https://httpoxy.org/).
+# CGI-like environments must be fixed for this exploit (https://access.redhat.com/security/vulnerabilities/httpoxy).
+# In an OpenShift context, it is common to use the upper-case 'HTTP_PROXY'.
+if [ -z "$http_proxy" ] && [ ! -z "$HTTP_PROXY" ]; then
+  export http_proxy="${HTTP_PROXY}"
+fi
 
 cmd="$1"; shift
 exec $cmd "$@"

--- a/2.0/runtime/test/run
+++ b/2.0/runtime/test/run
@@ -47,6 +47,10 @@ test_envvars() {
   assert_equal $(docker_get_env $IMAGE_NAME DOTNET_CORE_VERSION) "${dotnet_version_series}"
   # DOTNET_FRAMEWORK
   assert_equal $(docker_get_env $IMAGE_NAME DOTNET_FRAMEWORK) "netcoreapp${dotnet_version_series}"
+
+  # When HTTP_PROXY is set, we set http_proxy to match (unless it's already set).
+  assert_equal $(docker_run_withargs $IMAGE_NAME "-e HTTP_PROXY=proxy0"                      bash -c 'echo $http_proxy') "proxy0"
+  assert_equal $(docker_run_withargs $IMAGE_NAME "-e HTTP_PROXY=proxy0 -e http_proxy=proxy1" bash -c 'echo $http_proxy') "proxy1"
 }
 
 test_debuggable() {

--- a/2.0/runtime/test/testcommon
+++ b/2.0/runtime/test/testcommon
@@ -47,8 +47,16 @@ docker_run() {
   local image="$1"
   shift
 
+  docker_run_withargs "${image}" "" "$@"
+}
+
+docker_run_withargs() {
+  local image="$1"
+  local args="$2"
+  shift 2
+
   local output;
-  output=$(docker run --rm ${image} "$@" 2>&1)
+  output=$(docker run --rm ${args} ${image} "$@" 2>&1)
   if [ $? -ne 0 ]; then
     error "$output"
   else
@@ -158,7 +166,6 @@ curl_retry() {
 
   local output
   local attempt=1
-  local max_attempts=10
   local rv=$CURLE_COULNDT_CONNECT
   while [ $rv -eq $CURLE_COULNDT_CONNECT -a $attempt -le $max_attempts ]; do
     output=$(curl -sS "$url" 2>&1)


### PR DESCRIPTION
Implements https://github.com/redhat-developer/s2i-dotnetcore/issues/140

I've implemented this in container-entrypoint so it applies also to the runtime image.
This makes the split build pick up the proxy, which in OpenShift is typically upper-case (https://docs.openshift.com/enterprise/3.0/admin_guide/http_proxies.html).

After review of 2.0 changes, I will apply the same changes to the 1.0 and 1.1 images.