### PR TITLE
Support multiple SDKs and copy certs found in src directory.

### DIFF
--- a/2.1/build/Dockerfile.rhel7
+++ b/2.1/build/Dockerfile.rhel7
@@ -29,7 +29,7 @@ USER 0
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
 COPY ./s2i/bin/ /usr/libexec/s2i
 
-RUN INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1 rh-dotnet21-dotnet-sdk-2.1.3xx.x86_64 rsync" && \
+RUN INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1 rh-dotnet21-dotnet-sdk-2.1.3xx rsync" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \

--- a/2.1/build/Dockerfile.rhel7
+++ b/2.1/build/Dockerfile.rhel7
@@ -29,7 +29,7 @@ USER 0
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
 COPY ./s2i/bin/ /usr/libexec/s2i
 
-RUN INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1 rsync" && \
+RUN INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1 rh-dotnet21-dotnet-sdk-2.1.3xx.x86_64 rsync" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -31,14 +31,14 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
 # Versions of Microsoft.AspNetCore.{All,App} packages that are known by latest RHEL sdk.
-aspnet_latest_app_version=2.1.3
-aspnet_latest_all_version=2.1.3
+aspnet_latest_app_version=2.1.4
+aspnet_latest_all_version=2.1.4
 if [ "$BUILD_CENTOS" = "true" ]; then
 # sdk versions supported on CentOS
 sdk_versions=( "2.1.302" )
 else
 # sdk versions supported on RHEL
-sdk_versions=( "2.1.302" )
+sdk_versions=( "2.1.302" "2.1.402" )
 fi
 
 sdk_default_version=${sdk_versions[0]}

--- a/2.1/runtime/contrib/etc/trust_ssl_dirs
+++ b/2.1/runtime/contrib/etc/trust_ssl_dirs
@@ -28,21 +28,32 @@ if [ -n "$DOTNET_SSL_DIRS" ]; then
   rm -rf "$DOTNET_SSL_CERT_DIR"
   mkdir "$DOTNET_SSL_CERT_DIR"
 
+  populate_cert() {
+    CERT_FILE=$(realpath "$1")
+    CERT_DEST="$DOTNET_SSL_CERT_DIR/_s2i$2"
+    if [[ "$CERT_FILE" =~ ^/opt/app-root/src/* ]]; then
+      # If the cert file is in the src dir, copy it.
+      # Otherwise it may get removed by DOTNET_RM_SRC
+      cp "$CERT_FILE" "$CERT_DEST"
+    else
+      # Create a symbolic link to the file.
+      ln -s "$CERT_FILE" "$CERT_DEST"
+    fi
+  }
+
   # Populate it with certificates.
   CERT_ID=0
   for SSL_DIR in $_DOTNET_SSL_DIRS; do
     if [ -d "$SSL_DIR" ]; then
-      # Create a symbolic link for each certificate in the directory.
-      CERTFILES=(`find -L "$SSL_DIR" -maxdepth 1 -type f -exec realpath {} \;`)
+      # Walk through each certificate in the directory.
+      CERTFILES=(`find -L "$SSL_DIR" -maxdepth 1 -type f`)
       for CERT_FILE in ${CERTFILES[@]}
       do
-        ln -s "$CERT_FILE" "$DOTNET_SSL_CERT_DIR/_s2i$CERT_ID"
+        populate_cert "$CERT_FILE" $CERT_ID
         CERT_ID=$((CERT_ID + 1))
       done
     elif [ -f "$SSL_DIR" ]; then
-      # Create a symbolic link to the file.
-      CERT_FILE=$(realpath "$SSL_DIR")
-      ln -s "$CERT_FILE" "$DOTNET_SSL_CERT_DIR/_s2i$CERT_ID"
+      populate_cert "$SSL_DIR" $CERT_ID
       CERT_ID=$((CERT_ID + 1))
     fi
   done


### PR DESCRIPTION
The first commit adds 2.1.3xx sdks to the 2.1 build dockerfile, and then updates the tests to support 2.1.3xx and 2.1.4xx.

The second changes the trust_ssl_dirs file to copy cert files added to DOTNET_SSL_DIRS that exist inside the '/opt/app-root/src' path. When that code existed directly inside of s2i/assemble, that is what it did, but when the code was pulled out to trust_ssl_dirs and updated to support directories (and not just single files), it changed to only ever create sym-links.

This doesn't work with DOTNET_RM_SRC, because it removes all files in /opt/app-root/src, including those cert files.