### PR TITLE
Allow DOTNET_SSL_DIRS to be volumes mounted into the application cont…

### DIFF
--- a/2.1/build/README.md
+++ b/2.1/build/README.md
@@ -137,12 +137,6 @@ a `.s2i/environment` file inside your source code repository.
     `Release` or `Debug`.  This is passed to the `dotnet publish` invocation.
     Defaults to `Release`.
 
-* **DOTNET_SSL_DIRS**
-
-    Used to specify a list of folders with additional certificates to trust. The certificates are trusted by each process that runs
-    during the build and all processes that runs in the image after the build (including the application that was built). The folders
-    can be absolute paths (starting with `/`) or paths in the source repository (e.g. `certificates`). Defaults to ``.
-
 * **ASPNETCORE_URLS**
 
     This variable is set to `http://*:8080` to configure ASP.NET Core to use the

--- a/2.1/build/s2i/bin/assemble
+++ b/2.1/build/s2i/bin/assemble
@@ -30,43 +30,8 @@ EOF
 fi
 echo "Using SDK: $(dotnet --version)"
 
-# Trust certificates from all DOTNET_SSL_DIRS.
-# Store them in the DOTNET_SSL_CERT_DIR which is picked up by the container-entrypoint.
-if [ -n "$DOTNET_SSL_DIRS" ]; then
-
-  # Append SSL_CERT_DIR to DOTNET_SSL_DIRS.
-  # If SSL_CERT_DIR is unset, use the default location.
-  if [ -z ${SSL_CERT_DIR+x} ]; then
-    SSL_CERT_DIR=/etc/pki/tls/certs
-  fi
-  DOTNET_SSL_DIRS="$DOTNET_SSL_DIRS $SSL_CERT_DIR"
-
-  # Create certificate folder.
-  mkdir "$DOTNET_SSL_CERT_DIR"
-
-  # Populate it with certificates.
-  CERT_ID=0
-  for SSL_DIR in $DOTNET_SSL_DIRS; do
-    # Ignore non-existing directories.
-    if [ -d "$SSL_DIR" ]; then
-      # Copy the file when it is in the src folder so it can't get removed by DOTNET_RM_SRC.
-      # Create symbolic links for files in other folders.
-      CERTFILES=(`find -L "$SSL_DIR" -maxdepth 1 -type f -exec realpath {} \;`)
-      for CERT_FILE in ${CERTFILES[@]}
-      do
-        if [[ "$CERT_FILE" =~ ^/opt/app-root/src/* ]]; then
-          cp "$CERT_FILE" "$DOTNET_SSL_CERT_DIR/_s2i$CERT_ID"
-        else
-          ln -s "$CERT_FILE" "$DOTNET_SSL_CERT_DIR/_s2i$CERT_ID"
-        fi
-        CERT_ID=$((CERT_ID + 1))
-      done
-    fi
-  done
-
-  # Use the certificate folder.
-  export SSL_CERT_DIR="$DOTNET_SSL_CERT_DIR"
-fi
+# Trust certificates from DOTNET_SSL_DIRS.
+source /opt/app-root/etc/trust_ssl_dirs
 
 # npm
 if [ -n "${DOTNET_NPM_TOOLS}" ]; then

--- a/2.1/build/test/certificatecount/.s2i/environment
+++ b/2.1/build/test/certificatecount/.s2i/environment
@@ -1,1 +1,0 @@
-DOTNET_RM_SRC=true

--- a/2.1/runtime/README.md
+++ b/2.1/runtime/README.md
@@ -76,11 +76,11 @@ They must not to be overridden.
 
     These variables contain the working directory (`/opt/app-root/app`) and default CMD of the runtime image (`default-cmd.sh`).
 
-* **DOTNET_SSL_CERT_DIR**
+* **DOTNET_SSL_DIRS**
 
-    This variable is set to `/opt/app-root/ssl_dir`. This directory is not present in the runtime image.
-    When it added (e.g. by s2i assemble), it is used as `SSL_CERT_DIR`. `SSL_CERT_DIR` is used by applications (including `dotnet`)
-    to load CA certificates.
+    Used to specify a list of folders with additional certificates to trust. The certificates are trusted by each process that runs
+    during the build and all processes that runs in the image after the build (including the application that was built). The folders
+    can be absolute paths (starting with `/`) or paths in the source repository (e.g. `certificates`). Defaults to ``.
 
 * **DOTNET_FRAMEWORK,DOTNET_CORE_VERSION**
 

--- a/2.1/runtime/README.md
+++ b/2.1/runtime/README.md
@@ -79,7 +79,7 @@ They must not to be overridden.
 * **DOTNET_SSL_DIRS**
 
     Used to specify a list of folders with additional certificates to trust. The certificates are trusted by each process that runs
-    during the build and all processes that runs in the image after the build (including the application that was built). The folders
+    during the build and all processes that run in the image after the build (including the application that was built). The folders
     can be absolute paths (starting with `/`) or paths in the source repository (e.g. `certificates`). Defaults to ``.
 
 * **DOTNET_FRAMEWORK,DOTNET_CORE_VERSION**

--- a/2.1/runtime/contrib/etc/trust_ssl_dirs
+++ b/2.1/runtime/contrib/etc/trust_ssl_dirs
@@ -1,0 +1,54 @@
+# Trust certificates from all DOTNET_SSL_DIRS.
+if [ -n "$DOTNET_SSL_DIRS" ]; then
+
+  # For backwards compatibility we need to run this in the src folder.
+  # Create one if it does not exist.
+  if [ ! -d /opt/app-root/src ]; then
+    mkdir /opt/app-root/src
+    _REMOVE_SRC_DIR=true
+  fi
+  pushd /opt/app-root/src >/dev/null
+
+  # Store SSL_CERT_DIR since we'll overwrite it and we want to support
+  # calling this script several times.
+  if [ -z ${_USER_SSL_CERT_DIR+x} ]; then
+    # If SSL_CERT_DIR is unset, use the default location.
+    if [ -z ${SSL_CERT_DIR+x} ]; then
+      _USER_SSL_CERT_DIR=/etc/pki/tls/certs
+    else
+      _USER_SSL_CERT_DIR="${SSL_CERT_DIR}"
+    fi
+    export _USER_SSL_CERT_DIR
+  fi
+
+  # Append _USER_SSL_CERT_DIR to DOTNET_SSL_DIRS.
+  _DOTNET_SSL_DIRS="$DOTNET_SSL_DIRS $_USER_SSL_CERT_DIR"
+
+  # Create/replace certificate folder.
+  rm -rf "$DOTNET_SSL_CERT_DIR"
+  mkdir "$DOTNET_SSL_CERT_DIR"
+
+  # Populate it with certificates.
+  CERT_ID=0
+  for SSL_DIR in $_DOTNET_SSL_DIRS; do
+    # Ignore non-existing directories.
+    if [ -d "$SSL_DIR" ]; then
+      # Create a symbolic link for each certificate.
+      CERTFILES=(`find -L "$SSL_DIR" -maxdepth 1 -type f -exec realpath {} \;`)
+      for CERT_FILE in ${CERTFILES[@]}
+      do
+        ln -s "$CERT_FILE" "$DOTNET_SSL_CERT_DIR/_s2i$CERT_ID"
+        CERT_ID=$((CERT_ID + 1))
+      done
+    fi
+  done
+
+  popd >/dev/null
+  # Remove temporary src folder.
+  if [ "$_REMOVE_SRC_DIR" = true ] ; then
+    rm /opt/app-root/src
+  fi
+
+  # Use the certificate folder.
+  export SSL_CERT_DIR="$DOTNET_SSL_CERT_DIR"
+fi

--- a/2.1/runtime/root/usr/bin/container-entrypoint
+++ b/2.1/runtime/root/usr/bin/container-entrypoint
@@ -12,10 +12,14 @@ if [ -z "$http_proxy" ] && [ ! -z "$HTTP_PROXY" ]; then
   export http_proxy="${HTTP_PROXY}"
 fi
 
-# When there is an DOTNET_SSL_CERT_DIR folder, use it as the SSL_CERT_DIR.
-# The assemble script creates this folder when DOTNET_SSL_DIRS is set.
-if [ -d "$DOTNET_SSL_CERT_DIR" ]; then
-  export SSL_CERT_DIR="$DOTNET_SSL_CERT_DIR"
+# Trust certificates from DOTNET_SSL_DIRS.
+if [ -n "$DOTNET_SSL_DIRS" ]; then
+  # The main process (PID 1) sets up a certificate folder. The other processes use it.
+  if [ $$ -eq 1 ]; then
+    source /opt/app-root/etc/trust_ssl_dirs
+  else
+    export SSL_CERT_DIR="$DOTNET_SSL_CERT_DIR"
+  fi
 fi
 
 cmd="$1"; shift


### PR DESCRIPTION
This enables DOTNET_SSL_DIRS to include volumes that are mounted into the container.
Before this changes, only directories that were part of the build container ould be used as DOTNET_SSL_DIRS.

Implements https://github.com/redhat-developer/s2i-dotnetcore/issues/213.