### PR TITLE
Sync with downstream container repos and correct test nuget config files.

### DIFF
--- a/1.0/Dockerfile.rhel7
+++ b/1.0/Dockerfile.rhel7
@@ -22,7 +22,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 1.0 applic
 LABEL name="dotnet/dotnetcore-10-rhel7" \
       com.redhat.component="rh-dotnetcore10-docker" \
       version="1.0" \
-      release="26" \
+      release="30" \
       architecture="x86_64"
 
 COPY ./root/usr/bin /usr/bin

--- a/1.0/test/asp-net-hello-world/NuGet.Config
+++ b/1.0/test/asp-net-hello-world/NuGet.Config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-        <add key="AspNetVNext" value="https://www.myget.org/F/aspnetcirelease/api/v3/index.json" />
+        <add key="AspNetVNext" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
         <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/1.0/test/asp-net-hello-world/NuGet.Config
+++ b/1.0/test/asp-net-hello-world/NuGet.Config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-        <add key="AspNetVNext" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
-        <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -44,7 +44,7 @@ image_dir=$(readlink -zf ${test_dir}/..)
 if [ "$BUILD_CENTOS" = "true" ]; then
 dotnet_version="1.0.0-preview2-003221"
 else
-dotnet_version="1.0.0-preview2-003240"
+dotnet_version="1.0.0-preview2-003260"
 fi
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 

--- a/1.1/Dockerfile.rhel7
+++ b/1.1/Dockerfile.rhel7
@@ -22,7 +22,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 1.1 applic
 LABEL name="dotnet/dotnetcore-11-rhel7" \
       com.redhat.component="rh-dotnetcore11-docker" \
       version="1.1" \
-      release="17" \
+      release="21" \
       architecture="x86_64"
 
 COPY ./root/usr/bin /usr/bin

--- a/1.1/test/asp-net-hello-world/NuGet.Config
+++ b/1.1/test/asp-net-hello-world/NuGet.Config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-        <add key="AspNetVNext" value="https://www.myget.org/F/aspnetcirelease/api/v3/index.json" />
+        <add key="AspNetVNext" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
         <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/1.1/test/asp-net-hello-world/NuGet.Config
+++ b/1.1/test/asp-net-hello-world/NuGet.Config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-        <add key="AspNetVNext" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
-        <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -36,7 +36,7 @@ image_dir=$(readlink -zf ${test_dir}/..)
 if [ "$BUILD_CENTOS" = "true" ]; then
 dotnet_version="1.0.0-preview2-1-003232"
 else
-dotnet_version="1.0.0-preview2-1-003251"
+dotnet_version="1.0.0-preview2-1-003271"
 fi
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 

--- a/2.0/build/Dockerfile.rhel7
+++ b/2.0/build/Dockerfile.rhel7
@@ -17,7 +17,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 2.0 applic
 LABEL name="dotnet/dotnet-20-rhel7" \
       com.redhat.component="rh-dotnet20-docker" \
       version="2.0" \
-      release="10" \
+      release="14" \
       architecture="x86_64"
 
 # Labels consumed by Eclipse JBoss OpenShift plugin

--- a/2.0/build/test/asp-net-hello-world/NuGet.Config
+++ b/2.0/build/test/asp-net-hello-world/NuGet.Config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-        <add key="AspNetVNext" value="https://www.myget.org/F/aspnetcirelease/api/v3/index.json" />
+        <add key="AspNetVNext" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
         <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/2.0/build/test/asp-net-hello-world/NuGet.Config
+++ b/2.0/build/test/asp-net-hello-world/NuGet.Config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-        <add key="AspNetVNext" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
-        <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -31,8 +31,8 @@ if [ "$BUILD_CENTOS" = "true" ]; then
 sdk_latest_version="2.0.3"
 sdk_versions=( "2.0.3" )
 else
-sdk_latest_version="2.1.4"
-sdk_versions=( "2.0.3" "2.1.4" )
+sdk_latest_version="2.1.101"
+sdk_versions=( "2.0.3" "2.1.101" )
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"

--- a/2.0/runtime/Dockerfile.rhel7
+++ b/2.0/runtime/Dockerfile.rhel7
@@ -20,7 +20,7 @@ LABEL io.k8s.description="Platform for running .NET Core 2.0 applications" \
 LABEL name="dotnet/dotnet-20-runtime-rhel7" \
       com.redhat.component="rh-dotnet20-runtime-docker" \
       version="2.0" \
-      release="10" \
+      release="14" \
       architecture="x86_64"
 
 # Don't download/extract docs for nuget packages

--- a/2.0/runtime/test/aspnet-hello-world/nuget.config
+++ b/2.0/runtime/test/aspnet-hello-world/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
- <packageSources>
-    <add key="dotnet-myget" value="https://dotnet.myget.org/F/dotnet-core/api/v2"/>
-    <add key="aspnetcore-release" value="https://dotnet.myget.org/F/aspnetcore-release/api/v2"/>
- </packageSources>
-</configuration>

--- a/2.0/runtime/test/run
+++ b/2.0/runtime/test/run
@@ -22,7 +22,7 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
 dotnet_version_series="2.0"
-dotnet_version_suffix="3"
+dotnet_version_suffix="6"
 dotnet_version="${dotnet_version_series}.${dotnet_version_suffix}"
 
 test_dotnet() {


### PR DESCRIPTION
This is meant to sync with downstream container repos, but I also noticed that one of the asp-net tests is different than the others. All but the 2.0/runtime use the aspnetcore/release/api/v3. Do we want to change them all to use the same, or just keep it as is?