### PR TITLE
Clean-up 1.x bits in our templates

### DIFF
--- a/templates/dotnet-example.json
+++ b/templates/dotnet-example.json
@@ -246,7 +246,7 @@
             "displayName": "Memory Limit",
             "description": "Maximum amount of memory the container can use.",
             "required": true,
-            "value": "512Mi"
+            "value": "128Mi"
         },
         {
             "name": "DOTNET_IMAGE_STREAM_TAG",

--- a/templates/dotnet-example.json
+++ b/templates/dotnet-example.json
@@ -112,10 +112,6 @@
                                 "value": "${DOTNET_CONFIGURATION}"
                             },
                             {
-                                "name": "DOTNET_PUBLISH",
-                                "value": "true"
-                            },
-                            {
                                 "name": "DOTNET_RESTORE_SOURCES",
                                 "value": "${DOTNET_RESTORE_SOURCES}"
                             },
@@ -329,8 +325,7 @@
         {
             "name": "DOTNET_NPM_TOOLS",
             "displayName": "Npm Tools",
-            "description": "Set this to a space separated list of npm tools needed to publish.",
-            "value": "bower gulp"
+            "description": "Set this to a space separated list of npm tools needed to publish."
         },
         {
             "name": "DOTNET_TEST_PROJECTS",

--- a/templates/dotnet-pgsql-persistent.json
+++ b/templates/dotnet-pgsql-persistent.json
@@ -438,20 +438,20 @@
             "displayName": "Memory Limit",
             "required": true,
             "description": "Maximum amount of memory the .NET Core container can use.",
-            "value": "512Mi"
+            "value": "128Mi"
         },
         {
             "name": "MEMORY_POSTGRESQL_LIMIT",
             "displayName": "Memory Limit (PostgreSQL)",
             "required": true,
             "description": "Maximum amount of memory the PostgreSQL container can use.",
-            "value": "512Mi"
+            "value": "128Mi"
         },
         {
             "name": "VOLUME_CAPACITY",
             "displayName": "Volume Capacity",
             "description": "Volume space available for data, e.g. 512Mi, 2Gi",
-            "value": "1Gi",
+            "value": "256Mi",
             "required": true
         },
         {

--- a/templates/dotnet-pgsql-persistent.json
+++ b/templates/dotnet-pgsql-persistent.json
@@ -128,10 +128,6 @@
                                 "value": "${DOTNET_CONFIGURATION}"
                             },
                             {
-                                "name": "DOTNET_PUBLISH",
-                                "value": "true"
-                            },
-                            {
                                 "name": "DOTNET_RESTORE_SOURCES",
                                 "value": "${DOTNET_RESTORE_SOURCES}"
                             },

--- a/templates/dotnet-runtime-example.json
+++ b/templates/dotnet-runtime-example.json
@@ -322,7 +322,7 @@
             "displayName": "Memory Limit",
             "description": "Maximum amount of memory the container can use.",
             "required": true,
-            "value": "512Mi"
+            "value": "128Mi"
         },
         {
             "name": "DOTNET_RUNTIME_IMAGE_STREAM_TAG",

--- a/templates/dotnet-runtime-example.json
+++ b/templates/dotnet-runtime-example.json
@@ -408,8 +408,7 @@
         {
             "name": "DOTNET_NPM_TOOLS",
             "displayName": "Npm Tools",
-            "description": "Set this to a space separated list of npm tools needed to publish.",
-            "value": "bower gulp"
+            "description": "Set this to a space separated list of npm tools needed to publish."
         },
         {
             "name": "DOTNET_TEST_PROJECTS",


### PR DESCRIPTION
DOTNET_PUBLISH has been removed since 2.x.
ASP.NET Core 2.x templates don't rely on bower and gulp by default (DOTNET_NPM_TOOLS).