### PR TITLE
Re-work image OS detection.

### DIFF
--- a/1.0/test/run
+++ b/1.0/test/run
@@ -18,11 +18,7 @@
 #
 # Example usage: $ sudo ./test/run
 
-if ! [[ `grep "Red Hat Enterprise Linux" /etc/redhat-release` ]]; then
-  BUILD_CENTOS=true
-fi
-
-if [ "$BUILD_CENTOS" = "true" ]; then
+if [ "$IMAGE_OS" = "CENTOS" ]; then
   IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnetcore-10-centos7}
 else
   IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnetcore-10-rhel7}
@@ -45,7 +41,7 @@ declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
-if [ "$BUILD_CENTOS" = "true" ]; then
+if [ "$IMAGE_OS" = "CENTOS" ]; then
 dotnet_version="1.0.0-preview2-003320"
 else
 dotnet_version="1.0.0-preview2-003320"

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -37,7 +37,7 @@ declare -a WEB_APPS=(asp-net-hello-world asp-net-hello-world-envvar)
 
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
-if [ "$BUILD_CENTOS" = "true" ]; then
+if [ "$IMAGE_OS" = "CENTOS" ]; then
 dotnet_version="1.0.0-preview2-1-003331"
 else
 dotnet_version="1.0.0-preview2-1-003331"

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -18,7 +18,7 @@
 #
 # Example usage: $ sudo ./test/run
 
-if [ "$BUILD_CENTOS" = "true" ]; then
+if [ "$IMAGE_OS" = "CENTOS" ]; then
   IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnet-21-centos7}
   RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-dotnet/dotnet-21-runtime-centos7}
 else
@@ -33,7 +33,7 @@ source ${test_dir}/testcommon
 # Versions of Microsoft.AspNetCore.{All,App} packages that are known by latest RHEL sdk.
 aspnet_latest_app_version=2.1.5
 aspnet_latest_all_version=2.1.5
-if [ "$BUILD_CENTOS" = "true" ]; then
+if [ "$IMAGE_OS" = "CENTOS" ]; then
 # sdk versions supported on CentOS
 sdk_versions=( "2.1.302" )
 else
@@ -613,7 +613,7 @@ test_aspnet_implicit_using_latest()
 
   # verify aspnet_latest_{app,all}_version have the correct values.
   # If this fails, the variables in the test and environment variables in the Dockerfiles must be updated.
-  if [ "$sdk_version" == "$sdk_latest_version" -a "$BUILD_CENTOS" != "true" ]; then
+  if [ "$sdk_version" == "$sdk_latest_version" -a "$IMAGE_OS" != "CENTOS" ]; then
     info verifying aspnet_latest_{app,all}
 
     # build image

--- a/2.1/runtime/test/run
+++ b/2.1/runtime/test/run
@@ -15,7 +15,7 @@
 #
 # Example usage: $ sudo ./test/run
 
-if [ "$BUILD_CENTOS" = "true" ]; then
+if [ "$IMAGE_OS" = "CENTOS" ]; then
   IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnet-21-runtime-centos7}
 else
   IMAGE_NAME=${IMAGE_NAME:-dotnet/dotnet-21-runtime-rhel7}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ sudo VERSIONS=2.1 ./build.sh
 
 Note: to build RHEL 7 based images, you need to run the build on a
 properly subscribed RHEL machine. To build CentOS images on RHEL, set
-BUILD_CENTOS=true. On non-RHEL, building CentOS images is the default.
+IMAGE_OS=CENTOS. On non-RHEL, building CentOS images is the default.
 
 Installing
 ----------------

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,11 @@
 # VERSIONS        The list of versions to build/test.
 #                 Defaults to all versions. i.e "1.0 1.1".
 #
-# BUILD_CENTOS    If 'true' build CentOS based images.
+# IMAGE_OS        The base os image to use when building
+#                 the containers.
+#                 Options are CENTOS and RHEL.
+#                 Defaults to RHEL on a rhel system,
+#                 otherwise defaults to CENTOS.
 #
 # TEST_PORT       specifies the port on the docker host
 #                 to bind to when creating containers
@@ -80,12 +84,16 @@ test_images() {
   check_result_msg $? "Tests FAILED!"
 }
 
-# Default to CentOS when not on RHEL.
-if ! [[ `grep "Red Hat Enterprise Linux" /etc/redhat-release` ]]; then
-  export BUILD_CENTOS=true
+if [ -z ${IMAGE_OS+x} ]; then
+  # Default to CentOS when not on RHEL.
+  if [[ `grep "Red Hat Enterprise Linux" /etc/redhat-release` ]]; then
+    export IMAGE_OS="RHEL"
+  else
+    export IMAGE_OS="CENTOS"
+  fi
 fi
 
-if [ "$BUILD_CENTOS" = "true" ]; then
+if [ "$IMAGE_OS" = "CENTOS" ]; then
   VERSIONS="${VERSIONS:-1.0 2.1}"
   image_os="centos7"
   image_prefix="dotnet"


### PR DESCRIPTION
This makes it easier to add new base images for building and testing containers (like fedora, or a previous rhel), that may have different version or test requirements. 