### PR TITLE
Sync environment variables with Microsoft images

### DIFF
--- a/1.0/test/run
+++ b/1.0/test/run
@@ -42,7 +42,7 @@ declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
 if [ "$BUILD_CENTOS" = "true" ]; then
-dotnet_version="1.0.0-preview2-003221"
+dotnet_version="1.0.0-preview2-003260"
 else
 dotnet_version="1.0.0-preview2-003260"
 fi

--- a/2.0/build/Dockerfile
+++ b/2.0/build/Dockerfile
@@ -50,7 +50,9 @@ ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs6"
 
 # For backwards compatibility, s2i builds default to the oldest sdk in the image.
 # We keep the patch at '0', the latest patch version is automatically picked up.
-ENV DOTNET_SDK_BASE_VERSION=2.0.0
+ENV DOTNET_SDK_BASE_VERSION=2.0.0 \
+# Needed for the `dotnet watch` to detect changes in a container.
+    DOTNET_USE_POLLING_FILE_WATCHER=true
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.0/build/Dockerfile.rhel7
+++ b/2.0/build/Dockerfile.rhel7
@@ -51,7 +51,9 @@ ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs6"
 
 # For backwards compatibility, s2i builds default to the oldest sdk in the image.
 # We keep the patch at '0', the latest patch version is automatically picked up.
-ENV DOTNET_SDK_BASE_VERSION=2.0.0
+ENV DOTNET_SDK_BASE_VERSION=2.0.0 \
+# Needed for the `dotnet watch` to detect changes in a container.
+    DOTNET_USE_POLLING_FILE_WATCHER=true
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.0/build/README.md
+++ b/2.0/build/README.md
@@ -162,6 +162,10 @@ a `.s2i/environment` file inside your source code repository.
 
     Contains the lowest sdk version available in the image. This is used as the default value for `DOTNET_SDK_VERSION`.
 
+* **DOTNET_USE_POLLING_FILE_WATCHER**
+
+    This is set to `true` to ensure the `dotnet watch` command works in a container. This command is not used by the default scripts.
+
 NPM
 ---
 

--- a/2.0/build/test/run
+++ b/2.0/build/test/run
@@ -150,6 +150,9 @@ test_image() {
   local env=$(docker_run ${IMAGE_NAME} env)
   assert_contains "${env}" "HOME=/opt/app-root"$'\n'
 
+  # Verify the `dotnet watch` command can detect file changes in the container.
+  assert_contains "${env}" "DOTNET_USE_POLLING_FILE_WATCHER=true"$'\n'
+
   # verify npm is available
   local image_npm_version=$(docker_run ${IMAGE_NAME} 'npm --version')
   assert_equal "${image_npm_version}" "3.10.9"

--- a/2.0/runtime/Dockerfile
+++ b/2.0/runtime/Dockerfile
@@ -9,7 +9,9 @@ ENV HOME=/opt/app-root \
     DOTNET_APP_PATH=/opt/app-root/app \
     DOTNET_DEFAULT_CMD=default-cmd.sh \
     DOTNET_CORE_VERSION=2.0 \
-    DOTNET_FRAMEWORK=netcoreapp2.0
+    DOTNET_FRAMEWORK=netcoreapp2.0 \
+# Microsoft's images set this to enable detecting when an app is running in a container.
+    DOTNET_RUNNING_IN_CONTAINER=true
 
 LABEL io.k8s.description="Platform for running .NET Core 2.0 applications" \
       io.k8s.display-name=".NET Core 2.0" \

--- a/2.0/runtime/Dockerfile.rhel7
+++ b/2.0/runtime/Dockerfile.rhel7
@@ -9,7 +9,9 @@ ENV HOME=/opt/app-root \
     DOTNET_APP_PATH=/opt/app-root/app \
     DOTNET_DEFAULT_CMD=default-cmd.sh \
     DOTNET_CORE_VERSION=2.0 \
-    DOTNET_FRAMEWORK=netcoreapp2.0
+    DOTNET_FRAMEWORK=netcoreapp2.0 \
+# Microsoft's images set this to enable detecting when an app is running in a container.
+    DOTNET_RUNNING_IN_CONTAINER=true
 
 LABEL io.k8s.description="Platform for running .NET Core 2.0 applications" \
       io.k8s.display-name=".NET Core 2.0" \

--- a/2.0/runtime/README.md
+++ b/2.0/runtime/README.md
@@ -79,3 +79,7 @@ They must not to be overridden.
 * **DOTNET_FRAMEWORK,DOTNET_CORE_VERSION**
 
     These variables contain the framework (`netcoreapp2.0`) and .NET Core version (`2.0`) respectively.
+
+* **DOTNET_RUNNING_IN_CONTAINER**
+
+    Like Microsoft images, this is set to `true` and can be used to detect the application is built/running in a container.

--- a/2.0/runtime/test/run
+++ b/2.0/runtime/test/run
@@ -54,6 +54,9 @@ test_envvars() {
 
   # .NET Core determines culture based on LANG. It must be empty/unset to use the 'Invariant' culture
   assert_equal $(docker_get_env $IMAGE_NAME LANG) ""
+
+  # Like Microsoft images, we set this to 'true'
+  assert_equal $(docker_get_env $IMAGE_NAME DOTNET_RUNNING_IN_CONTAINER) "true"
 }
 
 test_debuggable() {

--- a/build.sh
+++ b/build.sh
@@ -77,7 +77,7 @@ test_images() {
 
 # Default to CentOS when not on RHEL.
 if ! [[ `grep "Red Hat Enterprise Linux" /etc/redhat-release` ]]; then
-  BUILD_CENTOS=true
+  export BUILD_CENTOS=true
 fi
 
 if [ "$BUILD_CENTOS" = "true" ]; then


### PR DESCRIPTION
Adds:
- DOTNET_RUNNING_IN_CONTAINER
This is set to `true` and can be used to detect the application is built/running in a container.

- DOTNET_USE_POLLING_FILE_WATCHER
This is set to `true` to ensure the `dotnet watch` command works in a container. This command is not used by the default scripts.

Fixes https://github.com/redhat-developer/s2i-dotnetcore/issues/163