### PR TITLE
.NET Core 2.0 is EOL

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -86,12 +86,12 @@ if ! [[ `grep "Red Hat Enterprise Linux" /etc/redhat-release` ]]; then
 fi
 
 if [ "$BUILD_CENTOS" = "true" ]; then
-  VERSIONS="${VERSIONS:-1.0 2.0}"
+  VERSIONS="${VERSIONS:-1.0 2.1}"
   image_os="centos7"
   image_prefix="dotnet"
   docker_filename="Dockerfile"
 else
-  VERSIONS="${VERSIONS:-1.0 1.1 2.0 2.1}"
+  VERSIONS="${VERSIONS:-1.0 1.1 2.1}"
   image_os="rhel7"
   image_prefix="dotnet"
   docker_filename="Dockerfile.rhel7"

--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -64,7 +64,7 @@
                         "name": "2.0",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.0",
-                            "description": "DEPRECATED: Build and run .NET Core 2.0 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.",
+                            "description": "RETIRED: Build and run .NET Core 2.0 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet20",
                             "supports": "dotnet:2.0,dotnet",
@@ -176,7 +176,7 @@
                         "name": "2.0",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.0 Runtime",
-                            "description": "DEPRECATED: Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.",
+                            "description": "RETIRED: Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime",

--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -64,7 +64,7 @@
                         "name": "2.0",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.0",
-                            "description": "Build and run .NET Core 2.0 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.",
+                            "description": "DEPRECATED: Build and run .NET Core 2.0 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet20",
                             "supports": "dotnet:2.0,dotnet",
@@ -176,7 +176,7 @@
                         "name": "2.0",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.0 Runtime",
-                            "description": "Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.",
+                            "description": "DEPRECATED: Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime",

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -58,7 +58,7 @@
                         "name": "2.0",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.0",
-                            "description": "DEPRECATED: Build and run .NET Core 2.0 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.",
+                            "description": "RETIRED: Build and run .NET Core 2.0 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet20",
                             "supports":"dotnet:2.0,dotnet",
@@ -119,7 +119,7 @@
                         "name": "2.0",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.0 Runtime",
-                            "description": "DEPRECATED: Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.",
+                            "description": "RETIRED: Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports":"dotnet-runtime",

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -58,7 +58,7 @@
                         "name": "2.0",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.0",
-                            "description": "Build and run .NET Core 2.0 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.",
+                            "description": "DEPRECATED: Build and run .NET Core 2.0 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet20",
                             "supports":"dotnet:2.0,dotnet",
@@ -119,7 +119,7 @@
                         "name": "2.0",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.0 Runtime",
-                            "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.",
+                            "description": "DEPRECATED: Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports":"dotnet-runtime",


### PR DESCRIPTION
imagestreams: add 'DEPRECATED' to the image tag descriptions.
build.sh: remove 2.0 build