### PR TITLE
Print sdk version after fetching sources.

### DIFF
--- a/1.0/s2i/bin/assemble
+++ b/1.0/s2i/bin/assemble
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 set -e
-shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
+# Include filenames beginning with a '.' when installing the application source code.
+shopt -s dotglob
 
 # User settable environment
 DOTNET_CONFIGURATION="${DOTNET_CONFIGURATION:-Release}"

--- a/1.0/s2i/bin/assemble
+++ b/1.0/s2i/bin/assemble
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
 
 # User settable environment
 DOTNET_CONFIGURATION="${DOTNET_CONFIGURATION:-Release}"
@@ -37,7 +38,6 @@ if [ -n "$DOTNET_ASSEMBLY_NAME" ]; then
   cd "$DOTNET_ASSEMBLY_NAME"
 fi
 
-shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
 echo "---> Installing application source ..."
 if [ -d /tmp/src ]; then
   mv /tmp/src/* ./

--- a/1.0/s2i/bin/assemble
+++ b/1.0/s2i/bin/assemble
@@ -37,8 +37,11 @@ if [ -n "$DOTNET_ASSEMBLY_NAME" ]; then
   cd "$DOTNET_ASSEMBLY_NAME"
 fi
 
-echo "---> Copying application source ..."
-cp -Rf /tmp/src/. ./
+shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
+echo "---> Installing application source ..."
+if [ -d /tmp/src ]; then
+  mv /tmp/src/* ./
+fi
 
 # output assembly name
 if [ -n "$DOTNET_ASSEMBLY_NAME" ]; then

--- a/1.1/s2i/bin/assemble
+++ b/1.1/s2i/bin/assemble
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 set -e
-shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
+# Include filenames beginning with a '.' when installing the application source code.
+shopt -s dotglob
 
 # User settable environment
 DOTNET_CONFIGURATION="${DOTNET_CONFIGURATION:-Release}"

--- a/1.1/s2i/bin/assemble
+++ b/1.1/s2i/bin/assemble
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
 
 # User settable environment
 DOTNET_CONFIGURATION="${DOTNET_CONFIGURATION:-Release}"
@@ -37,7 +38,6 @@ if [ -n "$DOTNET_ASSEMBLY_NAME" ]; then
   cd "$DOTNET_ASSEMBLY_NAME"
 fi
 
-shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
 echo "---> Installing application source ..."
 if [ -d /tmp/src ]; then
   mv /tmp/src/* ./

--- a/1.1/s2i/bin/assemble
+++ b/1.1/s2i/bin/assemble
@@ -37,8 +37,11 @@ if [ -n "$DOTNET_ASSEMBLY_NAME" ]; then
   cd "$DOTNET_ASSEMBLY_NAME"
 fi
 
-echo "---> Copying application source ..."
-cp -Rf /tmp/src/. ./
+shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
+echo "---> Installing application source ..."
+if [ -d /tmp/src ]; then
+  mv /tmp/src/* ./
+fi
 
 # output assembly name
 if [ -n "$DOTNET_ASSEMBLY_NAME" ]; then

--- a/2.0/build/s2i/bin/assemble
+++ b/2.0/build/s2i/bin/assemble
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 set -e
-shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
+# Include filenames beginning with a '.' when installing the application source code.
+shopt -s dotglob
 
 if [ -n "${DOTNET_VERBOSITY}" ]; then
   echo "--> Environment:"

--- a/2.0/build/s2i/bin/assemble
+++ b/2.0/build/s2i/bin/assemble
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
 
 if [ -n "${DOTNET_VERBOSITY}" ]; then
   echo "--> Environment:"
@@ -10,7 +11,6 @@ else
   VERBOSITY_OPTION=""
 fi
 
-shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
 echo "---> Installing application source ..."
 if [ -d /tmp/src ]; then
   mv /tmp/src/* ./

--- a/2.0/build/s2i/bin/assemble
+++ b/2.0/build/s2i/bin/assemble
@@ -10,6 +10,25 @@ else
   VERBOSITY_OPTION=""
 fi
 
+shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
+echo "---> Installing application source ..."
+if [ -d /tmp/src ]; then
+  mv /tmp/src/* ./
+fi
+
+# sdk version
+DOTNET_SDK_VERSION="${DOTNET_SDK_VERSION:-$DOTNET_SDK_BASE_VERSION}"
+if [ "$DOTNET_SDK_VERSION" != "latest" ]; then
+cat >../global.json <<EOF
+{
+  "sdk": {
+    "version": "$DOTNET_SDK_VERSION"
+  }
+}
+EOF
+fi
+echo "Using SDK: $(dotnet --version)"
+
 # npm
 if [ -n "${DOTNET_NPM_TOOLS}" ]; then
   echo "---> Installing npm tools ..."
@@ -31,22 +50,6 @@ if [ -n "${DOTNET_NPM_TOOLS}" ]; then
   npm install ${DOTNET_NPM_TOOLS}
   popd
 fi
-
-# sdk version
-DOTNET_SDK_VERSION="${DOTNET_SDK_VERSION:-$DOTNET_SDK_BASE_VERSION}"
-if [ "$DOTNET_SDK_VERSION" != "latest" ]; then
-cat >../global.json <<EOF
-{
-  "sdk": {
-    "version": "$DOTNET_SDK_VERSION"
-  }
-}
-EOF
-fi
-echo "Using SDK: $(dotnet --version)"
-
-echo "---> Copying application source ..."
-cp -Rf /tmp/src/. ./
 
 if [ "$DEV_MODE" == true ]; then
   # fix permissions

--- a/2.1/build/s2i/bin/assemble
+++ b/2.1/build/s2i/bin/assemble
@@ -10,6 +10,25 @@ else
   VERBOSITY_OPTION=""
 fi
 
+shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
+echo "---> Installing application source ..."
+if [ -d /tmp/src ]; then
+  mv /tmp/src/* ./
+fi
+
+# sdk version
+DOTNET_SDK_VERSION="${DOTNET_SDK_VERSION:-$DOTNET_SDK_BASE_VERSION}"
+if [ "$DOTNET_SDK_VERSION" != "latest" ]; then
+cat >../global.json <<EOF
+{
+  "sdk": {
+    "version": "$DOTNET_SDK_VERSION"
+  }
+}
+EOF
+fi
+echo "Using SDK: $(dotnet --version)"
+
 # npm
 if [ -n "${DOTNET_NPM_TOOLS}" ]; then
   echo "---> Installing npm tools ..."
@@ -31,19 +50,6 @@ if [ -n "${DOTNET_NPM_TOOLS}" ]; then
   npm install ${DOTNET_NPM_TOOLS}
   popd
 fi
-
-# sdk version
-DOTNET_SDK_VERSION="${DOTNET_SDK_VERSION:-$DOTNET_SDK_BASE_VERSION}"
-if [ "$DOTNET_SDK_VERSION" != "latest" ]; then
-cat >../global.json <<EOF
-{
-  "sdk": {
-    "version": "$DOTNET_SDK_VERSION"
-  }
-}
-EOF
-fi
-echo "Using SDK: $(dotnet --version)"
 
 # dotnet tools
 if [ -n "${DOTNET_TOOLS}" ]; then
@@ -79,9 +85,6 @@ EOF
     dotnet tool install -g $VERBOSITY_OPTION $TOOL_RESTORE_OPTIONS $DOTNET_TOOL_VERSION_OPTION $DOTNET_TOOL_NAME
   done
 fi
-
-echo "---> Copying application source ..."
-cp -Rf /tmp/src/. ./
 
 if [ "$DEV_MODE" == true ]; then
   # fix permissions

--- a/2.1/build/s2i/bin/assemble
+++ b/2.1/build/s2i/bin/assemble
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 set -e
-shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
+# Include filenames beginning with a '.' when installing the application source code.
+shopt -s dotglob
 
 if [ -n "${DOTNET_VERBOSITY}" ]; then
   echo "--> Environment:"

--- a/2.1/build/s2i/bin/assemble
+++ b/2.1/build/s2i/bin/assemble
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
 
 if [ -n "${DOTNET_VERBOSITY}" ]; then
   echo "--> Environment:"
@@ -10,7 +11,6 @@ else
   VERBOSITY_OPTION=""
 fi
 
-shopt -s dotglob # includes filenames beginning with a ‘.’ in the results of filename expansion
 echo "---> Installing application source ..."
 if [ -d /tmp/src ]; then
   mv /tmp/src/* ./


### PR DESCRIPTION
This makes the echoed version reflect the sdk that may be selected
via a global.json file in the source repository.

This commit also changes from using 'cp' to 'mv'. This avoids
having the sources stored twice in the image. This is similar to s2i node images.

An additional check is added to check if the '/tmp/src' directory exists.
Without that check the sdk version test would fail because it doesn't have
sources. Perhaps this can also happen in practice, in particular when setting using
DEV_MODE with an empty git repository.

For consistency, the changes are also applied to 1.0 and 1.1.