### PR TITLE
Bump the centos 2.0 build version again to trigger another build now that the centos triggers should be fixed.

### DIFF
--- a/2.0/build/Dockerfile
+++ b/2.0/build/Dockerfile
@@ -17,7 +17,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 2.0 applic
 LABEL name="dotnet/dotnet-20-centos7" \
       com.redhat.component="rh-dotnet20-docker" \
       version="2.0" \
-      release="2" \
+      release="3" \
       architecture="x86_64"
 
 # Labels consumed by Eclipse JBoss OpenShift plugin


### PR DESCRIPTION
The previous build failed because of issues in the Centos container-index build triggers, so here is another bump to trigger the containers to build again.

The runtime container built just fine for some reason.