### PR TITLE
Don't show retired image streams in OpenShift Console.

### DIFF
--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -66,7 +66,7 @@
                             "openshift.io/display-name": ".NET Core 2.0",
                             "description": "RETIRED: Build and run .NET Core 2.0 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet20",
+                            "tags": "hidden,builder,.net,dotnet,dotnetcore,rh-dotnet20",
                             "supports": "dotnet:2.0,dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
                             "sampleContextDir": "app",
@@ -178,7 +178,7 @@
                             "openshift.io/display-name": ".NET Core 2.0 Runtime",
                             "description": "RETIRED: Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "tags": "hidden,runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime",
                             "version": "2.0"
                         },

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -60,7 +60,7 @@
                             "openshift.io/display-name": ".NET Core 2.0",
                             "description": "RETIRED: Build and run .NET Core 2.0 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet20",
+                            "tags": "hidden,builder,.net,dotnet,dotnetcore,rh-dotnet20",
                             "supports":"dotnet:2.0,dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
                             "sampleContextDir": "app",
@@ -121,7 +121,7 @@
                             "openshift.io/display-name": ".NET Core 2.0 Runtime",
                             "description": "RETIRED: Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "tags": "hidden,runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports":"dotnet-runtime",
                             "version": "2.0"
                         },


### PR DESCRIPTION
This is done by adding the 'hidden' tag.