### PR TITLE
2.1, 2.2: Introduce DOTNET_DATA_DIR

### DIFF
--- a/2.1/runtime/Dockerfile
+++ b/2.1/runtime/Dockerfile
@@ -7,6 +7,7 @@ EXPOSE 8080
 ENV HOME=/opt/app-root \
     PATH=/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     DOTNET_APP_PATH=/opt/app-root/app \
+    DOTNET_DATA_PATH=/opt/app-root/data \
     DOTNET_DEFAULT_CMD=default-cmd.sh \
     DOTNET_CORE_VERSION=2.1 \
     DOTNET_FRAMEWORK=netcoreapp2.1 \
@@ -67,7 +68,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/etc/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/etc/scl_enable"
 
 # Add default user
-RUN mkdir -p ${DOTNET_APP_PATH} && \
+RUN mkdir -p ${DOTNET_APP_PATH} ${DOTNET_DATA_PATH} && \
     useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
       -c "Default Application User" default
 

--- a/2.1/runtime/Dockerfile.rhel7
+++ b/2.1/runtime/Dockerfile.rhel7
@@ -7,6 +7,7 @@ EXPOSE 8080
 ENV HOME=/opt/app-root \
     PATH=/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     DOTNET_APP_PATH=/opt/app-root/app \
+    DOTNET_DATA_PATH=/opt/app-root/data \
     DOTNET_DEFAULT_CMD=default-cmd.sh \
     DOTNET_CORE_VERSION=2.1 \
     DOTNET_FRAMEWORK=netcoreapp2.1 \
@@ -68,7 +69,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/etc/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/etc/scl_enable"
 
 # Add default user
-RUN mkdir -p ${DOTNET_APP_PATH} && \
+RUN mkdir -p ${DOTNET_APP_PATH} ${DOTNET_DATA_PATH} && \
     useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
       -c "Default Application User" default
 

--- a/2.1/runtime/README.md
+++ b/2.1/runtime/README.md
@@ -77,9 +77,10 @@ They must not to be overridden.
     This variable is set to `http://*:8080` to configure ASP.NET Core to use the
     port exposed by the image.
 
-* **DOTNET_APP_PATH,DOTNET_DEFAULT_CMD**
+* **DOTNET_APP_PATH,DOTNET_DEFAULT_CMD,DOTNET_DATA_PATH**
 
-    These variables contain the working directory (`/opt/app-root/app`) and default CMD of the runtime image (`default-cmd.sh`).
+    These variables contain the working directory (`/opt/app-root/app`), the default CMD of the runtime image (`default-cmd.sh`)
+    and an empty folder you can use to store your application data (`/opt/app-root/data`) and make persistent with a volume mount.
 
 * **DOTNET_SSL_DIRS**
 

