### PR TITLE
Update centos imagestream with 2.1 images.

### DIFF
--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -23,7 +23,7 @@
                         "name": "latest",
                         "annotations": {
                           "openshift.io/display-name": ".NET Core (Latest)",
-                          "description": "Build and run .NET Core applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
+                          "description": "Build and run .NET Core applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
                           "iconClass": "icon-dotnet",
                           "tags": "builder,.net,dotnet,dotnetcore",
                           "supports":"dotnet",
@@ -126,7 +126,7 @@
                         "name": "latest",
                         "annotations": {
                           "openshift.io/display-name": ".NET Core Runtime (Latest)",
-                          "description": "Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+                          "description": "Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
                           "iconClass": "icon-dotnet",
                           "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                           "supports":"dotnet-runtime"

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -37,24 +37,6 @@
                         }
                     },
                     {
-                        "name": "2.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET Core 2.0",
-                            "description": "Build and run .NET Core 2.0 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet20",
-                            "supports":"dotnet:2.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-2.0",
-                            "version": "2.0"
-                        },
-                        "from": {
-                          "kind": "DockerImage",
-                          "name": "registry.centos.org/dotnet/dotnet-20-centos7:latest"
-                        }
-                    },
-                    {
                         "name": "2.1",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.1",
@@ -70,6 +52,24 @@
                         "from": {
                           "kind": "DockerImage",
                           "name": "registry.centos.org/dotnet/dotnet-21-centos7:latest"
+                        }
+                    },
+                    {
+                        "name": "2.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 2.0",
+                            "description": "Build and run .NET Core 2.0 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet20",
+                            "supports":"dotnet:2.0,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-2.0",
+                            "version": "2.0"
+                        },
+                        "from": {
+                          "kind": "DockerImage",
+                          "name": "registry.centos.org/dotnet/dotnet-20-centos7:latest"
                         }
                     }
                 ]
@@ -101,21 +101,6 @@
                         }
                     },
                     {
-                        "name": "2.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET Core 2.0 Runtime",
-                            "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports":"dotnet-runtime",
-                            "version": "2.0"
-                        },
-                        "from": {
-                          "kind": "DockerImage",
-                          "name": "registry.centos.org/dotnet/dotnet-20-runtime-centos7:latest"
-                        }
-                    },
-                    {
                         "name": "2.1",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.1 Runtime",
@@ -128,6 +113,21 @@
                         "from": {
                           "kind": "DockerImage",
                           "name": "registry.centos.org/dotnet/dotnet-21-runtime-centos7:latest"
+                        }
+                    },
+                    {
+                        "name": "2.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 2.0 Runtime",
+                            "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports":"dotnet-runtime",
+                            "version": "2.0"
+                        },
+                        "from": {
+                          "kind": "DockerImage",
+                          "name": "registry.centos.org/dotnet/dotnet-20-runtime-centos7:latest"
                         }
                     }
                 ]

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -23,17 +23,17 @@
                         "name": "latest",
                         "annotations": {
                           "openshift.io/display-name": ".NET Core (Latest)",
-                          "description": "Build and run .NET Core applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
+                          "description": "Build and run .NET Core applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
                           "iconClass": "icon-dotnet",
                           "tags": "builder,.net,dotnet,dotnetcore",
                           "supports":"dotnet",
                           "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
                           "sampleContextDir": "app",
-                          "sampleRef": "dotnetcore-2.0"
+                          "sampleRef": "dotnetcore-2.1"
                         },
                         "from": {
                           "kind": "ImageStreamTag",
-                          "name": "2.0"
+                          "name": "2.1"
                         }
                     },
                     {
@@ -52,6 +52,24 @@
                         "from": {
                           "kind": "DockerImage",
                           "name": "registry.centos.org/dotnet/dotnet-20-centos7:latest"
+                        }
+                    },
+                    {
+                        "name": "2.1",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 2.1",
+                            "description": "Build and run .NET Core 2.1 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet21",
+                            "supports":"dotnet:2.1,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-2.1",
+                            "version": "2.1"
+                        },
+                        "from": {
+                          "kind": "DockerImage",
+                          "name": "registry.centos.org/dotnet/dotnet-21-centos7:latest"
                         }
                     }
                 ]
@@ -72,14 +90,14 @@
                         "name": "latest",
                         "annotations": {
                           "openshift.io/display-name": ".NET Core Runtime (Latest)",
-                          "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+                          "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
                           "iconClass": "icon-dotnet",
                           "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                           "supports":"dotnet-runtime"
                         },
                         "from": {
                           "kind": "ImageStreamTag",
-                          "name": "2.0"
+                          "name": "2.1"
                         }
                     },
                     {
@@ -95,6 +113,21 @@
                         "from": {
                           "kind": "DockerImage",
                           "name": "registry.centos.org/dotnet/dotnet-20-runtime-centos7:latest"
+                        }
+                    },
+                    {
+                        "name": "2.1",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 2.1 Runtime",
+                            "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports":"dotnet-runtime",
+                            "version": "2.1"
+                        },
+                        "from": {
+                          "kind": "DockerImage",
+                          "name": "registry.centos.org/dotnet/dotnet-21-runtime-centos7:latest"
                         }
                     }
                 ]


### PR DESCRIPTION
Also, the rhel imagestream latest tag was still pointing to the 2.0 readme instead of the 2.1 readme.