### PR TITLE
Fixed assemble script to restore packages only once

### DIFF
--- a/2.1/build/s2i/bin/assemble
+++ b/2.1/build/s2i/bin/assemble
@@ -193,7 +193,7 @@ if [ "$BUILD_TYPE" == "source" ]; then
       echo "---> Restoring test project ($TEST_PROJECT) dependencies..."
       dotnet restore "$TEST_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION
       echo "---> Running test project: $TEST_PROJECT..."
-      dotnet test "$TEST_PROJECT" -f "$DOTNET_FRAMEWORK" $VERBOSITY_OPTION
+      dotnet test "$TEST_PROJECT" -f "$DOTNET_FRAMEWORK" $VERBOSITY_OPTION --no-restore
   done
 
   # publish application


### PR DESCRIPTION
In the current assemble script the 'dotnet publish' does a restore in addition to the 'dotnet restore' command one line above it.
It caused me a lot of issues when I attempted to run a build on openshift for dotnet core 2.1.