### PR TITLE
2.1, 2.2: add support for incremental builds

### DIFF
--- a/2.1/build/Dockerfile
+++ b/2.1/build/Dockerfile
@@ -51,8 +51,8 @@ ENV DOTNET_SDK_BASE_VERSION=2.1.300 \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version
-    LatestPatchVersionForAspNetCoreApp2_1=2.1.6 \
-    LatestPatchVersionForAspNetCoreAll2_1=2.1.6
+    LatestPatchVersionForAspNetCoreApp2_1=2.1.7 \
+    LatestPatchVersionForAspNetCoreAll2_1=2.1.7
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.1/build/README.md
+++ b/2.1/build/README.md
@@ -26,6 +26,18 @@ HTTP:
 $ curl http://127.0.0.1:8080
 ```
 
+Incremental builds
+------------------
+
+The s2i image supports incremental builds. For incremental builds, NuGet packages
+will be re-used. To keep NuGet packages so they can be reused, you must set
+`DOTNET_RM_NUGET` to `false`.
+
+Note that the s2i builder does not remove unused NuGet packages on incremental
+builds. Over time the incremental application image may contain unused packages.
+To clean up those packages, you should occasionally perform a non-incremental build
+or perform a build with `DOTNET_RM_NUGET` set to `true`.
+
 Repository organization
 ------------------------
 
@@ -154,6 +166,11 @@ a `.s2i/environment` file inside your source code repository.
 * **DOTNET_RM_SRC**
 
     When set to `true`, the source code will not be included in the image. Defaults to ``.
+
+* **DOTNET_RM_NUGET**
+
+    When set to `true`, the NuGet packages will not be included in the image.
+    Set this to `false` for incremental builds. Defaults to `true`.
 
 * **NPM_MIRROR**
 

--- a/2.1/build/s2i/bin/assemble
+++ b/2.1/build/s2i/bin/assemble
@@ -12,6 +12,11 @@ else
   VERBOSITY_OPTION=""
 fi
 
+if [ -d /tmp/artifacts -a "$(ls -A /tmp/artifacts)" ]; then
+  echo "---> Installing artifacts from incremental build..."
+  mv /tmp/artifacts/* "${HOME}"
+fi
+
 echo "---> Installing application source..."
 if [ -d /tmp/src ]; then
   mv /tmp/src/* ./
@@ -228,7 +233,11 @@ if [ "$DOTNET_PACK" == "true" ]; then
 fi
 
 # cleanup NuGet artifacts
-rm -rf ~/{.local,.nuget}
+rm -rf /opt/app-root/.local
+DOTNET_RM_NUGET="${DOTNET_RM_NUGET:-true}"
+if [ "$DOTNET_RM_NUGET" == "true" ]; then
+  rm -rf /opt/app-root/.nuget
+fi
 
 if [ "$DOTNET_RM_SRC" == "true" ]; then
   echo "---> Removing sources..."

--- a/2.1/build/s2i/bin/assemble
+++ b/2.1/build/s2i/bin/assemble
@@ -14,7 +14,7 @@ fi
 
 if [ -d /tmp/artifacts -a "$(ls -A /tmp/artifacts)" ]; then
   echo "---> Installing artifacts from incremental build..."
-  mv /tmp/artifacts/* "${HOME}"
+  mv /tmp/artifacts/* /opt/app-root
 fi
 
 echo "---> Installing application source..."
@@ -130,7 +130,7 @@ EOF
       npm config set registry $NPM_MIRROR
     fi
 
-    pushd $HOME
+    pushd /opt/app-root
     npm install ${DOTNET_NPM_TOOLS}
     popd
   fi

--- a/2.1/build/s2i/bin/save-artifacts
+++ b/2.1/build/s2i/bin/save-artifacts
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+if [ -d ~/.nuget ]; then
+  cd
+  tar cf - .nuget
+fi

--- a/2.1/build/s2i/bin/save-artifacts
+++ b/2.1/build/s2i/bin/save-artifacts
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ -d ~/.nuget ]; then
-  cd
+if [ -d /opt/app-root/.nuget ]; then
+  cd /opt/app-root
   tar cf - .nuget
 fi

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -619,6 +619,61 @@ test_binary()
   assert_contains "${output}" "Hello World2!"
 }
 
+test_incremental()
+{
+  test_start
+
+  # asp-net-hello-world is an ASP.NET Core application
+  local app=asp-net-hello-world
+
+  # perform a first build, with the incremental flag
+  local image=$(s2i_image_tag ${app})
+  docker_rmi ${image}
+  local s2i_build=$(s2i_build_output_log ${app} ${image} --incremental -e DOTNET_RM_NUGET=false)
+  # verify packages are installed
+  assert_contains "${s2i_build}" "Installing System"
+  # verify the build completes succesfully
+  assert_contains "${s2i_build}" "Build completed successfully"
+
+  # perform a second build, with the incremental flag
+  s2i_build=$(s2i_build_output_log ${app} ${image} --incremental -e DOTNET_RM_NUGET=false)
+  # verify incremental build packages are installed
+  assert_contains "${s2i_build}" "Installing artifacts from incremental build"
+  # verify NO other packages are installed
+  assert_not_contains "${s2i_build}" "Installing System"
+  # verify the build completes succesfully
+  assert_contains "${s2i_build}" "Build completed successfully"
+
+  # cleanup
+  docker_rmi ${image}
+}
+
+test_incremental_without_packages()
+{
+  test_start
+
+  # asp-net-hello-world is an ASP.NET Core application
+  local app=asp-net-hello-world
+
+  # perform a first build without keeping packages
+  local image=$(s2i_image_tag ${app})
+  local s2i_build=$(s2i_build_output_log ${app} ${image} -e DOTNET_RM_NUGET=true)
+  # verify packages are installed
+  assert_contains "${s2i_build}" "Installing System"
+  # verify the build completes succesfully
+  assert_contains "${s2i_build}" "Build completed successfully"
+
+  # perform a second build, with the incremental flag
+  s2i_build=$(s2i_build_output_log ${app} ${image} --incremental)
+  # verify NO incremental packages are installed
+  assert_not_contains "${s2i_build}" "Installing artifacts from incremental build"
+  # verify the build completes succesfully
+  assert_contains "${s2i_build}" "Build completed successfully"
+
+  # cleanup
+  docker_rmi ${image}
+}
+
 info "Testing ${IMAGE_NAME}"
 
 if [ ${OPENSHIFT_ONLY} != true ]; then
@@ -642,6 +697,8 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
     test_user
     test_certificates
     test_binary
+    test_incremental
+    test_incremental_without_packages
   done
   # when unset, default to the lowest sdk version
   info "default sdk(${sdk_default_version}):"

--- a/2.1/build/test/testcommon
+++ b/2.1/build/test/testcommon
@@ -29,6 +29,16 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local actual="$1"
+  local unexpected="$2"
+
+  if echo "${actual}" | grep -q "${unexpected}"; then
+    error "'${actual}' contains '${unexpected}'"
+    exit 1
+  fi
+}
+
 assert_equal() {
   local actual="$1"
   local expected="$2"
@@ -205,7 +215,9 @@ s2i_build_output_log() {
   local tag="$2"
   shift 2
 
-  docker_rmi ${tag}
+  if [[ "$@" != *"--incremental"* ]]; then
+    docker_rmi ${tag}
+  fi
   s2i build --pull-policy=never -e DOTNET_SDK_VERSION=$sdk_version "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
 }
 

--- a/2.1/runtime/test/testcommon
+++ b/2.1/runtime/test/testcommon
@@ -29,6 +29,16 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local actual="$1"
+  local unexpected="$2"
+
+  if echo "${actual}" | grep -q "${unexpected}"; then
+    error "'${actual}' contains '${unexpected}'"
+    exit 1
+  fi
+}
+
 assert_equal() {
   local actual="$1"
   local expected="$2"
@@ -205,7 +215,9 @@ s2i_build_output_log() {
   local tag="$2"
   shift 2
 
-  docker_rmi ${tag}
+  if [[ "$@" != *"--incremental"* ]]; then
+    docker_rmi ${tag}
+  fi
   s2i build --pull-policy=never -e DOTNET_SDK_VERSION=$sdk_version "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
 }
 

--- a/2.2/build/Dockerfile
+++ b/2.2/build/Dockerfile
@@ -51,8 +51,8 @@ ENV DOTNET_SDK_BASE_VERSION=2.2.100 \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version
-    LatestPatchVersionForAspNetCoreApp2_2=2.2.0 \
-    LatestPatchVersionForAspNetCoreAll2_2=2.2.0
+    LatestPatchVersionForAspNetCoreApp2_2=2.2.1 \
+    LatestPatchVersionForAspNetCoreAll2_2=2.2.1
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.2/build/README.md
+++ b/2.2/build/README.md
@@ -26,6 +26,18 @@ HTTP:
 $ curl http://127.0.0.1:8080
 ```
 
