### PR TITLE
dotnet-example: Fix DOTNET_STARTUP_PROJECT being replaced by DOTNET_SDK_VERSION.

### DIFF
--- a/templates/dotnet-example.json
+++ b/templates/dotnet-example.json
@@ -307,7 +307,7 @@
             "value": ""
         },
         {
-            "name": "DOTNET_SDK_VERSION",
+            "name": "DOTNET_STARTUP_PROJECT",
             "displayName": "Startup Project",
             "description": "Set this to a project file (e.g. csproj) or a folder containing a single project file.",
             "value": "app"


### PR DESCRIPTION
Regression in https://github.com/redhat-developer/s2i-dotnetcore/pull/154