### PR TITLE
Remove having multiple sdks defaultly from build containers.

### DIFF
--- a/2.1/build/Dockerfile
+++ b/2.1/build/Dockerfile
@@ -26,7 +26,7 @@ USER 0
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
-    INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1.3xx rh-dotnet21-dotnet-sdk-2.1 rsync" && \
+    INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1 rsync" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
@@ -43,11 +43,7 @@ WORKDIR /opt/app-root/src
 # the permissions on those too.
 RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
-ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8"
-
-# For backwards compatibility, s2i builds default to the oldest sdk in the image.
-# We keep the patch at 'x00', the latest patch version is automatically picked up.
-ENV DOTNET_SDK_BASE_VERSION=2.1.300 \
+ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8" \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version

--- a/2.1/build/Dockerfile.rhel7
+++ b/2.1/build/Dockerfile.rhel7
@@ -12,7 +12,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 2.1 applic
 LABEL name="dotnet/dotnet-21-rhel7" \
       com.redhat.component="rh-dotnet21-container" \
       version="2.1" \
-      release="16" \
+      release="17" \
       architecture="x86_64"
 
 # Labels consumed by Eclipse JBoss OpenShift plugin
@@ -25,7 +25,7 @@ USER 0
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
 COPY ./s2i/bin/ /usr/libexec/s2i
 
-RUN INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1 rh-dotnet21-dotnet-sdk-2.1.4xx  rh-dotnet21-dotnet-sdk-2.1.3xx rsync" && \
+RUN INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1 rsync" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \
@@ -44,11 +44,7 @@ WORKDIR /opt/app-root/src
 # the permissions on those too.
 RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
-ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8"
-
-# For backwards compatibility, s2i builds default to the oldest sdk in the image.
-# We keep the patch at 'x00', the latest patch version is automatically picked up.
-ENV DOTNET_SDK_BASE_VERSION=2.1.300 \
+ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8" \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version

--- a/2.1/build/README.md
+++ b/2.1/build/README.md
@@ -101,10 +101,6 @@ a `.s2i/environment` file inside your source code repository.
 
     Used to select the project to run. This must be a project file (e.g. csproj, fsproj) or a folder containing a single project file. Defaults to `.`.
 
-* **DOTNET_SDK_VERSION**
-
-    Used to select the sdk version when building. If there is a `global.json` file in the source repository, that takes precedence.
-
 * **DOTNET_ASSEMBLY_NAME**
 
     Used to select the assembly to run. This must NOT include the `.dll` extension.
@@ -187,6 +183,10 @@ a `.s2i/environment` file inside your source code repository.
 * **DOTNET_USE_POLLING_FILE_WATCHER**
 
     This is set to `true` to ensure the `dotnet watch` command works in a container. This command is not used by the default scripts.
+
+* **[OBSOLETE] DOTNET_SDK_VERSION**
+
+    The s2i image only provides the latest SDK version.
 
 NPM
 ---

--- a/2.1/build/README.md
+++ b/2.1/build/README.md
@@ -103,8 +103,7 @@ a `.s2i/environment` file inside your source code repository.
 
 * **DOTNET_SDK_VERSION**
 
-    Used to select the default sdk version when building. If there is a `global.json` file in the source repository, that takes precedence.
-    When set to `latest` the latest sdk in the image is used. Defaults to the lowest sdk version available in the image.
+    Used to select the sdk version when building. If there is a `global.json` file in the source repository, that takes precedence.
 
 * **DOTNET_ASSEMBLY_NAME**
 
@@ -184,10 +183,6 @@ a `.s2i/environment` file inside your source code repository.
 
     When set to `true`, the application restart automatically when the source code changes. `dotnet run`
     is used to start the application.
-
-* **DOTNET_SDK_BASE_VERSION**
-
-    Contains the lowest sdk version available in the image. This is used as the default value for `DOTNET_SDK_VERSION`.
 
 * **DOTNET_USE_POLLING_FILE_WATCHER**
 

--- a/2.1/build/README.md
+++ b/2.1/build/README.md
@@ -184,9 +184,9 @@ a `.s2i/environment` file inside your source code repository.
 
     This is set to `true` to ensure the `dotnet watch` command works in a container. This command is not used by the default scripts.
 