--- a/2.1/runtime/test/run
+++ b/2.1/runtime/test/run
@@ -46,6 +46,8 @@ test_envvars() {
   assert_equal $(docker_get_env $IMAGE_NAME DOTNET_APP_PATH) "/opt/app-root/app"
   # DOTNET_DEFAULT_CMD
   assert_equal $(docker_get_env $IMAGE_NAME DOTNET_DEFAULT_CMD) "default-cmd.sh"
+  # DOTNET_DATA_PATH
+  assert_equal $(docker_get_env $IMAGE_NAME DOTNET_DATA_PATH) "/opt/app-root/data"
 
   # DOTNET_CORE_VERSION
   assert_equal $(docker_get_env $IMAGE_NAME DOTNET_CORE_VERSION) "${dotnet_version_series}"
@@ -77,6 +79,13 @@ test_default_cmd() {
   assert_contains $(docker_run $IMAGE_NAME) "This is a runtime image for .NET Core"
 }
 
+test_data_folder() {
+  test_start
+
+  # check a writable data folder is available
+  assert_equal $(docker_run $IMAGE_NAME "stat -c %a /opt/app-root/data") "777"
+}
+
 test_user() {
   test_start
 
@@ -89,6 +98,9 @@ test_user() {
 
   # ensure the passwd file used by nss_wrapper can be overwritten
   assert_equal $(docker_run_as $IMAGE_NAME 100001 "stat -c %a /opt/app-root/etc/passwd") "666"
+
+  # check a writable data folder is available
+  assert_equal $(docker_run_as $IMAGE_NAME 100001 "stat -c %a /opt/app-root/data") "777"
 }
 
 test_port() {
@@ -171,6 +183,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_dotnet
   test_envvars
   test_default_cmd
+  test_data_folder
   test_debuggable
   test_user
   test_port

--- a/2.2/runtime/Dockerfile
+++ b/2.2/runtime/Dockerfile
@@ -7,6 +7,7 @@ EXPOSE 8080
 ENV HOME=/opt/app-root \
     PATH=/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     DOTNET_APP_PATH=/opt/app-root/app \
+    DOTNET_DATA_PATH=/opt/app-root/data \
     DOTNET_DEFAULT_CMD=default-cmd.sh \
     DOTNET_CORE_VERSION=2.2 \
     DOTNET_FRAMEWORK=netcoreapp2.2 \

--- a/2.2/runtime/Dockerfile.rhel7
+++ b/2.2/runtime/Dockerfile.rhel7
@@ -7,6 +7,7 @@ EXPOSE 8080
 ENV HOME=/opt/app-root \
     PATH=/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     DOTNET_APP_PATH=/opt/app-root/app \
+    DOTNET_DATA_PATH=/opt/app-root/data \
     DOTNET_DEFAULT_CMD=default-cmd.sh \
     DOTNET_CORE_VERSION=2.2 \
     DOTNET_FRAMEWORK=netcoreapp2.2 \
@@ -68,7 +69,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/etc/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/etc/scl_enable"
 
 # Add default user
-RUN mkdir -p ${DOTNET_APP_PATH} && \
+RUN mkdir -p ${DOTNET_APP_PATH} ${DOTNET_DATA_PATH} && \
     useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
       -c "Default Application User" default
 

--- a/2.2/runtime/README.md
+++ b/2.2/runtime/README.md
@@ -78,9 +78,10 @@ They must not to be overridden.
     This variable is set to `http://*:8080` to configure ASP.NET Core to use the
     port exposed by the image.
 
-* **DOTNET_APP_PATH,DOTNET_DEFAULT_CMD**
+* **DOTNET_APP_PATH,DOTNET_DEFAULT_CMD,DOTNET_DATA_PATH**
 
-    These variables contain the working directory (`/opt/app-root/app`) and default CMD of the runtime image (`default-cmd.sh`).
+    These variables contain the working directory (`/opt/app-root/app`), the default CMD of the runtime image (`default-cmd.sh`)
+    and an empty folder you can use to store your application data (`/opt/app-root/data`) and make persistent with a volume mount.
 
 * **DOTNET_SSL_DIRS**
 

--- a/2.2/runtime/test/run
+++ b/2.2/runtime/test/run
@@ -46,6 +46,8 @@ test_envvars() {
   assert_equal $(docker_get_env $IMAGE_NAME DOTNET_APP_PATH) "/opt/app-root/app"
   # DOTNET_DEFAULT_CMD
   assert_equal $(docker_get_env $IMAGE_NAME DOTNET_DEFAULT_CMD) "default-cmd.sh"
+  # DOTNET_DATA_PATH
+  assert_equal $(docker_get_env $IMAGE_NAME DOTNET_DATA_PATH) "/opt/app-root/data"
 
   # DOTNET_CORE_VERSION
   assert_equal $(docker_get_env $IMAGE_NAME DOTNET_CORE_VERSION) "${dotnet_version_series}"
@@ -75,6 +77,13 @@ test_default_cmd() {
   test_start
 
   assert_contains $(docker_run $IMAGE_NAME) "This is a runtime image for .NET Core"
+}
+
+test_data_folder() {
+  test_start
+
+  # check a writable data folder is available
+  assert_equal $(docker_run $IMAGE_NAME "stat -c %a /opt/app-root/data") "777"
 }
 
 test_user() {
@@ -171,6 +180,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_dotnet
   test_envvars
   test_default_cmd
+  test_data_folder
   test_debuggable
   test_user
   test_port


### PR DESCRIPTION
Our images don't have an empty folder that is writable by the user and
could be used for persistent data.

This makes available a preferred location for such data.

The environment variable may be picked up by the application and used
as a location to store the data.

When doing a volume mount for persistance, the container platform creates
the folder in the container when it doesn't exist. By having the folder
already available in the image, we ensure it also exists when the image
is used in a non-persistent way.