### PR TITLE
2.0/build: add support for multiple SDKs

### DIFF
--- a/1.0/test/run
+++ b/1.0/test/run
@@ -41,7 +41,11 @@ declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
+if [ "$BUILD_CENTOS" = "true" ]; then
 dotnet_version="1.0.0-preview2-003221"
+else
+dotnet_version="1.0.0-preview2-003240"
+fi
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 
 test_port=8080

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -284,9 +284,6 @@ test_openshift_sample_app() {
   # Wait for the container to write it's CID file
   wait_for_cid
 
-  test_scl_usage "dotnet --version" "${dotnet_version}" "${cid_file}"
-  check_result $?
-
   test_http "/" "Sample pages using ASP.NET Core MVC" "grep \"ASP.NET Core MVC\" | sed -e 's#<li>##g' -e 's#</li>##g' -e 's#^ \\+##g'"
   check_result $?
 

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -33,7 +33,11 @@ declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
+if [ "$BUILD_CENTOS" = "true" ]; then
 dotnet_version="1.0.0-preview2-1-003232"
+else
+dotnet_version="1.0.0-preview2-1-003251"
+fi
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 
 test_port=8080

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -276,9 +276,6 @@ test_openshift_sample_app() {
   # Wait for the container to write it's CID file
   wait_for_cid
 
-  test_scl_usage "dotnet --version" "${dotnet_version}" "${cid_file}"
-  check_result $?
-
   test_http "/" "Sample pages using ASP.NET Core MVC" "grep \"ASP.NET Core MVC\" | sed -e 's#<li>##g' -e 's#</li>##g' -e 's#^ \\+##g'"
   check_result $?
 

--- a/2.0/build/Dockerfile
+++ b/2.0/build/Dockerfile
@@ -49,7 +49,7 @@ RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs6"
 
 # For backwards compatibility, s2i builds default to the oldest sdk in the image.
-# We keep the patch at '0', the latest patch versino is automatically picked up.
+# We keep the patch at '0', the latest patch version is automatically picked up.
 ENV DOTNET_SDK_BASE_VERSION=2.0.0
 
 # Run container by default as user with id 1001 (default)

--- a/2.0/build/Dockerfile
+++ b/2.0/build/Dockerfile
@@ -48,6 +48,9 @@ RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
 ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs6"
 
+# For backwards compatibility, s2i builds default to the oldest sdk in the image.
+ENV DOTNET_SDK_BASE_VERSION=2.0.0
+
 # Run container by default as user with id 1001 (default)
 USER 1001
 

--- a/2.0/build/Dockerfile
+++ b/2.0/build/Dockerfile
@@ -49,6 +49,7 @@ RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs6"
 
 # For backwards compatibility, s2i builds default to the oldest sdk in the image.
+# We keep the patch at '0', the latest patch versino is automatically picked up.
 ENV DOTNET_SDK_BASE_VERSION=2.0.0
 
 # Run container by default as user with id 1001 (default)

--- a/2.0/build/Dockerfile.rhel7
+++ b/2.0/build/Dockerfile.rhel7
@@ -50,6 +50,7 @@ RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs6"
 
 # For backwards compatibility, s2i builds default to the oldest sdk in the image.
+# We keep the patch at '0', the latest patch versino is automatically picked up.
 ENV DOTNET_SDK_BASE_VERSION=2.0.0
 
 # Run container by default as user with id 1001 (default)

--- a/2.0/build/Dockerfile.rhel7
+++ b/2.0/build/Dockerfile.rhel7
@@ -49,6 +49,9 @@ RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
 ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs6"
 
+# For backwards compatibility, s2i builds default to the oldest sdk in the image.
+ENV DOTNET_SDK_BASE_VERSION=2.0.0
+
 # Run container by default as user with id 1001 (default)
 USER 1001
 

--- a/2.0/build/Dockerfile.rhel7
+++ b/2.0/build/Dockerfile.rhel7
@@ -50,7 +50,7 @@ RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs6"
 
 # For backwards compatibility, s2i builds default to the oldest sdk in the image.
-# We keep the patch at '0', the latest patch versino is automatically picked up.
+# We keep the patch at '0', the latest patch version is automatically picked up.
 ENV DOTNET_SDK_BASE_VERSION=2.0.0
 
 # Run container by default as user with id 1001 (default)

--- a/2.0/build/Dockerfile.rhel7
+++ b/2.0/build/Dockerfile.rhel7
@@ -30,7 +30,7 @@ USER 0
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
 COPY ./s2i/bin/ /usr/libexec/s2i
 
-RUN INSTALL_PKGS="rh-nodejs6-npm rh-nodejs6-nodejs-nodemon rh-dotnet20-dotnet-sdk-2.0 rsync" && \
+RUN INSTALL_PKGS="rh-nodejs6-npm rh-nodejs6-nodejs-nodemon rh-dotnet20-dotnet-sdk-2.0 rh-dotnet20-dotnet-sdk-2.1 rsync" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \

--- a/2.0/build/README.md
+++ b/2.0/build/README.md
@@ -94,6 +94,11 @@ a `.s2i/environment` file inside your source code repository.
 
     Used to select the project to run. This must be a project file (e.g. csproj, fsproj) or a folder containing a single project file. Defaults to `.`.
 
+* **DOTNET_SDK_VERSION**
+
+    Used to select the default sdk version when building. If there is a `global.json` file in the source repository, that takes precedence.
+    When set to `latest` the latest sdk in the image is used. Defaults to the lowest sdk version available in the image.
+
 * **DOTNET_ASSEMBLY_NAME**
 
     Used to select the assembly to run. This must NOT include the `.dll` extension.
@@ -146,6 +151,10 @@ a `.s2i/environment` file inside your source code repository.
 
     When set to `true`, the application restart automatically when the source code changes. `dotnet run`
     is used to start the application.
+
+* **DOTNET_SDK_BASE_VERSION**
+
+    Contains the lowest sdk version available in the image. This is used as the default value for `DOTNET_SDK_VERSION`.
 
 NPM
 ---

--- a/2.0/build/s2i/bin/assemble
+++ b/2.0/build/s2i/bin/assemble
@@ -24,6 +24,19 @@ if [ -n "${DOTNET_NPM_TOOLS}" ]; then
   popd
 fi
 
+# sdk version
+DOTNET_SDK_VERSION="${DOTNET_SDK_VERSION:-$DOTNET_SDK_BASE_VERSION}"
+if [ "$DOTNET_SDK_VERSION" != "latest" ]; then
+cat >../global.json <<EOF
+{
+  "sdk": {
+    "version": "$DOTNET_SDK_VERSION"
+  }
+}
+EOF
+fi
+echo "Using SDK: $(dotnet --version)"
+
 echo "---> Copying application source ..."
 cp -Rf /tmp/src/. ./
 

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -455,7 +455,7 @@ test_devmode_user() {
   local container=$(docker_run_as_d ${image} ${run_user})
   # request
   local url=$(container_url ${container})
-  local response=$(curl_retry ${url}/ 30) # 30 attempts
+  local response=$(curl_retry ${url}/ 60) # 60 attempts
   # cleanup
   docker_rm ${container}
   docker_rmi ${image}

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -522,6 +522,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_image
   for sdk_version in "${sdk_versions[@]}"
   do
+    info "sdk ${sdk_version}:"
     test_config
     test_usage
     test_s2i_sdk_version $sdk_version
@@ -537,8 +538,10 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
     test_user
   done
   # when unset, default to the lowest sdk version
+  info "default sdk(${sdk_default_version}):"
   sdk_version="" test_s2i_sdk_version $sdk_default_version
   # when set to 'latest', use the higest sdk version
+  info "latest sdk(${sdk_latest_version}):"
   sdk_version="latest" test_s2i_sdk_version $sdk_latest_version
 else
   test_imagestream_sample

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -26,7 +26,10 @@ OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
-dotnet_version="2.0.3"
+sdk_default_version="2.0.3"
+sdk_latest_version="2.0.3"
+sdk_versions=( "2.0.3" )
+
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 
 s2i_image_tag() {
@@ -39,7 +42,7 @@ s2i_build_output_log() {
   local tag="$2"
 
   docker_rmi ${tag}
-  s2i build --pull-policy=never "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
+  s2i build --pull-policy=never -e DOTNET_SDK_VERSION=$sdk_version "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
 }
 
 s2i_build() {
@@ -88,6 +91,25 @@ Update the '.s2i/environment' file to specify the project you want to publish, f
   assert_contains "${s2i_build}" "${expected}"
 }
 
+test_s2i_sdk_version()
+{
+  test_start
+  local expected_version=$1
+
+  # The assemble script prints out the SDK version.
+  local app=sdkversion
+
+  # build image
+  local image=$(s2i_image_tag ${app})
+  local s2i_build=$(s2i_build_output_log ${app} ${image})
+
+  # cleanup
+  docker_rmi ${image}
+
+  # verify sdk version
+  assert_contains "${s2i_build}" "SDK Version: ${expected_version}"
+}
+
 test_s2i_usage() {
   local output=$(s2i usage ${IMAGE_NAME} 2>&1)
 
@@ -115,7 +137,7 @@ test_image() {
 
   # verify dotnet is available
   local image_dotnet_version=$(docker_run ${IMAGE_NAME} 'dotnet --version')
-  assert_equal "${image_dotnet_version}" "${dotnet_version}"
+  assert_equal "${image_dotnet_version}" "${sdk_latest_version}"
 
   # Verify $HOME != $CWD. See https://github.com/redhat-developer/s2i-dotnetcore/issues/28
   local working_dir=$(docker_run ${IMAGE_NAME} pwd)
@@ -479,15 +501,23 @@ test_devmode() {
 info "Testing ${IMAGE_NAME}"
 
 if [ ${OPENSHIFT_ONLY} != true ]; then
-  test_usage
   test_image
-  test_consoleapp
-  test_multiframework
-  test_fsharp
-  test_vb
-  test_published_files
-  test_aspnetapp
-  test_devmode
+  for sdk_version in "${sdk_versions[@]}"
+  do
+    test_usage
+    test_s2i_sdk_version $sdk_version
+    test_consoleapp
+    test_multiframework
+    test_fsharp
+    test_vb
+    test_published_files
+    test_aspnetapp
+    test_devmode
+  done
+  # when unset, default to the lowest sdk version
+  sdk_version="" test_s2i_sdk_version $sdk_default_version
+  # when set to 'latest', use the higest sdk version
+  sdk_version="latest" test_s2i_sdk_version $sdk_latest_version
 else
   test_imagestream_sample
 fi

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -27,8 +27,13 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
 sdk_default_version="2.0.3"
+if [ "$BUILD_CENTOS" = "true" ]; then
+sdk_latest_version="2.0.3"
+sdk_versions=( "2.0.3" )
+else
 sdk_latest_version="2.1.4"
 sdk_versions=( "2.0.3" "2.1.4" )
+fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -27,8 +27,8 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
 sdk_default_version="2.0.3"
-sdk_latest_version="2.0.3"
-sdk_versions=( "2.0.3" )
+sdk_latest_version="2.1.4"
+sdk_versions=( "2.0.3" "2.1.4" )
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 

--- a/2.0/build/test/sdkversion/.s2i/bin/assemble
+++ b/2.0/build/test/sdkversion/.s2i/bin/assemble
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# call base assemble script, this will create a global.json
+$STI_SCRIPTS_PATH/assemble >/dev/null 2>&1
+
+# print the sdk version
+sdk_version=$(dotnet --version)
+echo "SDK Version: ${sdk_version}"

--- a/templates/dotnet-example.json
+++ b/templates/dotnet-example.json
@@ -92,6 +92,10 @@
                                 "value": "${DOTNET_STARTUP_PROJECT}"
                             },
                             {
+                                "name": "DOTNET_SDK_VERSION",
+                                "value": "${DOTNET_SDK_VERSION}"
+                            },
+                            {
                                 "name": "DOTNET_ASSEMBLY_NAME",
                                 "value": "${DOTNET_ASSEMBLY_NAME}"
                             },
@@ -297,7 +301,13 @@
             "from": "[a-zA-Z0-9]{40}"
         },
         {
-            "name": "DOTNET_STARTUP_PROJECT",
+            "name": "DOTNET_SDK_VERSION",
+            "displayName": "SDK Version",
+            "description": "Set this to configure the default SDK version. This can be set to a specific version, '' (lowest version) or 'latest' (highest version).",
+            "value": ""
+        },
+        {
+            "name": "DOTNET_SDK_VERSION",
             "displayName": "Startup Project",
             "description": "Set this to a project file (e.g. csproj) or a folder containing a single project file.",
             "value": "app"

--- a/templates/dotnet-pgsql-persistent.json
+++ b/templates/dotnet-pgsql-persistent.json
@@ -108,6 +108,10 @@
                                 "value": "${DOTNET_STARTUP_PROJECT}"
                             },
                             {
+                                "name": "DOTNET_SDK_VERSION",
+                                "value": "${DOTNET_SDK_VERSION}"
+                            },
+                            {
                                 "name": "DOTNET_ASSEMBLY_NAME",
                                 "value": "${DOTNET_ASSEMBLY_NAME}"
                             },
@@ -487,6 +491,12 @@
             "displayName": "Startup Project",
             "description": "Set this to a project file (e.g. csproj) or a folder containing a single project file.",
             "value": "samples/MusicStore"
+        },
+        {
+            "name": "DOTNET_SDK_VERSION",
+            "displayName": "SDK Version",
+            "description": "Set this to configure the default SDK version. This can be set to a specific version, '' (lowest version) or 'latest' (highest version).",
+            "value": ""
         },
         {
             "name": "DOTNET_ASSEMBLY_NAME",

--- a/templates/dotnet-runtime-example.json
+++ b/templates/dotnet-runtime-example.json
@@ -102,6 +102,10 @@
                                 "value": "${DOTNET_STARTUP_PROJECT}"
                             },
                             {
+                                "name": "DOTNET_SDK_VERSION",
+                                "value": "${DOTNET_SDK_VERSION}"
+                            },
+                            {
                                 "name": "DOTNET_ASSEMBLY_NAME",
                                 "value": "${DOTNET_ASSEMBLY_NAME}"
                             },
@@ -380,6 +384,12 @@
             "displayName": "Startup Project",
             "description": "Set this to the folder containing your startup project.",
             "value": "app"
+        },
+        {
+            "name": "DOTNET_SDK_VERSION",
+            "displayName": "SDK Version",
+            "description": "Set this to configure the default SDK version. This can be set to a specific version, '' (lowest version) or 'latest' (highest version).",
+            "value": ""
         },
         {
             "name": "DOTNET_ASSEMBLY_NAME",


### PR DESCRIPTION
This adds an envvar `DOTNET_SDK_VERSION` to select the sdk version.
And updates the tests to run against multiple sdks.

When `DOTNET_SDK_VERSION` is not set, the build defaults to the lowest version sdk for backwards compatibility.
`DOTNET_SDK_VERSION` can be set to `latest` to use the highest version sdk.