### PR TITLE
2.1, 2.2: Improve incremental build speed

### DIFF
--- a/2.1/build/README.md
+++ b/2.1/build/README.md
@@ -31,12 +31,7 @@ Incremental builds
 
 The s2i image supports incremental builds. For incremental builds, NuGet packages
 will be re-used. To keep NuGet packages so they can be reused, you must set
-`DOTNET_RM_NUGET` to `false`.
-
-Note that the s2i builder does not remove unused NuGet packages on incremental
-builds. Over time the incremental application image may contain unused packages.
-To clean up those packages, you should occasionally perform a non-incremental build
-or perform a build with `DOTNET_RM_NUGET` set to `true`.
+`DOTNET_INCREMENTAL` to `true`.
 
 Repository organization
 ------------------------
@@ -167,10 +162,10 @@ a `.s2i/environment` file inside your source code repository.
 
     When set to `true`, the source code will not be included in the image. Defaults to ``.
 
-* **DOTNET_RM_NUGET**
+* **DOTNET_INCREMENTAL**
 
-    When set to `true`, the NuGet packages will not be included in the image.
-    Set this to `false` for incremental builds. Defaults to `true`.
+    When set to `true`, the NuGet packages will be kept so they can be re-used for an incremental build.
+    Defaults to `false`.
 
 * **NPM_MIRROR**
 

--- a/2.1/build/s2i/bin/assemble
+++ b/2.1/build/s2i/bin/assemble
@@ -12,11 +12,6 @@ else
   VERBOSITY_OPTION=""
 fi
 