-* **[OBSOLETE] DOTNET_SDK_VERSION**
+* **[OBSOLETE - April 2019] DOTNET_SDK_VERSION**
 
-    The s2i image only provides the latest SDK version.
+    The s2i image only provides the latest SDK version. Previous versions of the SDK may contain known vulnerabilities.
 
 NPM
 ---

--- a/2.1/build/s2i/bin/assemble
+++ b/2.1/build/s2i/bin/assemble
@@ -92,15 +92,6 @@ else
 fi
 
 if [ "$BUILD_TYPE" == "source" ]; then
-  if [ -n ${DOTNET_SDK_VERSION} ]; then
-      cat >../global.json <<EOF
-{
-  "sdk": {
-    "version": "$DOTNET_SDK_VERSION"
-  }
-}
-EOF
-  fi
   echo "Using SDK: $(dotnet --version)"
 
   # Trust certificates from DOTNET_SSL_DIRS.

--- a/2.1/build/s2i/bin/assemble
+++ b/2.1/build/s2i/bin/assemble
@@ -92,10 +92,8 @@ else
 fi
 
 if [ "$BUILD_TYPE" == "source" ]; then
-  # sdk version
-  DOTNET_SDK_VERSION="${DOTNET_SDK_VERSION:-$DOTNET_SDK_BASE_VERSION}"
-  if [ "$DOTNET_SDK_VERSION" != "latest" ]; then
-  cat >../global.json <<EOF
+  if [ -n ${DOTNET_SDK_VERSION} ]; then
+      cat >../global.json <<EOF
 {
   "sdk": {
     "version": "$DOTNET_SDK_VERSION"

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -34,17 +34,15 @@ source ${test_dir}/testcommon
 aspnet_latest_app_version=2.1.9
 aspnet_latest_all_version=2.1.9
 if [ "$IMAGE_OS" = "CENTOS" ]; then
-# sdk versions supported on CentOS
-sdk_versions=( "2.1.302" "2.1.503" )
+# sdk version supported on CentOS
+sdk_version=2.1.503
 aspnet_latest_app_version=2.1.7
 aspnet_latest_all_version=2.1.7
 else
-# sdk versions supported on RHEL
-sdk_versions=( "2.1.302" "2.1.403" "2.1.505" )
+# sdk version supported on RHEL
+sdk_version=2.1.505
 fi
 
-sdk_default_version=${sdk_versions[0]}
-sdk_latest_version=${sdk_versions[-1]}
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 
 s2i_build_and_run() {
@@ -125,7 +123,7 @@ test_image() {
 
   # verify dotnet is available
   local image_dotnet_version=$(docker_run ${IMAGE_NAME} 'dotnet --version')
-  assert_equal "${image_dotnet_version}" "${sdk_latest_version}"
+  assert_equal "${image_dotnet_version}" "${sdk_version}"
 
   # Verify $HOME != $CWD. See https://github.com/redhat-developer/s2i-dotnetcore/issues/28
   local working_dir=$(docker_run ${IMAGE_NAME} pwd)
@@ -586,7 +584,7 @@ test_aspnet_implicit_using_latest()
 
   # verify aspnet_latest_{app,all}_version have the correct values.
   # If this fails, the variables in the test and environment variables in the Dockerfiles must be updated.
-  if [ "$sdk_version" == "$sdk_latest_version" -a "$IMAGE_OS" != "CENTOS" ]; then
+  if [ "$IMAGE_OS" != "CENTOS" ]; then
     info verifying aspnet_latest_{app,all}
 
     # build image
@@ -678,34 +676,25 @@ info "Testing ${IMAGE_NAME}"
 
 if [ ${OPENSHIFT_ONLY} != true ]; then
   test_image
-  for sdk_version in "${sdk_versions[@]}"
-  do
-    info "sdk ${sdk_version}:"
-    test_config
-    test_usage
-    test_s2i_sdk_version $sdk_version
-    test_aspnet_implicit_using_latest
-    test_consoleapp
-    test_multiframework
-    test_fsharp
-    test_vb
-    test_published_files
-    test_aspnetapp
-    test_devmode
-    test_split_build
-    test_templates
-    test_user
-    test_certificates
-    test_binary
-    test_incremental
-    test_incremental_without_packages
-  done
-  # when unset, default to the lowest sdk version
-  info "default sdk(${sdk_default_version}):"
-  sdk_version="" test_s2i_sdk_version $sdk_default_version
-  # when set to 'latest', use the higest sdk version
-  info "latest sdk(${sdk_latest_version}):"
-  sdk_version="latest" test_s2i_sdk_version $sdk_latest_version
+  info "sdk ${sdk_version}:"
+  test_config
+  test_usage
+  test_s2i_sdk_version $sdk_version
+  test_aspnet_implicit_using_latest
+  test_consoleapp
+  test_multiframework
+  test_fsharp
+  test_vb
+  test_published_files
+  test_aspnetapp
+  test_devmode
+  test_split_build
+  test_templates
+  test_user
+  test_certificates
+  test_binary
+  test_incremental
+  test_incremental_without_packages
 else
   test_imagestream_sample
 fi

--- a/2.1/build/test/testcommon
+++ b/2.1/build/test/testcommon
@@ -218,7 +218,8 @@ s2i_build_output_log() {
   if [[ "$@" != *"--incremental"* ]]; then
     docker_rmi ${tag}
   fi
-  s2i build --pull-policy=never -e DOTNET_SDK_VERSION=$sdk_version "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
+
+  s2i build --pull-policy=never "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
 }
 
 s2i_build() {

--- a/2.1/build/test/testcommon
+++ b/2.1/build/test/testcommon
@@ -218,7 +218,6 @@ s2i_build_output_log() {
   if [[ "$@" != *"--incremental"* ]]; then
     docker_rmi ${tag}
   fi
-
   s2i build --pull-policy=never "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
 }
 

--- a/2.1/runtime/test/testcommon
+++ b/2.1/runtime/test/testcommon
@@ -218,7 +218,7 @@ s2i_build_output_log() {
   if [[ "$@" != *"--incremental"* ]]; then
     docker_rmi ${tag}
   fi
-  s2i build --pull-policy=never -e DOTNET_SDK_VERSION=$sdk_version "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
+  s2i build --pull-policy=never "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
 }
 
 s2i_build() {

--- a/2.2/build/Dockerfile
+++ b/2.2/build/Dockerfile
@@ -43,11 +43,7 @@ WORKDIR /opt/app-root/src
 # the permissions on those too.
 RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
-ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8"
-
-# For backwards compatibility, s2i builds default to the oldest sdk in the image.
-# We keep the patch at 'x00', the latest patch version is automatically picked up.
-ENV DOTNET_SDK_BASE_VERSION=2.2.100 \
+ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8" \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version

--- a/2.2/build/Dockerfile.rhel7
+++ b/2.2/build/Dockerfile.rhel7
@@ -12,7 +12,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 2.2 applic
 LABEL name="dotnet/dotnet-22-rhel7" \
       com.redhat.component="rh-dotnet22-container" \
       version="2.2" \
-      release="6" \
+      release="7" \
       architecture="x86_64"
 
 # Labels consumed by Eclipse JBoss OpenShift plugin
@@ -44,11 +44,7 @@ WORKDIR /opt/app-root/src
 # the permissions on those too.
 RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
-ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8"
-
-# For backwards compatibility, s2i builds default to the oldest sdk in the image.
-# We keep the patch at 'x00', the latest patch version is automatically picked up.
-ENV DOTNET_SDK_BASE_VERSION=2.2.100 \
+ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8" \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version

--- a/2.2/build/README.md
+++ b/2.2/build/README.md
@@ -103,8 +103,7 @@ a `.s2i/environment` file inside your source code repository.
 
 * **DOTNET_SDK_VERSION**
 
-    Used to select the default sdk version when building. If there is a `global.json` file in the source repository, that takes precedence.
-    When set to `latest` the latest sdk in the image is used. Defaults to the lowest sdk version available in the image.
+    Used to select the sdk version when building. If there is a `global.json` file in the source repository, tha takes precedence.
 
 * **DOTNET_ASSEMBLY_NAME**
 
@@ -184,10 +183,6 @@ a `.s2i/environment` file inside your source code repository.
 
     When set to `true`, the application restart automatically when the source code changes. `dotnet run`
     is used to start the application.
-
-* **DOTNET_SDK_BASE_VERSION**
-
-    Contains the lowest sdk version available in the image. This is used as the default value for `DOTNET_SDK_VERSION`.
 
 * **DOTNET_USE_POLLING_FILE_WATCHER**
 

--- a/2.2/build/README.md
+++ b/2.2/build/README.md
@@ -184,8 +184,9 @@ a `.s2i/environment` file inside your source code repository.
 
     This is set to `true` to ensure the `dotnet watch` command works in a container. This command is not used by the default scripts.
 
-* **[OBSOLETE] DOTNET_SDK_VERSION**
-    The s2i image only provides the latest SDK version.
+* **[OBSOLETE - April 2019] DOTNET_SDK_VERSION**
+
+    The s2i image only provides the latest SDK version. Previous versions of the SDK may contain known vulnerabilities.
 
 NPM
 ---

--- a/2.2/build/README.md
+++ b/2.2/build/README.md
@@ -101,10 +101,6 @@ a `.s2i/environment` file inside your source code repository.
 
     Used to select the project to run. This must be a project file (e.g. csproj, fsproj) or a folder containing a single project file. Defaults to `.`.
 
-* **DOTNET_SDK_VERSION**
-
-    Used to select the sdk version when building. If there is a `global.json` file in the source repository, tha takes precedence.
-
 * **DOTNET_ASSEMBLY_NAME**
 
     Used to select the assembly to run. This must NOT include the `.dll` extension.
@@ -187,6 +183,9 @@ a `.s2i/environment` file inside your source code repository.
 * **DOTNET_USE_POLLING_FILE_WATCHER**
 
     This is set to `true` to ensure the `dotnet watch` command works in a container. This command is not used by the default scripts.
+
+* **[OBSOLETE] DOTNET_SDK_VERSION**
+    The s2i image only provides the latest SDK version.
 
 NPM
 ---

--- a/2.2/build/s2i/bin/assemble
+++ b/2.2/build/s2i/bin/assemble
@@ -92,10 +92,8 @@ else
 fi
 
 if [ "$BUILD_TYPE" == "source" ]; then
-  # sdk version
-  DOTNET_SDK_VERSION="${DOTNET_SDK_VERSION:-$DOTNET_SDK_BASE_VERSION}"
-  if [ "$DOTNET_SDK_VERSION" != "latest" ]; then
-  cat >../global.json <<EOF
+  if [ -n ${DOTNET_SDK_VERSION} ]; then
+    cat >../global.json <<EOF
 {
   "sdk": {
     "version": "$DOTNET_SDK_VERSION"

--- a/2.2/build/s2i/bin/assemble
+++ b/2.2/build/s2i/bin/assemble
@@ -92,15 +92,6 @@ else
 fi
 
 if [ "$BUILD_TYPE" == "source" ]; then
-  if [ -n ${DOTNET_SDK_VERSION} ]; then
-    cat >../global.json <<EOF
-{
-  "sdk": {
-    "version": "$DOTNET_SDK_VERSION"
-  }
-}
-EOF
-  fi
   echo "Using SDK: $(dotnet --version)"
 
   # Trust certificates from DOTNET_SSL_DIRS.

--- a/2.2/build/test/run
+++ b/2.2/build/test/run
@@ -35,17 +35,15 @@ source ${test_dir}/testcommon
 aspnet_latest_app_version=2.2.3
 aspnet_latest_all_version=2.2.3
 if [ "$IMAGE_OS" = "CENTOS" ]; then
-# sdk versions supported on CentOS
-sdk_versions=( "2.2.103" )
+# sdk version supported on CentOS
+sdk_version=2.2.103
 aspnet_latest_app_version=2.2.1
 aspnet_latest_all_version=2.2.1
 else
-# sdk versions supported on RHEL
-sdk_versions=( "2.2.105" )
+# sdk version supported on RHEL
+sdk_version=2.2.105
 fi
 
-sdk_default_version=${sdk_versions[0]}
-sdk_latest_version=${sdk_versions[-1]}
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
 
 s2i_build_and_run() {
@@ -126,7 +124,7 @@ test_image() {
 
   # verify dotnet is available
   local image_dotnet_version=$(docker_run ${IMAGE_NAME} 'dotnet --version')
-  assert_equal "${image_dotnet_version}" "${sdk_latest_version}"
+  assert_equal "${image_dotnet_version}" "${sdk_version}"
 
   # Verify $HOME != $CWD. See https://github.com/redhat-developer/s2i-dotnetcore/issues/28
   local working_dir=$(docker_run ${IMAGE_NAME} pwd)
@@ -587,7 +585,7 @@ test_aspnet_implicit_using_latest()
 
   # verify aspnet_latest_{app,all}_version have the correct values.
   # If this fails, the variables in the test and environment variables in the Dockerfiles must be updated.
-  if [ "$sdk_version" == "$sdk_latest_version" -a "$BUILD_CENTOS" != "true" ]; then
+  if [ "$BUILD_CENTOS" != "true" ]; then
     info verifying aspnet_latest_{app,all}
 
     # build image
@@ -679,34 +677,25 @@ info "Testing ${IMAGE_NAME}"
 
 if [ ${OPENSHIFT_ONLY} != true ]; then
   test_image
-  for sdk_version in "${sdk_versions[@]}"
-  do
-    info "sdk ${sdk_version}:"
-    test_config
-    test_usage
-    test_s2i_sdk_version $sdk_version
-    test_aspnet_implicit_using_latest
-    test_consoleapp
-    test_multiframework
-    test_fsharp
-    test_vb
-    test_published_files
-    test_aspnetapp
-    test_devmode
-    test_split_build
-    test_templates
-    test_user
-    test_certificates
-    test_binary
-    test_incremental
-    test_incremental_without_packages
-  done
-  # when unset, default to the lowest sdk version
-  info "default sdk(${sdk_default_version}):"
-  sdk_version="" test_s2i_sdk_version $sdk_default_version
-  # when set to 'latest', use the higest sdk version
-  info "latest sdk(${sdk_latest_version}):"
-  sdk_version="latest" test_s2i_sdk_version $sdk_latest_version
+  info "sdk ${sdk_version}:"
+  test_config
+  test_usage
+  test_s2i_sdk_version $sdk_version
+  test_aspnet_implicit_using_latest
+  test_consoleapp
+  test_multiframework
+  test_fsharp
+  test_vb
+  test_published_files
+  test_aspnetapp
+  test_devmode
+  test_split_build
+  test_templates
+  test_user
+  test_certificates
+  test_binary
+  test_incremental
+  test_incremental_without_packages
 else
   test_imagestream_sample
 fi

--- a/2.2/build/test/testcommon
+++ b/2.2/build/test/testcommon
@@ -218,7 +218,7 @@ s2i_build_output_log() {
   if [[ "$@" != *"--incremental"* ]]; then
     docker_rmi ${tag}
   fi
-  s2i build --pull-policy=never -e DOTNET_SDK_VERSION=$sdk_version "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
+  s2i build --pull-policy=never "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
 }
 
 s2i_build() {

--- a/2.2/runtime/test/testcommon
+++ b/2.2/runtime/test/testcommon
@@ -218,7 +218,7 @@ s2i_build_output_log() {
   if [[ "$@" != *"--incremental"* ]]; then
     docker_rmi ${tag}
   fi
-  s2i build --pull-policy=never -e DOTNET_SDK_VERSION=$sdk_version "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
+  s2i build --pull-policy=never "$@" "file://${test_dir}/${app}" ${IMAGE_NAME} ${tag} 2>&1
 }
 
 s2i_build() {

--- a/templates/community/dotnet-baget.json
+++ b/templates/community/dotnet-baget.json
@@ -84,10 +84,6 @@
                                     {
                                         "name": "DOTNET_STARTUP_PROJECT",
                                         "value": "${DOTNET_STARTUP_PROJECT}"
-                                    },
-                                    {
-                                        "name": "DOTNET_SDK_VERSION",
-                                        "value": "${DOTNET_SDK_VERSION}"
                                     }
                                 ]
                             }
@@ -344,11 +340,6 @@
                     "displayName": "Startup Project",
                     "description": "Set this to a project file (e.g. csproj) or a folder containing a single project file.",
                     "value": "src/BaGet"
-                },
-                {
-                    "name": "DOTNET_SDK_VERSION",
-                    "displayName": "SDK Version",
-                    "description": "Set this to configure the default SDK version. This can be set to a specific version, '' (lowest version) or 'latest' (highest version)."
                 }
             ]
         },
@@ -433,10 +424,6 @@
                                     {
                                         "name": "DOTNET_STARTUP_PROJECT",
                                         "value": "${DOTNET_STARTUP_PROJECT}"
-                                    },
-                                    {
-                                        "name": "DOTNET_SDK_VERSION",
-                                        "value": "${DOTNET_SDK_VERSION}"
                                     }
                                 ]
                             }
@@ -655,11 +642,6 @@
                     "displayName": "Startup Project",
                     "description": "Set this to a project file (e.g. csproj) or a folder containing a single project file.",
                     "value": "src/BaGet"
-                },
-                {
-                    "name": "DOTNET_SDK_VERSION",
-                    "displayName": "SDK Version",
-                    "description": "Set this to configure the default SDK version. This can be set to a specific version, '' (lowest version) or 'latest' (highest version)."
                 }
             ]
         }

--- a/templates/dotnet-example.json
+++ b/templates/dotnet-example.json
@@ -92,10 +92,6 @@
                                 "value": "${DOTNET_STARTUP_PROJECT}"
                             },
                             {
-                                "name": "DOTNET_SDK_VERSION",
-                                "value": "${DOTNET_SDK_VERSION}"
-                            },
-                            {
                                 "name": "DOTNET_ASSEMBLY_NAME",
                                 "value": "${DOTNET_ASSEMBLY_NAME}"
                             },
@@ -299,12 +295,6 @@
             "description": "A secret string used to configure the Generic webhook.",
             "generate": "expression",
             "from": "[a-zA-Z0-9]{40}"
-        },
-        {
-            "name": "DOTNET_SDK_VERSION",
-            "displayName": "SDK Version",
-            "description": "Set this to configure the default SDK version. This can be set to a specific version, '' (lowest version) or 'latest' (highest version).",
-            "value": ""
         },
         {
             "name": "DOTNET_STARTUP_PROJECT",

--- a/templates/dotnet-pgsql-persistent.json
+++ b/templates/dotnet-pgsql-persistent.json
@@ -108,10 +108,6 @@
                                 "value": "${DOTNET_STARTUP_PROJECT}"
                             },
                             {
-                                "name": "DOTNET_SDK_VERSION",
-                                "value": "${DOTNET_SDK_VERSION}"
-                            },
-                            {
                                 "name": "DOTNET_ASSEMBLY_NAME",
                                 "value": "${DOTNET_ASSEMBLY_NAME}"
                             },
