### PR TITLE
Add explicit rm for yum cache to reduce image size.

### DIFF
--- a/2.1/build/Dockerfile
+++ b/2.1/build/Dockerfile
@@ -31,13 +31,12 @@ USER 0
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 # TODO: install 2.1 sdk
-# The 'rm -rf /var/cache/yum' line is there to clean out orphaned yum cache files,
-# which can be quite large in size.
 RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
     INSTALL_PKGS="rh-nodejs6-npm rh-nodejs6-nodejs-nodemon rh-dotnet20-dotnet-sdk-2.0 rsync" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
+    # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*
 
 # Directory with the sources is set as the working directory.

--- a/2.1/build/Dockerfile
+++ b/2.1/build/Dockerfile
@@ -31,11 +31,14 @@ USER 0
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 # TODO: install 2.1 sdk
+# The 'rm -rf /var/cache/yum' line is there to clean out orphaned yum cache files,
+# which can be quite large in size.
 RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
     INSTALL_PKGS="rh-nodejs6-npm rh-nodejs6-nodejs-nodemon rh-dotnet20-dotnet-sdk-2.0 rsync" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all -y
+    yum clean all -y && \
+    rm -rf /var/cache/yum/*
 
 # Directory with the sources is set as the working directory.
 RUN mkdir /opt/app-root/src

--- a/2.1/build/Dockerfile
+++ b/2.1/build/Dockerfile
@@ -36,7 +36,7 @@ RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
-    # yum cache files may still exist (and quite large in size)
+# yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*
 
 # Directory with the sources is set as the working directory.

--- a/2.1/build/Dockerfile.rhel7
+++ b/2.1/build/Dockerfile.rhel7
@@ -31,14 +31,13 @@ USER 0
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 # TODO: install 2.1 sdk
-# The 'rm -rf /var/cache/yum' line is there to clean out orphaned yum cache files,
-# # which can be quite large in size.
 RUN INSTALL_PKGS="rh-nodejs6-npm rh-nodejs6-nodejs-nodemon rh-dotnet20-dotnet-sdk-2.0 rh-dotnet20-dotnet-sdk-2.1 rsync" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
+    # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*
 
 # Directory with the sources is set as the working directory.

--- a/2.1/build/Dockerfile.rhel7
+++ b/2.1/build/Dockerfile.rhel7
@@ -31,12 +31,15 @@ USER 0
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 # TODO: install 2.1 sdk
+# The 'rm -rf /var/cache/yum' line is there to clean out orphaned yum cache files,
+# # which can be quite large in size.
 RUN INSTALL_PKGS="rh-nodejs6-npm rh-nodejs6-nodejs-nodemon rh-dotnet20-dotnet-sdk-2.0 rh-dotnet20-dotnet-sdk-2.1 rsync" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all -y
+    yum clean all -y && \
+    rm -rf /var/cache/yum/*
 
 # Directory with the sources is set as the working directory.
 RUN mkdir /opt/app-root/src

--- a/2.1/build/Dockerfile.rhel7
+++ b/2.1/build/Dockerfile.rhel7
@@ -37,7 +37,7 @@ RUN INSTALL_PKGS="rh-nodejs6-npm rh-nodejs6-nodejs-nodemon rh-dotnet20-dotnet-sd
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
-    # yum cache files may still exist (and quite large in size)
+# yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*
 
 # Directory with the sources is set as the working directory.

--- a/2.1/runtime/Dockerfile
+++ b/2.1/runtime/Dockerfile
@@ -47,7 +47,7 @@ RUN yum install -y centos-release-dotnet && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
-    # yum cache files may still exist (and quite large in size)
+# yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*
 
 # TODO: remove Microsoft binaries

--- a/2.1/runtime/Dockerfile
+++ b/2.1/runtime/Dockerfile
@@ -42,13 +42,12 @@ COPY ./contrib/ /opt/app-root
 COPY ./root/usr/bin /usr/bin
 
 # TODO: install 2.1 runtime
-# The 'rm -rf /var/cache/yum' line is there to clean out orphaned yum cache files,
-# which can be quite large in size.
 RUN yum install -y centos-release-dotnet && \
     INSTALL_PKGS="rh-dotnet20-dotnet-runtime-2.0 nss_wrapper tar unzip" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
+    # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*
 
 # TODO: remove Microsoft binaries

--- a/2.1/runtime/Dockerfile
+++ b/2.1/runtime/Dockerfile
@@ -42,11 +42,14 @@ COPY ./contrib/ /opt/app-root
 COPY ./root/usr/bin /usr/bin
 
 # TODO: install 2.1 runtime
+# The 'rm -rf /var/cache/yum' line is there to clean out orphaned yum cache files,
+# which can be quite large in size.
 RUN yum install -y centos-release-dotnet && \
     INSTALL_PKGS="rh-dotnet20-dotnet-runtime-2.0 nss_wrapper tar unzip" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all -y
+    yum clean all -y && \
+    rm -rf /var/cache/yum/*
 
 # TODO: remove Microsoft binaries
 RUN curl https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008530-linux-x64.tar.gz -o /tmp/dotnet-sdk.tar.gz && \

--- a/2.1/runtime/Dockerfile.rhel7
+++ b/2.1/runtime/Dockerfile.rhel7
@@ -42,12 +42,15 @@ COPY ./contrib/ /opt/app-root
 COPY ./root/usr/bin /usr/bin
 
 # TODO: install 2.1 runtime
+# The 'rm -rf /var/cache/yum' line is there to clean out orphaned yum cache files,
+# # which can be quite large in size.
 RUN INSTALL_PKGS="rh-dotnet20-dotnet-runtime-2.0 nss_wrapper tar unzip" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all -y
+    yum clean all -y && \
+    rm -rf /var/cache/yum/*
 
 # TODO: remove Microsoft binaries
 RUN curl https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008530-linux-x64.tar.gz -o /tmp/dotnet-sdk.tar.gz && \

--- a/2.1/runtime/Dockerfile.rhel7
+++ b/2.1/runtime/Dockerfile.rhel7
@@ -42,14 +42,13 @@ COPY ./contrib/ /opt/app-root
 COPY ./root/usr/bin /usr/bin
 
 # TODO: install 2.1 runtime
-# The 'rm -rf /var/cache/yum' line is there to clean out orphaned yum cache files,
-# # which can be quite large in size.
 RUN INSTALL_PKGS="rh-dotnet20-dotnet-runtime-2.0 nss_wrapper tar unzip" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
+    # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*
 
 # TODO: remove Microsoft binaries

--- a/2.1/runtime/Dockerfile.rhel7
+++ b/2.1/runtime/Dockerfile.rhel7
@@ -48,7 +48,7 @@ RUN INSTALL_PKGS="rh-dotnet20-dotnet-runtime-2.0 nss_wrapper tar unzip" && \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
-    # yum cache files may still exist (and quite large in size)
+# yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*
 
 # TODO: remove Microsoft binaries


### PR DESCRIPTION
Turns out the yum clear all -y line doesn't clear out all the cache files. I believe this is because we disable the repos and then enable them manually. Explicitly removing the cache saves ~350 MB in the image.

Note: the centos image doesn't have this problem, assumidly because it doesn't disable repos like the rhel image does, but I went ahead and added the lines for consistency. If anyone disagrees with that, just let me know and I'll remove the changes to the centos image.