### PR TITLE
Enhancements for #146 and #145 to support publish --no-restore and verbosity

### DIFF
--- a/2.0/build/README.md
+++ b/2.0/build/README.md
@@ -147,14 +147,14 @@ a `.s2i/environment` file inside your source code repository.
     When set to `true`, the application restart automatically when the source code changes. `dotnet run`
     is used to start the application.
 
-* **DOTNET_NO_RESTORE**
+* **DOTNET_NO_RESTORE** (dotnet 2.0 only)
 
   Can be set to `--no-restore`, will be passed to the `dotnet publish` command in `assemble`. Intended to be used for
   situations where not attempting to connect to an external `nuget.org` site is useful. An example of this
   would be a disconnected build configuration where all desired nuget packages are already accessible to the
   build either on the host or in the image.
 
-* **DOTNET_VERBOSITY**
+* **DOTNET_VERBOSITY** (dotnet 2.0 only)
 
   Will be passed to `assemble` script `dotnet publish` command allowing additional build related descriptive output.
   Example values are `-v  [ q | n | d | diag ]` (for quiet, minimal, normal, detailed and diagnostic levels).

--- a/2.0/build/README.md
+++ b/2.0/build/README.md
@@ -147,6 +147,18 @@ a `.s2i/environment` file inside your source code repository.
     When set to `true`, the application restart automatically when the source code changes. `dotnet run`
     is used to start the application.
 
+* **DOTNET_NO_RESTORE**
+
+  Can be set to `--no-restore`, will be passed to the `dotnet publish` command in `assemble`. Intended to be used for
+  situations where not attempting to connect to an external `nuget.org` site is useful. An example of this
+  would be a disconnected build configuration where all desired nuget packages are already accessible to the
+  build either on the host or in the image.
+
+* **DOTNET_VERBOSITY**
+
+  Will be passed to `assemble` script `dotnet publish` command allowing additional build related descriptive output.
+  Example values are `-v  [ q | n | d | diag ]` (for quiet, minimal, normal, detailed and diagnostic levels).
+
 NPM
 ---
 

--- a/2.0/build/s2i/bin/assemble
+++ b/2.0/build/s2i/bin/assemble
@@ -91,8 +91,11 @@ done
 echo "---> Restoring application dependencies..."
 dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS
 echo "---> Publishing application..."
+
+echo "dotnet publish arguments: DOTNET_STARTUP_PROJECT=$DOTNET_STARTUP_PROJECT DOTNET_FRAMEWORK=$DOTNET_FRAMEWORK DOTNET_CONFIGURATION=$DOTNET_CONFIGURATION DOTNET_ASPNET_STORE=$DOTNET_ASPNET_STORE DOTNET_APP_PATH=$DOTNET_APP_PATH DOTNET_NO_RESTORE=$DOTNET_NO_RESTORE DOTNET_VERBOSITY=$DOTNET_VERBOSITY"
+
 dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" \
-       --self-contained false /p:PublishWithAspNetCoreTargetManifest=$DOTNET_ASPNET_STORE -o "$DOTNET_APP_PATH"
+       --self-contained false /p:PublishWithAspNetCoreTargetManifest=$DOTNET_ASPNET_STORE -o "$DOTNET_APP_PATH" $DOTNET_NO_RESTORE $DOTNET_VERBOSITY
 
 # check if the assembly used by the script exists
 if [ ! -f "$DOTNET_APP_PATH/${APP_DLL_NAME}" ]; then
@@ -119,3 +122,4 @@ rm -rf ~/{.local,.nuget}
 
 # fix permissions
 fix-permissions /opt/app-root
+


### PR DESCRIPTION
I found these changes helpful for controlling assemble dotnet publish to both add optional verbosity control and to support --no-restore for environments where an external repo such as nuget.org was not available.
These only apply to the dotnet 2.0 assemble script as they do not appear to be available in 1.0/1.1.