@@ -479,12 +475,6 @@
             "displayName": "Startup Project",
             "description": "Set this to a project file (e.g. csproj) or a folder containing a single project file.",
             "value": "samples/MusicStore"
-        },
-        {
-            "name": "DOTNET_SDK_VERSION",
-            "displayName": "SDK Version",
-            "description": "Set this to configure the default SDK version. This can be set to a specific version, '' (lowest version) or 'latest' (highest version).",
-            "value": ""
         },
         {
             "name": "DOTNET_ASSEMBLY_NAME",

--- a/templates/dotnet-runtime-example.json
+++ b/templates/dotnet-runtime-example.json
@@ -102,10 +102,6 @@
                                 "value": "${DOTNET_STARTUP_PROJECT}"
                             },
                             {
-                                "name": "DOTNET_SDK_VERSION",
-                                "value": "${DOTNET_SDK_VERSION}"
-                            },
-                            {
                                 "name": "DOTNET_ASSEMBLY_NAME",
                                 "value": "${DOTNET_ASSEMBLY_NAME}"
                             },
@@ -388,12 +384,6 @@
             "displayName": "Startup Project",
             "description": "Set this to the folder containing your startup project.",
             "value": "app"
-        },
-        {
-            "name": "DOTNET_SDK_VERSION",
-            "displayName": "SDK Version",
-            "description": "Set this to configure the default SDK version. This can be set to a specific version, '' (lowest version) or 'latest' (highest version).",
-            "value": ""
         },
         {
             "name": "DOTNET_ASSEMBLY_NAME",


### PR DESCRIPTION
This removes installing multiple SDKs by default in the build images. It also updates the test framework to align with this.

I left in the DOTNET_SDK_VERSION var, and adjusted how it is used in the s2i assemble script, to make it easier for users who want to install older/multiple SDKs themselves. We could trim that out as well, but then users would have to create their own version of the assemble script if they wanted to support multiple SDKs. Still up for removing it is there is consensus about it.