### PR TITLE
Update Dockerfiles and tests for new dotnet versions.

### DIFF
--- a/1.0/Dockerfile.rhel7
+++ b/1.0/Dockerfile.rhel7
@@ -22,7 +22,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 1.0 applic
 LABEL name="dotnet/dotnetcore-10-rhel7" \
       com.redhat.component="rh-dotnetcore10-container" \
       version="1.0" \
-      release="43" \
+      release="45" \
       architecture="x86_64"
 
 COPY ./root/usr/bin /usr/bin

--- a/1.0/test/run
+++ b/1.0/test/run
@@ -44,7 +44,7 @@ image_dir=$(readlink -zf ${test_dir}/..)
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 dotnet_version="1.0.0-preview2-003320"
 else
-dotnet_version="1.0.0-preview2-003340"
+dotnet_version="1.0.0-preview2-003360"
 fi
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 

--- a/1.1/Dockerfile.rhel7
+++ b/1.1/Dockerfile.rhel7
@@ -22,7 +22,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 1.1 applic
 LABEL name="dotnet/dotnetcore-11-rhel7" \
       com.redhat.component="rh-dotnetcore11-container" \
       version="1.1" \
-      release="35" \
+      release="36" \
       architecture="x86_64"
 
 COPY ./root/usr/bin /usr/bin

--- a/1.1/test/run
+++ b/1.1/test/run
@@ -40,7 +40,7 @@ image_dir=$(readlink -zf ${test_dir}/..)
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 dotnet_version="1.0.0-preview2-1-003331"
 else
-dotnet_version="1.0.0-preview2-1-003351"
+dotnet_version="1.0.0-preview2-1-003371"
 fi
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 

--- a/2.1/build/Dockerfile.rhel7
+++ b/2.1/build/Dockerfile.rhel7
@@ -12,7 +12,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 2.1 applic
 LABEL name="dotnet/dotnet-21-rhel7" \
       com.redhat.component="rh-dotnet21-container" \
       version="2.1" \
-      release="14" \
+      release="16" \
       architecture="x86_64"
 
 # Labels consumed by Eclipse JBoss OpenShift plugin
@@ -52,8 +52,8 @@ ENV DOTNET_SDK_BASE_VERSION=2.1.300 \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version
-    LatestPatchVersionForAspNetCoreApp2_1=2.1.8 \
-    LatestPatchVersionForAspNetCoreAll2_1=2.1.8
+    LatestPatchVersionForAspNetCoreApp2_1=2.1.9 \
+    LatestPatchVersionForAspNetCoreAll2_1=2.1.9
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -31,8 +31,8 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
 # Versions of Microsoft.AspNetCore.{All,App} packages that are known by latest RHEL sdk.
-aspnet_latest_app_version=2.1.8
-aspnet_latest_all_version=2.1.8
+aspnet_latest_app_version=2.1.9
+aspnet_latest_all_version=2.1.9
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 # sdk versions supported on CentOS
 sdk_versions=( "2.1.302" "2.1.503" )
@@ -40,7 +40,7 @@ aspnet_latest_app_version=2.1.7
 aspnet_latest_all_version=2.1.7
 else
 # sdk versions supported on RHEL
-sdk_versions=( "2.1.302" "2.1.403" "2.1.504" )
+sdk_versions=( "2.1.302" "2.1.403" "2.1.505" )
 fi
 
 sdk_default_version=${sdk_versions[0]}

--- a/2.1/runtime/Dockerfile.rhel7
+++ b/2.1/runtime/Dockerfile.rhel7
@@ -26,7 +26,7 @@ LABEL io.k8s.description="Platform for running .NET Core 2.1 applications" \
 LABEL name="dotnet/dotnet-21-runtime-rhel7" \
       com.redhat.component="rh-dotnet21-runtime-container" \
       version="2.1" \
-      release="14" \
+      release="16" \
       architecture="x86_64"
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.

--- a/2.1/runtime/test/run
+++ b/2.1/runtime/test/run
@@ -26,7 +26,7 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
 dotnet_version_series="2.1"
-dotnet_version_suffix="302"
+dotnet_version_suffix="505"
 dotnet_version="${dotnet_version_series}.${dotnet_version_suffix}"
 
 test_dotnet() {

--- a/2.1/runtime/test/run
+++ b/2.1/runtime/test/run
@@ -26,7 +26,7 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
 dotnet_version_series="2.1"
-dotnet_version_suffix="505"
+dotnet_version_suffix="302"
 dotnet_version="${dotnet_version_series}.${dotnet_version_suffix}"
 
 test_dotnet() {

--- a/2.2/build/Dockerfile.rhel7
+++ b/2.2/build/Dockerfile.rhel7
@@ -12,7 +12,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 2.2 applic
 LABEL name="dotnet/dotnet-22-rhel7" \
       com.redhat.component="rh-dotnet22-container" \
       version="2.2" \
-      release="3" \
+      release="6" \
       architecture="x86_64"
 
 # Labels consumed by Eclipse JBoss OpenShift plugin
@@ -52,8 +52,8 @@ ENV DOTNET_SDK_BASE_VERSION=2.2.100 \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version
-    LatestPatchVersionForAspNetCoreApp2_2=2.2.2 \
-    LatestPatchVersionForAspNetCoreAll2_2=2.2.2
+    LatestPatchVersionForAspNetCoreApp2_2=2.2.3 \
+    LatestPatchVersionForAspNetCoreAll2_2=2.2.3
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.2/build/test/run
+++ b/2.2/build/test/run
@@ -32,8 +32,8 @@ source ${test_dir}/testcommon
 
 # Versions of Microsoft.AspNetCore.{All,App} packages that are known by latest RHEL sdk.
 # TODO: update latest patch versions below
-aspnet_latest_app_version=2.2.2
-aspnet_latest_all_version=2.2.2
+aspnet_latest_app_version=2.2.3
+aspnet_latest_all_version=2.2.3
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 # sdk versions supported on CentOS
 sdk_versions=( "2.2.103" )
@@ -41,7 +41,7 @@ aspnet_latest_app_version=2.2.1
 aspnet_latest_all_version=2.2.1
 else
 # sdk versions supported on RHEL
-sdk_versions=( "2.2.104" )
+sdk_versions=( "2.2.105" )
 fi
 
 sdk_default_version=${sdk_versions[0]}

--- a/2.2/runtime/Dockerfile.rhel7
+++ b/2.2/runtime/Dockerfile.rhel7
@@ -26,7 +26,7 @@ LABEL io.k8s.description="Platform for running .NET Core 2.2 applications" \
 LABEL name="dotnet/dotnet-22-runtime-rhel7" \
       com.redhat.component="rh-dotnet22-runtime-container" \
       version="2.2" \
-      release="3" \
+      release="6" \
       architecture="x86_64"
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.

--- a/2.2/runtime/test/run
+++ b/2.2/runtime/test/run
@@ -26,7 +26,7 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
 dotnet_version_series="2.2"
-dotnet_version_suffix="100-preview2"
+dotnet_version_suffix="105"
 dotnet_version="${dotnet_version_series}.${dotnet_version_suffix}"
 
 test_dotnet() {


### PR DESCRIPTION
Update Dockerfiles and tests for new dotnet versions, which include:

1.0.15
1.1.12
2.1.9 runtime
2.1.9 ASP.NET Core
2.1.505 SDK
2.2.3 runtime
2.2.3 ASP.NET Core
2.2.105 SDK