+Incremental builds
+------------------
+
+The s2i image supports incremental builds. For incremental builds, NuGet packages
+will be re-used. To keep NuGet packages so they can be reused, you must set
+`DOTNET_RM_NUGET` to `false`.
+
+Note that the s2i builder does not remove unused NuGet packages on incremental
+builds. Over time the incremental application image may contain unused packages.
+To clean up those packages, you should occasionally perform a non-incremental build
+or perform a build with `DOTNET_RM_NUGET` set to `true`.
+
 Repository organization
 ------------------------
 
@@ -154,6 +166,11 @@ a `.s2i/environment` file inside your source code repository.
 * **DOTNET_RM_SRC**
 
     When set to `true`, the source code will not be included in the image. Defaults to ``.
+
+* **DOTNET_RM_NUGET**
+
+    When set to `true`, the NuGet packages will not be included in the image.
+    Set this to `false` for incremental builds. Defaults to `true`.
 
 * **NPM_MIRROR**
 

--- a/2.2/build/s2i/bin/assemble
+++ b/2.2/build/s2i/bin/assemble
@@ -12,6 +12,11 @@ else
   VERBOSITY_OPTION=""
 fi
 
+if [ -d /tmp/artifacts -a "$(ls -A /tmp/artifacts)" ]; then
+  echo "---> Installing artifacts from incremental build..."
+  mv /tmp/artifacts/* "${HOME}"
+fi
+
 echo "---> Installing application source..."
 if [ -d /tmp/src ]; then
   mv /tmp/src/* ./
@@ -228,7 +233,11 @@ if [ "$DOTNET_PACK" == "true" ]; then
 fi
 
 # cleanup NuGet artifacts
-rm -rf ~/{.local,.nuget}
+rm -rf /opt/app-root/.local
+DOTNET_RM_NUGET="${DOTNET_RM_NUGET:-true}"
+if [ "$DOTNET_RM_NUGET" == "true" ]; then
+  rm -rf /opt/app-root/.nuget
+fi
 
 if [ "$DOTNET_RM_SRC" == "true" ]; then
   echo "---> Removing sources..."

--- a/2.2/build/s2i/bin/assemble
+++ b/2.2/build/s2i/bin/assemble
@@ -14,7 +14,7 @@ fi
 
 if [ -d /tmp/artifacts -a "$(ls -A /tmp/artifacts)" ]; then
   echo "---> Installing artifacts from incremental build..."
-  mv /tmp/artifacts/* "${HOME}"
+  mv /tmp/artifacts/* /opt/app-root
 fi
 
 echo "---> Installing application source..."
@@ -130,7 +130,7 @@ EOF
       npm config set registry $NPM_MIRROR
     fi
 
-    pushd $HOME
+    pushd /opt/app-root
     npm install ${DOTNET_NPM_TOOLS}
     popd
   fi

--- a/2.2/build/s2i/bin/save-artifacts
+++ b/2.2/build/s2i/bin/save-artifacts
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+if [ -d ~/.nuget ]; then
+  cd
+  tar cf - .nuget
+fi

--- a/2.2/build/s2i/bin/save-artifacts
+++ b/2.2/build/s2i/bin/save-artifacts
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ -d ~/.nuget ]; then
-  cd
+if [ -d /opt/app-root/.nuget ]; then
+  cd /opt/app-root
   tar cf - .nuget
 fi

--- a/2.2/build/test/run
+++ b/2.2/build/test/run
@@ -621,6 +621,61 @@ test_binary()
   assert_contains "${output}" "Hello World2!"
 }
 
+test_incremental()
+{
+  test_start
+
+  # asp-net-hello-world is an ASP.NET Core application
+  local app=asp-net-hello-world
+
+  # perform a first build, with the incremental flag
+  local image=$(s2i_image_tag ${app})
+  docker_rmi ${image}
+  local s2i_build=$(s2i_build_output_log ${app} ${image} --incremental -e DOTNET_RM_NUGET=false)
+  # verify packages are installed
+  assert_contains "${s2i_build}" "Installing System"
+  # verify the build completes succesfully
+  assert_contains "${s2i_build}" "Build completed successfully"
+
+  # perform a second build, with the incremental flag
+  s2i_build=$(s2i_build_output_log ${app} ${image} --incremental -e DOTNET_RM_NUGET=false)
+  # verify incremental build packages are installed
+  assert_contains "${s2i_build}" "Installing artifacts from incremental build"
+  # verify NO other packages are installed
+  assert_not_contains "${s2i_build}" "Installing System"
+  # verify the build completes succesfully
+  assert_contains "${s2i_build}" "Build completed successfully"
+
+  # cleanup
+  docker_rmi ${image}
+}
+
+test_incremental_without_packages()
+{
+  test_start
+
+  # asp-net-hello-world is an ASP.NET Core application
+  local app=asp-net-hello-world
+
+  # perform a first build without keeping packages
+  local image=$(s2i_image_tag ${app})
+  local s2i_build=$(s2i_build_output_log ${app} ${image} -e DOTNET_RM_NUGET=true)
+  # verify packages are installed
+  assert_contains "${s2i_build}" "Installing System"
+  # verify the build completes succesfully
+  assert_contains "${s2i_build}" "Build completed successfully"
+
+  # perform a second build, with the incremental flag
+  s2i_build=$(s2i_build_output_log ${app} ${image} --incremental)
+  # verify NO incremental packages are installed
+  assert_not_contains "${s2i_build}" "Installing artifacts from incremental build"
+  # verify the build completes succesfully
+  assert_contains "${s2i_build}" "Build completed successfully"
+
+  # cleanup
+  docker_rmi ${image}
+}
+
 info "Testing ${IMAGE_NAME}"
 
 if [ ${OPENSHIFT_ONLY} != true ]; then
@@ -644,6 +699,8 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
     test_user
     test_certificates
     test_binary
+    test_incremental
+    test_incremental_without_packages
   done
   # when unset, default to the lowest sdk version
   info "default sdk(${sdk_default_version}):"

--- a/2.2/build/test/testcommon
+++ b/2.2/build/test/testcommon
@@ -29,6 +29,16 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local actual="$1"
+  local unexpected="$2"
+
+  if echo "${actual}" | grep -q "${unexpected}"; then
+    error "'${actual}' contains '${unexpected}'"
+    exit 1
+  fi
+}
+
 assert_equal() {
   local actual="$1"
   local expected="$2"
@@ -205,7 +215,9 @@ s2i_build_output_log() {
   local tag="$2"
   shift 2
 
-  docker_rmi ${tag}
+  if [[ "$@" != *"--incremental"* ]]; then
+    docker_rmi ${tag}
+  fi
   s2i build --pull-policy=never -e DOTNET_SDK_VERSION=$sdk_version "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
 }
 

--- a/2.2/runtime/test/testcommon
+++ b/2.2/runtime/test/testcommon
@@ -29,6 +29,16 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local actual="$1"
+  local unexpected="$2"
+
+  if echo "${actual}" | grep -q "${unexpected}"; then
+    error "'${actual}' contains '${unexpected}'"
+    exit 1
+  fi
+}
+
 assert_equal() {
   local actual="$1"
   local expected="$2"
@@ -205,7 +215,9 @@ s2i_build_output_log() {
   local tag="$2"
   shift 2
 
-  docker_rmi ${tag}
+  if [[ "$@" != *"--incremental"* ]]; then
+    docker_rmi ${tag}
+  fi
   s2i build --pull-policy=never -e DOTNET_SDK_VERSION=$sdk_version "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
 }
 


### PR DESCRIPTION
For incremental builds, we save and restore the NuGet packages.

The user needs to set `DOTNET_RM_NUGET` to `false` in order to keep the NuGet
packages, so they can be re-used.

Note that the builder does not remove unused NuGet packages on incremental
builds. Over time the incremental application image may contain unused packages.
To clean up those packages, the user should occasionally perform a
non-incremental build or perform a build with `DOTNET_RM_NUGET` set to `true`.