### PR TITLE
Update centos files for the newly available RPMs.

### DIFF
--- a/2.1/build/Dockerfile
+++ b/2.1/build/Dockerfile
@@ -26,7 +26,7 @@ USER 0
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
-    INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1 rsync" && \
+    INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1.3xx rh-dotnet21-dotnet-sdk-2.1 rsync" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -35,7 +35,9 @@ aspnet_latest_app_version=2.1.8
 aspnet_latest_all_version=2.1.8
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 # sdk versions supported on CentOS
-sdk_versions=( "2.1.302" )
+sdk_versions=( "2.1.302" "2.1.503" )
+aspnet_latest_app_version=2.1.7
+aspnet_latest_all_version=2.1.7
 else
 # sdk versions supported on RHEL
 sdk_versions=( "2.1.302" "2.1.403" "2.1.504" )

--- a/2.2/build/Dockerfile
+++ b/2.2/build/Dockerfile
@@ -51,8 +51,8 @@ ENV DOTNET_SDK_BASE_VERSION=2.2.100 \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version
-    LatestPatchVersionForAspNetCoreApp2_2=2.2.1 \
-    LatestPatchVersionForAspNetCoreAll2_2=2.2.1
+    LatestPatchVersionForAspNetCoreApp2_2=2.2.2 \
+    LatestPatchVersionForAspNetCoreAll2_2=2.2.2
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.2/build/test/run
+++ b/2.2/build/test/run
@@ -36,8 +36,9 @@ aspnet_latest_app_version=2.2.2
 aspnet_latest_all_version=2.2.2
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 # sdk versions supported on CentOS
-error "No versions supported"
-exit 1
+sdk_versions=( "2.2.103" )
+aspnet_latest_app_version=2.2.1
+aspnet_latest_all_version=2.2.1
 else
 # sdk versions supported on RHEL
 sdk_versions=( "2.2.104" )

--- a/2.2/runtime/Dockerfile
+++ b/2.2/runtime/Dockerfile
@@ -68,7 +68,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/etc/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/etc/scl_enable"
 
 # Add default user
-RUN mkdir -p ${DOTNET_APP_PATH} && \
+RUN mkdir -p ${DOTNET_APP_PATH} ${DOTNET_DATA_PATH} && \
     useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
       -c "Default Application User" default
 

--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,9 @@ base_image_name() {
 
 image_exists() {
   docker inspect $1 &>/dev/null
+  # docker returns a value on no results while podman returns null,
+  # so explicitly return the exit code for consistency.
+  return $?
 }
 
 check_result_msg() {
@@ -94,7 +97,7 @@ if [ -z ${IMAGE_OS+x} ]; then
 fi
 
 if [ "$IMAGE_OS" = "CENTOS" ]; then
-  VERSIONS="${VERSIONS:-1.0 2.1}"
+  VERSIONS="${VERSIONS:-1.0 2.1 2.2}"
   image_os="centos7"
   image_prefix="dotnet"
   docker_filename="Dockerfile"

--- a/build.sh
+++ b/build.sh
@@ -47,9 +47,6 @@ base_image_name() {
 
 image_exists() {
   docker inspect $1 &>/dev/null
-  # docker returns a value on no results while podman returns null,
-  # so explicitly return the exit code for consistency.
-  return $?
 }
 
 check_result_msg() {


### PR DESCRIPTION
There's a new 2.1 SDK available, and the build script was not setup to build 2.2 images, which now has the RPMs available and so are possible to build.