### PR TITLE
2.2: runtime image: support building from pre-compiled applications

### DIFF
--- a/2.2/build/Dockerfile
+++ b/2.2/build/Dockerfile
@@ -6,11 +6,7 @@ ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/node_m
     STI_SCRIPTS_PATH=/usr/libexec/s2i
 
 LABEL io.k8s.description="Platform for building and running .NET Core 2.2 applications" \
-      io.k8s.display-name=".NET Core 2.2" \
-      io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
-      io.openshift.tags="builder,.net,dotnet,dotnetcore,rh-dotnet22" \
-      io.openshift.expose-services="8080:http" \
-      io.s2i.scripts-url=image:///usr/libexec/s2i
+      io.openshift.tags="builder,.net,dotnet,dotnetcore,rh-dotnet22"
 
 # Labels consumed by Red Hat build service
 LABEL name="dotnet/dotnet-22-centos7" \

--- a/2.2/build/Dockerfile.rhel7
+++ b/2.2/build/Dockerfile.rhel7
@@ -6,11 +6,7 @@ ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/node_m
     STI_SCRIPTS_PATH=/usr/libexec/s2i
 
 LABEL io.k8s.description="Platform for building and running .NET Core 2.2 applications" \
-      io.k8s.display-name=".NET Core 2.2" \
-      io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
-      io.openshift.tags="builder,.net,dotnet,dotnetcore,rh-dotnet22" \
-      io.openshift.expose-services="8080:http" \
-      io.s2i.scripts-url=image:///usr/libexec/s2i
+      io.openshift.tags="builder,.net,dotnet,dotnetcore,rh-dotnet22"
 
 # Labels consumed by Red Hat build service
 LABEL name="dotnet/dotnet-22-rhel7" \

--- a/2.2/build/README.md
+++ b/2.2/build/README.md
@@ -1,17 +1,17 @@
-.Net Docker image
+.NET Core SDK image
 =================
 