-if [ "$(ls -A /tmp/artifacts 2>/dev/null)" ]; then
-  echo "---> Installing artifacts from incremental build..."
-  mv /tmp/artifacts/* /opt/app-root
-fi
-
 echo "---> Installing application source..."
 if [ -d /tmp/src ]; then
   mv /tmp/src/* ./
@@ -139,6 +134,10 @@ EOF
   if [ -n "${DOTNET_TOOLS}" ]; then
     # Build nuget sources list for when doing the restore
     TOOL_RESTORE_OPTIONS=""
+    if [ -d /tmp/artifacts/packages-for-incremental-build ]; then
+      # use packages-for-incremental-build as a source
+      TOOL_RESTORE_OPTIONS="$TOOL_RESTORE_OPTIONS --add-source file:///tmp/artifacts/packages-for-incremental-build"
+    fi
     if [ -n "${DOTNET_RESTORE_SOURCES}" ]; then
       # `dotnet tool install` doesn't have a `--source` parameter that behaves like
       # `dotnet restore` (i.e. replacing vs adding sources). We generate a config file
@@ -183,27 +182,40 @@ if [ "$BUILD_TYPE" == "source" ]; then
   DOTNET_CONFIGURATION="${DOTNET_CONFIGURATION:-Release}"
 
   # Build nuget sources list for when doing the restore
-  RESTORE_OPTIONS=""
+  RESTORE_SOURCE_OPTIONS=""
   for SOURCE in $DOTNET_RESTORE_SOURCES; do
-    RESTORE_OPTIONS="$RESTORE_OPTIONS --source $SOURCE"
+    RESTORE_SOURCE_OPTIONS="$RESTORE_SOURCE_OPTIONS --source $SOURCE"
   done
+  INCREMENTAL_SOURCE_OPTION=""
+  if [ -d /tmp/artifacts/packages-for-incremental-build ]; then
+    INCREMENTAL_SOURCE_OPTION="--source file:///tmp/artifacts/packages-for-incremental-build"
+  fi
 
+  RESTORE_OPTIONS=""
   # If true, run dotnet restore with --disable-parallel
   if [ "$DOTNET_RESTORE_DISABLE_PARALLEL" = true ]; then
     RESTORE_OPTIONS="$RESTORE_OPTIONS --disable-parallel"
   fi
-  
+
   # run tests
   for TEST_PROJECT in $DOTNET_TEST_PROJECTS; do
       echo "---> Restoring test project ($TEST_PROJECT) dependencies..."
-      dotnet restore "$TEST_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION
+      if [ -n "$INCREMENTAL_SOURCE_OPTION" ]; then
+        # perform a restore against packages-for-incremental-build
+        dotnet restore "$TEST_PROJECT" $RESTORE_OPTIONS $INCREMENTAL_SOURCE_OPTION $VERBOSITY_OPTION >/dev/null 2>&1 || true
+      fi
+      dotnet restore "$TEST_PROJECT" $RESTORE_OPTIONS $RESTORE_SOURCE_OPTIONS $VERBOSITY_OPTION
       echo "---> Running test project: $TEST_PROJECT..."
       dotnet test "$TEST_PROJECT" -f "$DOTNET_FRAMEWORK" $VERBOSITY_OPTION --no-restore
   done
 
   # publish application
   echo "---> Restoring application dependencies..."
-  dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION
+  if [ -n "$INCREMENTAL_SOURCE_OPTION" ]; then
+    # perform a restore against packages-for-incremental-build
+    dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $INCREMENTAL_SOURCE_OPTION $VERBOSITY_OPTION >/dev/null 2>&1 || true
+  fi
+  dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $RESTORE_SOURCE_OPTIONS $VERBOSITY_OPTION
   echo "---> Publishing application..."
   dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" $VERBOSITY_OPTION \
          --self-contained false /p:PublishWithAspNetCoreTargetManifest=false --no-restore -o "$DOTNET_APP_PATH"
@@ -233,11 +245,12 @@ if [ "$DOTNET_PACK" == "true" ]; then
 fi
 
 # cleanup NuGet artifacts
-rm -rf /opt/app-root/.local
-DOTNET_RM_NUGET="${DOTNET_RM_NUGET:-true}"
-if [ "$DOTNET_RM_NUGET" == "true" ]; then
-  rm -rf /opt/app-root/.nuget
+DOTNET_INCREMENTAL="${DOTNET_INCREMENTAL:-false}"
+if [ "$DOTNET_INCREMENTAL" == "true" ]; then
+  mkdir /opt/app-root/packages-for-incremental-build
+  find /opt/app-root/.nuget/packages -type f -name '*.nupkg' -exec mv -t /opt/app-root/packages-for-incremental-build {} \+
 fi
+rm -rf /opt/app-root/{.nuget,.local}
 
 if [ "$DOTNET_RM_SRC" == "true" ]; then
   echo "---> Removing sources..."

--- a/2.1/build/s2i/bin/assemble
+++ b/2.1/build/s2i/bin/assemble
@@ -248,7 +248,7 @@ fi
 DOTNET_INCREMENTAL="${DOTNET_INCREMENTAL:-false}"
 if [ "$DOTNET_INCREMENTAL" == "true" ]; then
   mkdir /opt/app-root/packages-for-incremental-build
-  find /opt/app-root/.nuget/packages -type f -name '*.nupkg' -exec mv -t /opt/app-root/packages-for-incremental-build {} \+
+  find /opt/app-root/.nuget/packages -type f -maxdepth 3 -name '*.nupkg' -exec mv -t /opt/app-root/packages-for-incremental-build {} \+
 fi
 rm -rf /opt/app-root/{.nuget,.local}
 

--- a/2.1/build/s2i/bin/save-artifacts
+++ b/2.1/build/s2i/bin/save-artifacts
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ -d /opt/app-root/.nuget ]; then
+if [ -d /opt/app-root/packages-for-incremental-build ]; then
   cd /opt/app-root
-  tar cf - .nuget
+  tar cf - packages-for-incremental-build
 fi

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -629,16 +629,14 @@ test_incremental()
   # perform a first build, with the incremental flag
   local image=$(s2i_image_tag ${app})
   docker_rmi ${image}
-  local s2i_build=$(s2i_build_output_log ${app} ${image} --incremental -e DOTNET_RM_NUGET=false)
+  local s2i_build=$(s2i_build_output_log ${app} ${image} --incremental -e DOTNET_INCREMENTAL=true)
   # verify packages are installed
   assert_contains "${s2i_build}" "Installing System"
   # verify the build completes succesfully
   assert_contains "${s2i_build}" "Build completed successfully"
 
   # perform a second build, with the incremental flag
-  s2i_build=$(s2i_build_output_log ${app} ${image} --incremental -e DOTNET_RM_NUGET=false)
-  # verify incremental build packages are installed
-  assert_contains "${s2i_build}" "Installing artifacts from incremental build"
+  s2i_build=$(s2i_build_output_log ${app} ${image} --incremental -e DOTNET_INCREMENTAL=true)
   # verify NO other packages are installed
   assert_not_contains "${s2i_build}" "Installing System"
   # verify the build completes succesfully
@@ -657,7 +655,7 @@ test_incremental_without_packages()
 
   # perform a first build without keeping packages
   local image=$(s2i_image_tag ${app})
-  local s2i_build=$(s2i_build_output_log ${app} ${image} -e DOTNET_RM_NUGET=true)
+  local s2i_build=$(s2i_build_output_log ${app} ${image} -e DOTNET_INCREMENTAL=false)
   # verify packages are installed
   assert_contains "${s2i_build}" "Installing System"
   # verify the build completes succesfully

--- a/2.2/build/README.md
+++ b/2.2/build/README.md
@@ -31,12 +31,7 @@ Incremental builds
 
 The s2i image supports incremental builds. For incremental builds, NuGet packages
 will be re-used. To keep NuGet packages so they can be reused, you must set
-`DOTNET_RM_NUGET` to `false`.
-
-Note that the s2i builder does not remove unused NuGet packages on incremental
-builds. Over time the incremental application image may contain unused packages.
-To clean up those packages, you should occasionally perform a non-incremental build
-or perform a build with `DOTNET_RM_NUGET` set to `true`.
+`DOTNET_INCREMENTAL` to `true`.
 
 Repository organization
 ------------------------
@@ -167,10 +162,10 @@ a `.s2i/environment` file inside your source code repository.
 
     When set to `true`, the source code will not be included in the image. Defaults to ``.
 
-* **DOTNET_RM_NUGET**
+* **DOTNET_INCREMENTAL**
 
-    When set to `true`, the NuGet packages will not be included in the image.
-    Set this to `false` for incremental builds. Defaults to `true`.
+    When set to `true`, the NuGet packages will be kept so they can be re-used for an incremental build.
+    Defaults to `false`.
 
 * **NPM_MIRROR**
 

--- a/2.2/build/s2i/bin/assemble
+++ b/2.2/build/s2i/bin/assemble
@@ -12,11 +12,6 @@ else
   VERBOSITY_OPTION=""
 fi
 
-if [ "$(ls -A /tmp/artifacts 2>/dev/null)" ]; then
-  echo "---> Installing artifacts from incremental build..."
-  mv /tmp/artifacts/* /opt/app-root
-fi
-
 echo "---> Installing application source..."
 if [ -d /tmp/src ]; then
   mv /tmp/src/* ./
@@ -139,6 +134,10 @@ EOF
   if [ -n "${DOTNET_TOOLS}" ]; then
     # Build nuget sources list for when doing the restore
     TOOL_RESTORE_OPTIONS=""
+    if [ -d /tmp/artifacts/packages-for-incremental-build ]; then
+      # use packages-for-incremental-build as a source
+      TOOL_RESTORE_OPTIONS="$TOOL_RESTORE_OPTIONS --add-source file:///tmp/artifacts/packages-for-incremental-build"
+    fi
     if [ -n "${DOTNET_RESTORE_SOURCES}" ]; then
       # `dotnet tool install` doesn't have a `--source` parameter that behaves like
       # `dotnet restore` (i.e. replacing vs adding sources). We generate a config file
@@ -183,27 +182,40 @@ if [ "$BUILD_TYPE" == "source" ]; then
   DOTNET_CONFIGURATION="${DOTNET_CONFIGURATION:-Release}"
 
   # Build nuget sources list for when doing the restore
-  RESTORE_OPTIONS=""
+  RESTORE_SOURCE_OPTIONS=""
   for SOURCE in $DOTNET_RESTORE_SOURCES; do
-    RESTORE_OPTIONS="$RESTORE_OPTIONS --source $SOURCE"
+    RESTORE_SOURCE_OPTIONS="$RESTORE_SOURCE_OPTIONS --source $SOURCE"
   done
+  INCREMENTAL_SOURCE_OPTION=""
+  if [ -d /tmp/artifacts/packages-for-incremental-build ]; then
+    INCREMENTAL_SOURCE_OPTION="--source file:///tmp/artifacts/packages-for-incremental-build"
+  fi
 
+  RESTORE_OPTIONS=""
   # If true, run dotnet restore with --disable-parallel
   if [ "$DOTNET_RESTORE_DISABLE_PARALLEL" = true ]; then
     RESTORE_OPTIONS="$RESTORE_OPTIONS --disable-parallel"
   fi
-  
+
   # run tests
   for TEST_PROJECT in $DOTNET_TEST_PROJECTS; do
       echo "---> Restoring test project ($TEST_PROJECT) dependencies..."
-      dotnet restore "$TEST_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION
+      if [ -n "$INCREMENTAL_SOURCE_OPTION" ]; then
+        # perform a restore against packages-for-incremental-build
+        dotnet restore "$TEST_PROJECT" $RESTORE_OPTIONS $INCREMENTAL_SOURCE_OPTION $VERBOSITY_OPTION >/dev/null 2>&1 || true
+      fi
+      dotnet restore "$TEST_PROJECT" $RESTORE_OPTIONS $RESTORE_SOURCE_OPTIONS $VERBOSITY_OPTION
       echo "---> Running test project: $TEST_PROJECT..."
       dotnet test "$TEST_PROJECT" -f "$DOTNET_FRAMEWORK" $VERBOSITY_OPTION --no-restore
   done
 
   # publish application
   echo "---> Restoring application dependencies..."
-  dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION
+  if [ -n "$INCREMENTAL_SOURCE_OPTION" ]; then
+    # perform a restore against packages-for-incremental-build
+    dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $INCREMENTAL_SOURCE_OPTION $VERBOSITY_OPTION >/dev/null 2>&1 || true
+  fi
+  dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $RESTORE_SOURCE_OPTIONS $VERBOSITY_OPTION
   echo "---> Publishing application..."
   dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" $VERBOSITY_OPTION \
          --self-contained false /p:PublishWithAspNetCoreTargetManifest=false --no-restore -o "$DOTNET_APP_PATH"
@@ -233,11 +245,12 @@ if [ "$DOTNET_PACK" == "true" ]; then
 fi
 
 # cleanup NuGet artifacts
-rm -rf /opt/app-root/.local
-DOTNET_RM_NUGET="${DOTNET_RM_NUGET:-true}"
-if [ "$DOTNET_RM_NUGET" == "true" ]; then
-  rm -rf /opt/app-root/.nuget
+DOTNET_INCREMENTAL="${DOTNET_INCREMENTAL:-false}"
+if [ "$DOTNET_INCREMENTAL" == "true" ]; then
+  mkdir /opt/app-root/packages-for-incremental-build
+  find /opt/app-root/.nuget/packages -type f -name '*.nupkg' -exec mv -t /opt/app-root/packages-for-incremental-build {} \+
 fi
+rm -rf /opt/app-root/{.nuget,.local}
 
 if [ "$DOTNET_RM_SRC" == "true" ]; then
   echo "---> Removing sources..."

--- a/2.2/build/s2i/bin/assemble
+++ b/2.2/build/s2i/bin/assemble
@@ -248,7 +248,7 @@ fi
 DOTNET_INCREMENTAL="${DOTNET_INCREMENTAL:-false}"
 if [ "$DOTNET_INCREMENTAL" == "true" ]; then
   mkdir /opt/app-root/packages-for-incremental-build
-  find /opt/app-root/.nuget/packages -type f -name '*.nupkg' -exec mv -t /opt/app-root/packages-for-incremental-build {} \+
+  find /opt/app-root/.nuget/packages -type f -maxdepth 3 -name '*.nupkg' -exec mv -t /opt/app-root/packages-for-incremental-build {} \+
 fi
 rm -rf /opt/app-root/{.nuget,.local}
 

--- a/2.2/build/s2i/bin/save-artifacts
+++ b/2.2/build/s2i/bin/save-artifacts
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ -d /opt/app-root/.nuget ]; then
+if [ -d /opt/app-root/packages-for-incremental-build ]; then
   cd /opt/app-root
-  tar cf - .nuget
+  tar cf - packages-for-incremental-build
 fi

--- a/2.2/build/test/run
+++ b/2.2/build/test/run
@@ -631,16 +631,14 @@ test_incremental()
   # perform a first build, with the incremental flag
   local image=$(s2i_image_tag ${app})
   docker_rmi ${image}
-  local s2i_build=$(s2i_build_output_log ${app} ${image} --incremental -e DOTNET_RM_NUGET=false)
+  local s2i_build=$(s2i_build_output_log ${app} ${image} --incremental -e DOTNET_INCREMENTAL=true)
   # verify packages are installed
   assert_contains "${s2i_build}" "Installing System"
   # verify the build completes succesfully
   assert_contains "${s2i_build}" "Build completed successfully"
 
   # perform a second build, with the incremental flag
-  s2i_build=$(s2i_build_output_log ${app} ${image} --incremental -e DOTNET_RM_NUGET=false)
-  # verify incremental build packages are installed
-  assert_contains "${s2i_build}" "Installing artifacts from incremental build"
+  s2i_build=$(s2i_build_output_log ${app} ${image} --incremental -e DOTNET_INCREMENTAL=true)
   # verify NO other packages are installed
   assert_not_contains "${s2i_build}" "Installing System"
   # verify the build completes succesfully
@@ -659,7 +657,7 @@ test_incremental_without_packages()
 
   # perform a first build without keeping packages
   local image=$(s2i_image_tag ${app})
-  local s2i_build=$(s2i_build_output_log ${app} ${image} -e DOTNET_RM_NUGET=true)
+  local s2i_build=$(s2i_build_output_log ${app} ${image} -e DOTNET_INCREMENTAL=false)
   # verify packages are installed
   assert_contains "${s2i_build}" "Installing System"
   # verify the build completes succesfully


### PR DESCRIPTION
Incremental builds have a cost of fetching the previous image from
the registry.

This change reduces the number of artifacts we keep in the application
image for an incremental build. Instead of keeping the entire
~/.nuget/packages folder, we only keep the *.nupkg files. On the next
build, we pass those files to a separate restore step.

As a bonus, this change causes packages that are no longer used from
the previous build to no longer be kept around.