### PR TITLE
Sync with downstream container repos and bump release version in centos dockerfiles

### DIFF
--- a/1.0/Dockerfile.rhel7
+++ b/1.0/Dockerfile.rhel7
@@ -24,7 +24,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 1.0 applic
 LABEL name="dotnet/dotnetcore-10-rhel7" \
       com.redhat.component="rh-dotnetcore10-docker" \
       version="1.0" \
-      release="24" \
+      release="26" \
       architecture="x86_64"
 
 COPY ./root/usr/bin /usr/bin

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -41,7 +41,7 @@ declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
-dotnet_version="1.0.0-preview2-003200"
+dotnet_version="1.0.0-preview2-003221"
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 
 test_port=8080

--- a/1.1/Dockerfile.rhel7
+++ b/1.1/Dockerfile.rhel7
@@ -24,7 +24,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 1.1 applic
 LABEL name="dotnet/dotnetcore-11-rhel7" \
       com.redhat.component="rh-dotnetcore11-docker" \
       version="1.1" \
-      release="15" \
+      release="17" \
       architecture="x86_64"
 
 COPY ./root/usr/bin /usr/bin

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -33,7 +33,7 @@ declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
-dotnet_version="1.0.0-preview2-1-003211"
+dotnet_version="1.0.0-preview2-1-003232"
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 
 test_port=8080

--- a/2.0/build/Dockerfile
+++ b/2.0/build/Dockerfile
@@ -17,7 +17,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 2.0 applic
 LABEL name="dotnet/dotnet-20-centos7" \
       com.redhat.component="rh-dotnet20-docker" \
       version="2.0" \
-      release="1" \
+      release="2" \
       architecture="x86_64"
 
 # Labels consumed by Eclipse JBoss OpenShift plugin

--- a/2.0/build/Dockerfile.rhel7
+++ b/2.0/build/Dockerfile.rhel7
@@ -17,7 +17,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 2.0 applic
 LABEL name="dotnet/dotnet-20-rhel7" \
       com.redhat.component="rh-dotnet20-docker" \
       version="2.0" \
-      release="8" \
+      release="10" \
       architecture="x86_64"
 
 # Labels consumed by Eclipse JBoss OpenShift plugin

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -26,7 +26,7 @@ OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
-dotnet_version="2.0.0"
+dotnet_version="2.0.3"
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 
 s2i_image_tag() {

--- a/2.0/runtime/Dockerfile
+++ b/2.0/runtime/Dockerfile
@@ -22,7 +22,7 @@ LABEL io.k8s.description="Platform for running .NET Core 2.0 applications" \
 LABEL name="dotnet/dotnet-20-runtime-centos7" \
       com.redhat.component="rh-dotnet20-runtime-docker" \
       version="2.0" \
-      release="1" \
+      release="2" \
       architecture="x86_64"
 
 # Don't download/extract docs for nuget packages

--- a/2.0/runtime/Dockerfile.rhel7
+++ b/2.0/runtime/Dockerfile.rhel7
@@ -22,7 +22,7 @@ LABEL io.k8s.description="Platform for running .NET Core 2.0 applications" \
 LABEL name="dotnet/dotnet-20-runtime-rhel7" \
       com.redhat.component="rh-dotnet20-runtime-docker" \
       version="2.0" \
-      release="7" \
+      release="10" \
       architecture="x86_64"
 
 # Don't download/extract docs for nuget packages

--- a/2.0/runtime/test/run
+++ b/2.0/runtime/test/run
@@ -22,7 +22,7 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
 dotnet_version_series="2.0"
-dotnet_version_suffix="0"
+dotnet_version_suffix="3"
 dotnet_version="${dotnet_version_series}.${dotnet_version_suffix}"
 
 test_dotnet() {


### PR DESCRIPTION
This should trigger a container rebuild in the centos registry, which should pull in the new dotnet release.