-This repository contains the source for building .Net applications
-as a reproducible Docker image using
+This repository contains the source for building .NET Core applications
+as a reproducible container image using
 [source-to-image](https://github.com/openshift/source-to-image).
-The resulting image can be run using [Docker](http://docker.io).
+The resulting image can be run using [docker](http://docker.io)/[podman](https://podman.io/).
 
 
 Usage
 ---------------------
 To build a simple [dotnet-sample-app](test/asp-net-hello-world) application
 using standalone [S2I](https://github.com/openshift/source-to-image) and then run the
-resulting image with [Docker](http://docker.io) execute:
+resulting image with `docker`/`podman` execute:
 
     ```
     $ sudo s2i build git://github.com/redhat-developer/s2i-dotnetcore --context-dir=2.2/test/asp-net-hello-world dotnet/dotnet-22-rhel7 dotnet-sample-app

--- a/2.2/build/test/run
+++ b/2.2/build/test/run
@@ -46,35 +46,6 @@ sdk_default_version=${sdk_versions[0]}
 sdk_latest_version=${sdk_versions[-1]}
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 
-s2i_image_tag() {
-  local app="$1"
-  echo "${IMAGE_NAME}-${app}"
-}
-
-s2i_build_output_log() {
-  local app="$1"
-  local tag="$2"
-  shift 2
-
-  docker_rmi ${tag}
-  s2i build --pull-policy=never -e DOTNET_SDK_VERSION=$sdk_version "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
-}
-
-s2i_build() {
-  local app="$1"
-  local tag=$(s2i_image_tag ${app})
-  shift 1
-
-  local output;
-  output=$(s2i_build_output_log ${app} ${tag} "$@")
-  if [ $? -ne 0 ]; then
-    error "$output"
-    echo "no-image"
-  else
-    echo "$tag"
-  fi
-}
-
 s2i_build_and_run() {
   local app="$1"
 

--- a/2.2/build/test/testcommon
+++ b/2.2/build/test/testcommon
@@ -194,3 +194,32 @@ container_url() {
     echo "http://$output:8080"
   fi
 }
+
+s2i_image_tag() {
+  local app="$1"
+  echo "${IMAGE_NAME}-${app}"
+}
+
+s2i_build_output_log() {
+  local app="$1"
+  local tag="$2"
+  shift 2
+
+  docker_rmi ${tag}
+  s2i build --pull-policy=never -e DOTNET_SDK_VERSION=$sdk_version "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
+}
+
+s2i_build() {
+  local app="$1"
+  local tag=$(s2i_image_tag ${app})
+  shift 1
+
+  local output;
+  output=$(s2i_build_output_log ${app} ${tag} "$@")
+  if [ $? -ne 0 ]; then
+    error "$output"
+    echo "no-image"
+  else
+    echo "$tag"
+  fi
+}

--- a/2.2/runtime/Dockerfile
+++ b/2.2/runtime/Dockerfile
@@ -17,7 +17,9 @@ ENV HOME=/opt/app-root \
 LABEL io.k8s.description="Platform for running .NET Core 2.2 applications" \
       io.k8s.display-name=".NET Core 2.2" \
       io.openshift.tags="runtime,.net,dotnet,dotnetcore,rh-dotnet22-runtime" \
-      io.openshift.expose-services="8080:http"
+      io.openshift.expose-services="8080:http" \
+      io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
+      io.s2i.scripts-url=image:///usr/libexec/s2i
 
 # Labels consumed by Red Hat build service
 LABEL name="dotnet/dotnet-22-runtime-centos7" \
@@ -25,6 +27,9 @@ LABEL name="dotnet/dotnet-22-runtime-centos7" \
       version="2.2" \
       release="1" \
       architecture="x86_64"
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
+COPY ./s2i/bin/ /usr/libexec/s2i
 
 # Don't download/extract docs for nuget packages
 ENV NUGET_XMLDOC_MODE=skip

--- a/2.2/runtime/Dockerfile.rhel7
+++ b/2.2/runtime/Dockerfile.rhel7
@@ -17,7 +17,9 @@ ENV HOME=/opt/app-root \
 LABEL io.k8s.description="Platform for running .NET Core 2.2 applications" \
       io.k8s.display-name=".NET Core 2.2" \
       io.openshift.tags="runtime,.net,dotnet,dotnetcore,rh-dotnet22-runtime" \
-      io.openshift.expose-services="8080:http"
+      io.openshift.expose-services="8080:http" \
+      io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
+      io.s2i.scripts-url=image:///usr/libexec/s2i
 
 # Labels consumed by Red Hat build service
 LABEL name="dotnet/dotnet-22-runtime-rhel7" \
@@ -25,6 +27,9 @@ LABEL name="dotnet/dotnet-22-runtime-rhel7" \
       version="2.2" \
       release="1" \
       architecture="x86_64"
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
+COPY ./s2i/bin/ /usr/libexec/s2i
 
 # Don't download/extract docs for nuget packages
 ENV NUGET_XMLDOC_MODE=skip

--- a/2.2/runtime/README.md
+++ b/2.2/runtime/README.md
@@ -1,31 +1,37 @@
-.Net Docker image
+.NET Core Runtime image
 =================
 
-This repository contains the source for building a docker image that
-can be used as a base in which to run already built .Net applications.
+This repository contains the source for building a container image that
+can be used as a base in which to run already built .NET Core applications.
 
-The image can be run using [Docker](http://docker.io).
+The container image can be used as a base image using [docker](http://docker.io)/[podman](https://podman.io/).
+Or you can build an application image using [s2i](https://github.com/openshift/source-to-image/releases).
+The image can be run using `docker`/`podman`.
 
 Usage
 ---------------------
 The distributale binaries of an application should be copied to this image and
 a new docker image should be created using this image as the base.
 
-For example to create a Docker image for [s2i-dotnetcore-ex](https://github.com/redhat-developer/s2i-dotnetcore-ex) 
+For example to create an image for [s2i-dotnetcore-ex](https://github.com/redhat-developer/s2i-dotnetcore-ex)
 
 Publish the application:
 ```
 $ git clone -b dotnetcore-2.2 https://github.com/redhat-developer/s2i-dotnetcore-ex.git
 $ cd s2i-dotnetcore-ex/app
-$ dotnet restore -r rhel.7-x64
-$ dotnet publish -f netcoreapp2.2 -c Release -r rhel.7-x64 --self-contained false
+$ dotnet publish -c Release /p:MicrosoftNETPlatformLibrary=Microsoft.NETCore.App
 ```
 
-Create the Docker image:
+To create an image using `s2i`:
+```
+$ s2i build bin/Release/netcoreapp2.2/publish dotnet/dotnet-22-runtime-rhel7 s2i-dotnetcore-ex
+```
+
+To create an image using `docker`/`podman`:
 ```
 $ cat > Dockerfile <<EOF
 FROM dotnet/dotnet-22-runtime-rhel7
-ADD bin/Release/netcoreapp2.2/rhel.7-x64/publish/. .
+ADD bin/Release/netcoreapp2.2/publish/. .
 CMD [ "dotnet", "app.dll" ]
 EOF
 $ docker build -t s2i-dotnetcore-ex .
@@ -36,7 +42,7 @@ Start a container:
 $ docker run --rm -p 8080:8080 s2i-dotnetcore-ex
 ```
 
-Visit the web application that is running in the docker container with a browser at [http://localhost:8080].
+Visit the web application that is running in the container with a browser at [http://localhost:8080].
 
 Repository organization
 ------------------------

--- a/2.2/runtime/default-cmd.sh
+++ b/2.2/runtime/default-cmd.sh
@@ -4,4 +4,6 @@ cat <<EOF
 This is a runtime image for .NET Core ${DOTNET_CORE_VERSION}.
 
 See the documentation at https://github.com/redhat-developer/s2i-dotnetcore/tree/master/${DOTNET_CORE_VERSION}/runtime.
+
+This image can also be used as an S2I image for pre-compiled applications. Run 's2i usage <image>' for more information.
 EOF

--- a/2.2/runtime/s2i/bin/assemble
+++ b/2.2/runtime/s2i/bin/assemble
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+# Include filenames beginning with a '.' when installing the application.
+shopt -s dotglob
+
+echo "---> Installing application..."
+if [ -d /tmp/src ]; then
+  mv /tmp/src/* "$DOTNET_APP_PATH"
+fi
+cd "$DOTNET_APP_PATH"
+
+# determine DOTNET_STARTUP_ASSEMBLY
+if [ -n "${DOTNET_STARTUP_ASSEMBLY}" ]; then
+  if [ ! -f "${DOTNET_STARTUP_ASSEMBLY}" ]; then
+    echo "error: application does not contain DOTNET_STARTUP_ASSEMBLY: ${DOTNET_STARTUP_ASSEMBLY}"
+    exit 1
+  fi
+else
+  # determine entrypoint assembly based on *.runtimeconfig.json files
+  RUNTIMECFGFILES=(`find -maxdepth 1 -name "*.runtimeconfig.json"`)
+  if [ ${#RUNTIMECFGFILES[@]} -eq 1 ]; then
+    DOTNET_STARTUP_ASSEMBLY="${RUNTIMECFGFILES[0]: : -19}.dll"
+  elif [ ${#RUNTIMECFGFILES[@]} -gt 1 ]; then
+    echo "error: application contains multiple startup assemblies"
+    echo "You can select the startup assembly by specifying DOTNET_STARTUP_ASSEMBLY."
+    exit 1
+  else
+    echo "error: cannot find startup assembly"
+    echo "This image does not contain an sdk and can only be used with pre-built applications."
+    echo "If your startup assembly is not in the root folder, you can specify it using DOTNET_STARTUP_ASSEMBLY."
+    echo "If you want to build an application, you must use the sdk image instead."
+    exit 1
+  fi
+fi
+
+echo "Using pre-built application with entrypoint assembly: ${DOTNET_STARTUP_ASSEMBLY}"
+
+APP_DLL_NAME="${DOTNET_STARTUP_ASSEMBLY}"
+# check if the assembly used by the script exists
+if [ ! -f "$DOTNET_APP_PATH/${APP_DLL_NAME}" ]; then
+  echo "error: application does not contain entrypoint assembly: ${APP_DLL_NAME}"
+  exit 1
+fi
+
+# Create run script in publish folder
+cat << EOF >"$DOTNET_APP_PATH/$DOTNET_DEFAULT_CMD"
+#!/bin/bash
+
+exec dotnet ${APP_DLL_NAME} \$@
+EOF
+chmod +x "$DOTNET_APP_PATH/$DOTNET_DEFAULT_CMD"
+
+# fix permissions
+fix-permissions /opt/app-root

--- a/2.2/runtime/s2i/bin/run
+++ b/2.2/runtime/s2i/bin/run
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+cd $DOTNET_APP_PATH
+
+echo "---> Running application ..."
+exec "./$DOTNET_DEFAULT_CMD"

--- a/2.2/runtime/s2i/bin/usage
+++ b/2.2/runtime/s2i/bin/usage
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
+NAMESPACE=dotnet
+
+cat <<EOF
+This is a S2I .Net core ${DISTRO} image for pre-compiled applications:
+To use it, install S2I: https://github.com/openshift/source-to-image
+
+To build an image from a published application at 'bin/Release/netcoreapp2.2/publish':
+
+sudo s2i build bin/Release/netcoreapp2.2/publish ${NAMESPACE}/dotnet-22-runtime-${DISTRO}7 dotnet-sample-app
+
+You can then run the resulting image via:
+sudo docker run -p 8080:8080 dotnet-sample-app
+EOF

--- a/2.2/runtime/test/run
+++ b/2.2/runtime/test/run
@@ -100,18 +100,8 @@ test_port() {
   assert_equal $(docker_get_env $IMAGE_NAME ASPNETCORE_URLS) "http://*:8080"
 }
 
-test_aspnet() {
-  test_start
-
-  pushd ${test_dir}/aspnet-hello-world >/dev/null
-
-  # create image
-  cat >Dockerfile <<EOF
-FROM ${IMAGE_NAME}
-ADD app.tar.gz .
-CMD [ "dotnet", "aspnet-hello-world.dll" ]
-EOF
-  local image=$(docker_build .)
+verify_aspnet_image_works() {
+  local image=$1
 
   # start container
   local container=$(docker_run_d ${image})
@@ -126,8 +116,53 @@ EOF
 
   # assert
   assert_equal "${response}" "Hello World!"
+}
+
+test_aspnet() {
+  test_start
+
+  pushd ${test_dir}/aspnet-hello-world >/dev/null
+
+  # create image
+  cat >Dockerfile <<EOF
+FROM ${IMAGE_NAME}
+ADD app.tar.gz .
+CMD [ "dotnet", "aspnet-hello-world.dll" ]
+EOF
+  local image=$(docker_build .)
+
+  verify_aspnet_image_works $image
 
   popd >/dev/null
+}
+
+test_s2i_usage() {
+  test_start
+
+  local output=$(s2i usage ${IMAGE_NAME} 2>&1)
+
+  # s2i usage describes this is for pre-compiled applications
+  assert_contains "$output" "image for pre-compiled application"
+}
+
+test_s2i_build() {
+  test_start
+
+  local app=precompiled
+
+  # extract the pre-compiled application from the aspnet test
+  rm -rf ${test_dir}/${app}
+  mkdir ${test_dir}/${app} && tar -C ${test_dir}/${app} -xf ${test_dir}/aspnet-hello-world/app.tar.gz
+  # Verify the entry point assembly is detected and ran
+  local image=$(s2i_build $app)
+  verify_aspnet_image_works ${image}
+
+  # extract the pre-compiled application from the aspnet test in a nested folder
+  rm -rf ${test_dir}/${app}
+  mkdir -p ${test_dir}/${app}/nested && tar -C ${test_dir}/${app}/nested -xf ${test_dir}/aspnet-hello-world/app.tar.gz
+  # Verify the entry point assembly is detected and ran using DOTNET_STARTUP_ASSEMBLY.
+  image=$(s2i_build $app -e DOTNET_STARTUP_ASSEMBLY=nested/aspnet-hello-world.dll)
+  verify_aspnet_image_works ${image}
 }
 
 info "Testing ${IMAGE_NAME}"
@@ -140,6 +175,8 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_user
   test_port
   test_aspnet
+  test_s2i_usage
+  test_s2i_build
 fi
 
 info "All tests finished successfully."

--- a/2.2/runtime/test/testcommon
+++ b/2.2/runtime/test/testcommon
@@ -194,3 +194,32 @@ container_url() {
     echo "http://$output:8080"
   fi
 }
+
+s2i_image_tag() {
+  local app="$1"
+  echo "${IMAGE_NAME}-${app}"
+}
+
+s2i_build_output_log() {
+  local app="$1"
+  local tag="$2"
+  shift 2
+
+  docker_rmi ${tag}
+  s2i build --pull-policy=never -e DOTNET_SDK_VERSION=$sdk_version "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
+}
+
+s2i_build() {
+  local app="$1"
+  local tag=$(s2i_image_tag ${app})
+  shift 1
+
+  local output;
+  output=$(s2i_build_output_log ${app} ${tag} "$@")
+  if [ $? -ne 0 ]; then
+    error "$output"
+    echo "no-image"
+  else
+    echo "$tag"
+  fi
+}


### PR DESCRIPTION
Port https://github.com/redhat-developer/s2i-dotnetcore/pull/241 to 2.2