### PR TITLE
Add DOTNET_VERBOSITY to specify verbosity of dotnet build commands

### DIFF
--- a/2.0/build/README.md
+++ b/2.0/build/README.md
@@ -115,6 +115,12 @@ a `.s2i/environment` file inside your source code repository.
     Used to specify the list of test projects to run. This must be project files or folders containing a
     single project file. `dotnet test` is invoked for each item. Defaults to ``.
 
+* **DOTNET_VERBOSITY**
+
+    Used to specify the verbosity of the dotnet build commands. When set, the environment variables are printed at the start
+    of the build. This variable can be set to one of the msbuild verbosity values (`q[uiet]`, `m[inimal]`, `n[ormal]`,
+    `d[etailed]`, and `diag[nostic]`). Defaults to ``.
+
 * **DOTNET_CONFIGURATION**
 
     Used to run the application in Debug or Release mode. This should be either

--- a/2.0/build/s2i/bin/assemble
+++ b/2.0/build/s2i/bin/assemble
@@ -2,6 +2,13 @@
 
 set -e
 
+DOTNET_OPTIONS=""
+if [ -n "${DOTNET_VERBOSITY}" ]; then
+  echo "--> Environment:"
+  env | sort
+  DOTNET_OPTIONS="$DOTNET_OPTIONS -v ${DOTNET_VERBOSITY}"
+fi
+
 # npm
 if [ -n "${DOTNET_NPM_TOOLS}" ]; then
   echo "---> Installing npm tools ..."
@@ -82,16 +89,16 @@ done
 # run tests
 for TEST_PROJECT in $DOTNET_TEST_PROJECTS; do
     echo "---> Restoring test project ($TEST_PROJECT) dependencies..."
-    dotnet restore "$TEST_PROJECT" $RESTORE_OPTIONS
+    dotnet restore "$TEST_PROJECT" $RESTORE_OPTIONS $DOTNET_OPTIONS
     echo "---> Running test project: $TEST_PROJECT..."
-    dotnet test "$TEST_PROJECT" -f "$DOTNET_FRAMEWORK"
+    dotnet test "$TEST_PROJECT" -f "$DOTNET_FRAMEWORK" $DOTNET_OPTIONS
 done
 
 # publish application
 echo "---> Restoring application dependencies..."
-dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS
+dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $DOTNET_OPTIONS
 echo "---> Publishing application..."
-dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" \
+dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" $DOTNET_OPTIONS \
        --self-contained false /p:PublishWithAspNetCoreTargetManifest=$DOTNET_ASPNET_STORE -o "$DOTNET_APP_PATH"
 
 # check if the assembly used by the script exists

--- a/2.0/build/s2i/bin/assemble
+++ b/2.0/build/s2i/bin/assemble
@@ -2,11 +2,12 @@
 
 set -e
 
-DOTNET_OPTIONS=""
 if [ -n "${DOTNET_VERBOSITY}" ]; then
   echo "--> Environment:"
   env | sort
-  DOTNET_OPTIONS="$DOTNET_OPTIONS -v ${DOTNET_VERBOSITY}"
+  VERBOSITY_OPTION="-v ${DOTNET_VERBOSITY}"
+else
+  VERBOSITY_OPTION=""
 fi
 
 # npm
@@ -89,16 +90,16 @@ done
 # run tests
 for TEST_PROJECT in $DOTNET_TEST_PROJECTS; do
     echo "---> Restoring test project ($TEST_PROJECT) dependencies..."
-    dotnet restore "$TEST_PROJECT" $RESTORE_OPTIONS $DOTNET_OPTIONS
+    dotnet restore "$TEST_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION
     echo "---> Running test project: $TEST_PROJECT..."
-    dotnet test "$TEST_PROJECT" -f "$DOTNET_FRAMEWORK" $DOTNET_OPTIONS
+    dotnet test "$TEST_PROJECT" -f "$DOTNET_FRAMEWORK" $VERBOSITY_OPTION
 done
 
 # publish application
 echo "---> Restoring application dependencies..."
-dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $DOTNET_OPTIONS
+dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION
 echo "---> Publishing application..."
-dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" $DOTNET_OPTIONS \
+dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" $VERBOSITY_OPTION \
        --self-contained false /p:PublishWithAspNetCoreTargetManifest=$DOTNET_ASPNET_STORE -o "$DOTNET_APP_PATH"
 
 # check if the assembly used by the script exists

--- a/2.0/build/test/asp-net-hello-world-envvar2/.s2i/environment
+++ b/2.0/build/test/asp-net-hello-world-envvar2/.s2i/environment
@@ -3,3 +3,4 @@ DOTNET_CONFIGURATION=Debug
 DOTNET_TEST_PROJECTS=test/test1/test1.csproj test/test2
 DOTNET_ASSEMBLY_NAME=SampleApp
 DOTNET_RESTORE_SOURCES=https://api.nuget.org/v3/index.json https://www.myget.org/F/s2i-dotnetcore
+DOTNET_VERBOSITY=normal

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -315,6 +315,19 @@ test_config_2() {
   # DOTNET_TEST_PROJECTS=test/test1/test1.csproj test/test2
   assert_contains "${s2i_build}" "Test run for /opt/app-root/src/test/test1"
   assert_contains "${s2i_build}" "Test run for /opt/app-root/src/test/test2"
+
+  # DOTNET_VERBOSITY=normal
+  ## Environment
+  assert_contains "${s2i_build}" "Environment:"
+  assert_contains "${s2i_build}" "DOTNET_VERBOSITY=normal"
+  ## Test project restore
+  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/test/test1/test1.csproj" on node 1 (Restore target(s)).'
+  ## Test project test
+  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/test/test1/test1.csproj" on node 1 (VSTest target(s)).'
+  ## App project restore
+  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/src/app/app.csproj" on node 1 (Restore target(s)).'
+  ## App project publish
+  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/src/app/app.csproj" on node 1 (Publish target(s)).'
 }
 
 test_config() {
@@ -481,6 +494,7 @@ info "Testing ${IMAGE_NAME}"
 if [ ${OPENSHIFT_ONLY} != true ]; then
   test_usage
   test_image
+  test_config
   test_consoleapp
   test_multiframework
   test_fsharp
@@ -488,6 +502,9 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_published_files
   test_aspnetapp
   test_devmode
+  test_split_build
+  test_new_web_app
+  test_user
 else
   test_imagestream_sample
 fi


### PR DESCRIPTION
Implements https://github.com/redhat-developer/s2i-dotnetcore/issues/145
Replaces https://github.com/redhat-developer/s2i-dotnetcore/pull/147

CC @dougtoppin