### PR TITLE
Fix 2.1 tests and cccp ids for CentOS

### DIFF
--- a/2.1/build/Dockerfile
+++ b/2.1/build/Dockerfile
@@ -2,7 +2,7 @@ FROM dotnet/dotnet-21-runtime-centos7
 # This image provides a .NET Core 2.1 environment you can use to run your .NET
 # applications.
 
-ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/dotnet_tools:/opt/app-root/node_modules/.bin:${PATH} \
+ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/.dotnet/tools:/opt/app-root/node_modules/.bin:${PATH} \
     STI_SCRIPTS_PATH=/usr/libexec/s2i
 
 LABEL io.k8s.description="Platform for building and running .NET Core 2.1 applications" \

--- a/2.1/build/cccp.yml
+++ b/2.1/build/cccp.yml
@@ -1,3 +1,3 @@
 # This is for the purpose of building this container
 # on the centos container pipeline.
-job-id: dotnet-20-centos7
+job-id: dotnet-21-centos7

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -31,9 +31,9 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
 if [ "$BUILD_CENTOS" = "true" ]; then
-sdk_default_version="2.1.300"
-sdk_latest_version="2.1.300"
-sdk_versions=( "2.1.300" )
+sdk_default_version="2.1.302"
+sdk_latest_version="2.1.302"
+sdk_versions=( "2.1.302" )
 else
 sdk_default_version="2.1.301"
 sdk_latest_version="2.1.301"

--- a/2.1/runtime/cccp.yml
+++ b/2.1/runtime/cccp.yml
@@ -1,3 +1,3 @@
 # This is for the purpose of building this container
 # on the centos container pipeline.
-job-id: dotnet-20-runtime-centos7
+job-id: dotnet-21-runtime-centos7


### PR DESCRIPTION
.NET Core 2.1 is now built in CentOS. Update the tests and the build yml
files to work for that.

Also update the CentOS dockerfile to match the RHEL 7 dockerfile.