### PR TITLE
Fix DOTNET_SSL_DIRS in runtime image

### DIFF
--- a/2.1/runtime/contrib/etc/trust_ssl_dirs
+++ b/2.1/runtime/contrib/etc/trust_ssl_dirs
@@ -50,7 +50,7 @@ if [ -n "$DOTNET_SSL_DIRS" ]; then
   popd >/dev/null
   # Remove temporary src folder.
   if [ "$_REMOVE_SRC_DIR" = true ] ; then
-    rm /opt/app-root/src
+    rmdir /opt/app-root/src
   fi
 
   # Use the certificate folder.

--- a/2.2/runtime/contrib/etc/trust_ssl_dirs
+++ b/2.2/runtime/contrib/etc/trust_ssl_dirs
@@ -50,7 +50,7 @@ if [ -n "$DOTNET_SSL_DIRS" ]; then
   popd >/dev/null
   # Remove temporary src folder.
   if [ "$_REMOVE_SRC_DIR" = true ] ; then
-    rm /opt/app-root/src
+    rmdir /opt/app-root/src
   fi
 
   # Use the certificate folder.


### PR DESCRIPTION
For DOTNET_SSL_DIRS in the runtime image a temporary 'src' directory
is created. This folder was removed with 'rm' instead of 'rmdir'
which fails for directories.

Fixes https://github.com/redhat-developer/s2i-dotnetcore/issues/249

CC @nordseth 