### PR TITLE
Prettify openshift.io/display-names

### DIFF
--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -14,7 +14,7 @@
             "metadata": {
                 "name": "dotnet",
                 "annotations": {
-                    "openshift.io/display-name": ".NET Core Builder Images"
+                    "openshift.io/display-name": ".NET Core"
                 }
             },
             "spec": {
@@ -99,7 +99,7 @@
             "metadata": {
                 "name": "dotnet-runtime",
                 "annotations": {
-                    "openshift.io/display-name": ".NET Core Runtime Images"
+                    "openshift.io/display-name": ".NET Core Runtime"
                 }
             },
             "spec": {

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -14,7 +14,7 @@
             "metadata": {
                 "name": "dotnet",
                 "annotations": {
-                    "openshift.io/display-name": ".NET Core Builder Images"
+                    "openshift.io/display-name": ".NET Core"
                 }
             },
             "spec": {
@@ -63,7 +63,7 @@
             "metadata": {
                 "name": "dotnet-runtime",
                 "annotations": {
-                    "openshift.io/display-name": ".NET Core Runtime Images"
+                    "openshift.io/display-name": ".NET Core Runtime"
                 }
             },
             "spec": {


### PR DESCRIPTION
The display name shows up in lists with other s2i images which don't
include the words "Image"/"Builder".