### PR TITLE
 Update dockerfiles for new dotnet versions.

### DIFF
--- a/1.0/Dockerfile.rhel7
+++ b/1.0/Dockerfile.rhel7
@@ -22,7 +22,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 1.0 applic
 LABEL name="dotnet/dotnetcore-10-rhel7" \
       com.redhat.component="rh-dotnetcore10-container" \
       version="1.0" \
-      release="45" \
+      release="46" \
       architecture="x86_64"
 
 COPY ./root/usr/bin /usr/bin

--- a/1.1/Dockerfile.rhel7
+++ b/1.1/Dockerfile.rhel7
@@ -22,7 +22,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 1.1 applic
 LABEL name="dotnet/dotnetcore-11-rhel7" \
       com.redhat.component="rh-dotnetcore11-container" \
       version="1.1" \
-      release="36" \
+      release="37" \
       architecture="x86_64"
 
 COPY ./root/usr/bin /usr/bin

--- a/2.1/build/Dockerfile.rhel7
+++ b/2.1/build/Dockerfile.rhel7
@@ -12,7 +12,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 2.1 applic
 LABEL name="dotnet/dotnet-21-rhel7" \
       com.redhat.component="rh-dotnet21-container" \
       version="2.1" \
-      release="17" \
+      release="18" \
       architecture="x86_64"
 
 # Labels consumed by Eclipse JBoss OpenShift plugin
@@ -48,8 +48,8 @@ ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8" \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version
-    LatestPatchVersionForAspNetCoreApp2_1=2.1.9 \
-    LatestPatchVersionForAspNetCoreAll2_1=2.1.9
+    LatestPatchVersionForAspNetCoreApp2_1=2.1.10 \
+    LatestPatchVersionForAspNetCoreAll2_1=2.1.10
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -129,10 +129,10 @@ test_image() {
   local working_dir=$(docker_run ${IMAGE_NAME} pwd)
   assert_equal "${working_dir}" "/opt/app-root/src"
   local env=$(docker_run ${IMAGE_NAME} env)
-  assert_contains "${env}" "HOME=/opt/app-root"$
+  assert_contains "${env}" "HOME=/opt/app-root$"
 
   # Verify the `dotnet watch` command can detect file changes in the container.
-  assert_contains "${env}" "DOTNET_USE_POLLING_FILE_WATCHER=true"$
+  assert_contains "${env}" "DOTNET_USE_POLLING_FILE_WATCHER=true$"
 
   # verify npm is available
   local image_npm_version=$(docker_run ${IMAGE_NAME} 'npm --version')

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -31,8 +31,8 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
 # Versions of Microsoft.AspNetCore.{All,App} packages that are known by latest RHEL sdk.
-aspnet_latest_app_version=2.1.9
-aspnet_latest_all_version=2.1.9
+aspnet_latest_app_version=2.1.10
+aspnet_latest_all_version=2.1.10
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 # sdk version supported on CentOS
 sdk_version=2.1.503
@@ -40,7 +40,7 @@ aspnet_latest_app_version=2.1.7
 aspnet_latest_all_version=2.1.7
 else
 # sdk version supported on RHEL
-sdk_version=2.1.505
+sdk_version=2.1.506
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
@@ -129,10 +129,10 @@ test_image() {
   local working_dir=$(docker_run ${IMAGE_NAME} pwd)
   assert_equal "${working_dir}" "/opt/app-root/src"
   local env=$(docker_run ${IMAGE_NAME} env)
-  assert_contains "${env}" "HOME=/opt/app-root"$'\n'
+  assert_contains "${env}" "HOME=/opt/app-root"$
 
   # Verify the `dotnet watch` command can detect file changes in the container.
-  assert_contains "${env}" "DOTNET_USE_POLLING_FILE_WATCHER=true"$'\n'
+  assert_contains "${env}" "DOTNET_USE_POLLING_FILE_WATCHER=true"$
 
   # verify npm is available
   local image_npm_version=$(docker_run ${IMAGE_NAME} 'npm --version')
@@ -325,7 +325,7 @@ test_config_1() {
   # DOTNET_RM_SRC=true
   # The application folder contains a file and folder that starts with a '.', we verify that *all* files are removed.
   assert_contains "${s2i_build}" "Removing sources..."
-  assert_contains "${src_folder_content}" "."$'\n'".."
+  assert_not_contains "${src_folder_content}" "[^.]"
 }
 
 test_config_2() {

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -73,8 +73,8 @@ You can specify the startup project by adding an '.s2i/environment' file to the 
 The source repository contains the following projects:
 - proj1/proj1.csproj
 - proj2/proj2.fsproj
-Update the '.s2i/environment' file to specify the project you want to publish, for example DOTNET_STARTUP_PROJECT=proj1/proj1.csproj"
-  assert_contains "${s2i_build}" "${expected}"
+Update the '.s2i/environment' file to specify the project you want to publish, for example DOTNET_STARTUP_PROJECT=proj1/proj1.csproj."
+  assert_contains_multiline "${s2i_build}" "${expected}"
 }
 
 test_s2i_sdk_version()
@@ -321,7 +321,7 @@ test_config_1() {
   # DOTNET_TOOLS=dotnet-watch@2.1.0-preview1-final dotnet-serve
   assert_equal "${watch_path}" "/opt/app-root/.dotnet/tools/dotnet-watch"
   assert_equal "${serve_path}" "/opt/app-root/.dotnet/tools/dotnet-serve"
-  assert_contains "${s2i_build}" "Tool 'dotnet-watch' (version '2.1.0-preview1-final') was successfully installed."
+  assert_contains "${s2i_build}" "Tool 'dotnet-watch' \(version '2.1.0-preview1-final'\) was successfully installed."
   # DOTNET_RM_SRC=true
   # The application folder contains a file and folder that starts with a '.', we verify that *all* files are removed.
   assert_contains "${s2i_build}" "Removing sources..."
@@ -354,16 +354,16 @@ test_config_2() {
   ## Environment
   assert_contains "${s2i_build}" "Environment:"
   assert_contains "${s2i_build}" "DOTNET_VERBOSITY=detailed"
-  # DOTNET_RESTORE_DISABLE_PARALLEL=true                                                                                                                                     
+  # DOTNET_RESTORE_DISABLE_PARALLEL=true
   assert_contains "${s2i_build}" "Running non-parallel restore"
   ## Test project restore
-  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/test/test1/test1.csproj" on node 1 (Restore target(s)).'
+  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/test/test1/test1.csproj" on node 1 \(Restore target\(s\)\).'
   ## Test project test
-  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/test/test1/test1.csproj" on node 1 (VSTest target(s)).'
+  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/test/test1/test1.csproj" on node 1 \(VSTest target\(s\)\).'
   ## App project restore
-  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/src/app/app.csproj" on node 1 (Restore target(s)).'
+  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/src/app/app.csproj" on node 1 \(Restore target\(s\)\).'
   ## App project publish
-  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/src/app/app.csproj" on node 1 (Publish target(s)).'
+  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/src/app/app.csproj" on node 1 \(Publish target\(s\)\).'
 }
 
 test_config() {

--- a/2.1/build/test/testcommon
+++ b/2.1/build/test/testcommon
@@ -23,17 +23,24 @@ assert_contains() {
   local actual="$1"
   local expected="$2"
 
-  if ! echo "${actual}" | grep -q "${expected}"; then
+  if ! echo "${actual}" | grep -qP "${expected}"; then
     error "'${actual}' does not contain '${expected}'"
     exit 1
   fi
 }
 
+assert_contains_multiline() {
+  local actual=$(echo "$1" | tr -d '\r' | tr '\n' ' ')
+  local expected=$(echo "$2" | tr -d '\r' | tr '\n' ' ')
+
+  assert_contains "${actual}" "${expected}"
+
+}
 assert_not_contains() {
   local actual="$1"
   local unexpected="$2"
 
-  if echo "${actual}" | grep -q "${unexpected}"; then
+  if echo "${actual}" | grep -qP "${unexpected}"; then
     error "'${actual}' contains '${unexpected}'"
     exit 1
   fi

--- a/2.1/runtime/Dockerfile.rhel7
+++ b/2.1/runtime/Dockerfile.rhel7
@@ -26,7 +26,7 @@ LABEL io.k8s.description="Platform for running .NET Core 2.1 applications" \
 LABEL name="dotnet/dotnet-21-runtime-rhel7" \
       com.redhat.component="rh-dotnet21-runtime-container" \
       version="2.1" \
-      release="16" \
+      release="18" \
       architecture="x86_64"
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.

--- a/2.1/runtime/test/run
+++ b/2.1/runtime/test/run
@@ -36,7 +36,7 @@ test_dotnet() {
   assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Host"
   assert_contains "$(docker run --rm ${IMAGE_NAME} dotnet)" "Usage: dotnet"
   # Check version
-  assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version: ${dotnet_version}"$
+  assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version: ${dotnet_version}$"
 }
 
 test_envvars() {

--- a/2.1/runtime/test/run
+++ b/2.1/runtime/test/run
@@ -26,7 +26,7 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
 dotnet_version_series="2.1"
-dotnet_version_suffix="302"
+dotnet_version_suffix="10"
 dotnet_version="${dotnet_version_series}.${dotnet_version_suffix}"
 
 test_dotnet() {
@@ -36,7 +36,7 @@ test_dotnet() {
   assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Host"
   assert_contains "$(docker run --rm ${IMAGE_NAME} dotnet)" "Usage: dotnet"
   # Check version
-  assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version  : ${dotnet_version}"$'\r\n'
+  assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version: ${dotnet_version}"$
 }
 
 test_envvars() {

--- a/2.1/runtime/test/testcommon
+++ b/2.1/runtime/test/testcommon
@@ -23,17 +23,24 @@ assert_contains() {
   local actual="$1"
   local expected="$2"
 
-  if ! echo "${actual}" | grep -q "${expected}"; then
+  if ! echo "${actual}" | grep -qP "${expected}"; then
     error "'${actual}' does not contain '${expected}'"
     exit 1
   fi
+}
+
+assert_contains_multiline() {
+  local actual=$(echo "$1" | tr -d '\r' | tr '\n' ' ')
+  local expected=$(echo "$2" | tr -d '\r' | tr '\n' ' ')
+
+  assert_contains "${actual}" "${expected}"
 }
 
 assert_not_contains() {
   local actual="$1"
   local unexpected="$2"
 
-  if echo "${actual}" | grep -q "${unexpected}"; then
+  if echo "${actual}" | grep -qP "${unexpected}"; then
     error "'${actual}' contains '${unexpected}'"
     exit 1
   fi

--- a/2.2/build/Dockerfile.rhel7
+++ b/2.2/build/Dockerfile.rhel7
@@ -12,7 +12,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 2.2 applic
 LABEL name="dotnet/dotnet-22-rhel7" \
       com.redhat.component="rh-dotnet22-container" \
       version="2.2" \
-      release="7" \
+      release="8" \
       architecture="x86_64"
 
 # Labels consumed by Eclipse JBoss OpenShift plugin
@@ -48,8 +48,8 @@ ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8" \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version
-    LatestPatchVersionForAspNetCoreApp2_2=2.2.3 \
-    LatestPatchVersionForAspNetCoreAll2_2=2.2.3
+    LatestPatchVersionForAspNetCoreApp2_2=2.2.4 \
+    LatestPatchVersionForAspNetCoreAll2_2=2.2.4
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.2/build/test/run
+++ b/2.2/build/test/run
@@ -130,10 +130,10 @@ test_image() {
   local working_dir=$(docker_run ${IMAGE_NAME} pwd)
   assert_equal "${working_dir}" "/opt/app-root/src"
   local env=$(docker_run ${IMAGE_NAME} env)
-  assert_contains "${env}" "HOME=/opt/app-root"$
+  assert_contains "${env}" "HOME=/opt/app-root$"
 
   # Verify the `dotnet watch` command can detect file changes in the container.
-  assert_contains "${env}" "DOTNET_USE_POLLING_FILE_WATCHER=true"$
+  assert_contains "${env}" "DOTNET_USE_POLLING_FILE_WATCHER=true$"
 
   # verify npm is available
   local image_npm_version=$(docker_run ${IMAGE_NAME} 'npm --version')

--- a/2.2/build/test/run
+++ b/2.2/build/test/run
@@ -74,8 +74,8 @@ You can specify the startup project by adding an '.s2i/environment' file to the 
 The source repository contains the following projects:
 - proj1/proj1.csproj
 - proj2/proj2.fsproj
-Update the '.s2i/environment' file to specify the project you want to publish, for example DOTNET_STARTUP_PROJECT=proj1/proj1.csproj"
-  assert_contains "${s2i_build}" "${expected}"
+Update the '.s2i/environment' file to specify the project you want to publish, for example DOTNET_STARTUP_PROJECT=proj1/proj1.csproj."
+  assert_contains_multiline "${s2i_build}" "${expected}"
 }
 
 test_s2i_sdk_version()
@@ -322,7 +322,7 @@ test_config_1() {
   # DOTNET_TOOLS=dotnet-watch@2.2.0 dotnet-serve
   assert_equal "${watch_path}" "/opt/app-root/.dotnet/tools/dotnet-watch"
   assert_equal "${serve_path}" "/opt/app-root/.dotnet/tools/dotnet-serve"
-  assert_contains "${s2i_build}" "Tool 'dotnet-watch' (version '2.2.0') was successfully installed."
+  assert_contains "${s2i_build}" "Tool 'dotnet-watch' \(version '2.2.0'\) was successfully installed."
   # DOTNET_RM_SRC=true
   # The application folder contains a file and folder that starts with a '.', we verify that *all* files are removed.
   assert_contains "${s2i_build}" "Removing sources..."
@@ -355,16 +355,16 @@ test_config_2() {
   ## Environment
   assert_contains "${s2i_build}" "Environment:"
   assert_contains "${s2i_build}" "DOTNET_VERBOSITY=detailed"
-  # DOTNET_RESTORE_DISABLE_PARALLEL=true                                                                                                                                     
+  # DOTNET_RESTORE_DISABLE_PARALLEL=true
   assert_contains "${s2i_build}" "Running non-parallel restore"
   ## Test project restore
-  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/test/test1/test1.csproj" on node 1 (Restore target(s)).'
+  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/test/test1/test1.csproj" on node 1 \(Restore target\(s\)\).'
   ## Test project test
-  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/test/test1/test1.csproj" on node 1 (VSTest target(s)).'
+  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/test/test1/test1.csproj" on node 1 \(VSTest target\(s\)\).'
   ## App project restore
-  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/src/app/app.csproj" on node 1 (Restore target(s)).'
+  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/src/app/app.csproj" on node 1 \(Restore target\(s\)\).'
   ## App project publish
-  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/src/app/app.csproj" on node 1 (Publish target(s)).'
+  assert_contains "${s2i_build}" 'Project "/opt/app-root/src/src/app/app.csproj" on node 1 \(Publish target\(s\)\).'
 }
 
 test_config() {

--- a/2.2/build/test/run
+++ b/2.2/build/test/run
@@ -32,8 +32,8 @@ source ${test_dir}/testcommon
 
 # Versions of Microsoft.AspNetCore.{All,App} packages that are known by latest RHEL sdk.
 # TODO: update latest patch versions below
-aspnet_latest_app_version=2.2.3
-aspnet_latest_all_version=2.2.3
+aspnet_latest_app_version=2.2.4
+aspnet_latest_all_version=2.2.4
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 # sdk version supported on CentOS
 sdk_version=2.2.103
@@ -41,7 +41,7 @@ aspnet_latest_app_version=2.2.1
 aspnet_latest_all_version=2.2.1
 else
 # sdk version supported on RHEL
-sdk_version=2.2.105
+sdk_version=2.2.106
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
@@ -130,10 +130,10 @@ test_image() {
   local working_dir=$(docker_run ${IMAGE_NAME} pwd)
   assert_equal "${working_dir}" "/opt/app-root/src"
   local env=$(docker_run ${IMAGE_NAME} env)
-  assert_contains "${env}" "HOME=/opt/app-root"$'\n'
+  assert_contains "${env}" "HOME=/opt/app-root"$
 
   # Verify the `dotnet watch` command can detect file changes in the container.
-  assert_contains "${env}" "DOTNET_USE_POLLING_FILE_WATCHER=true"$'\n'
+  assert_contains "${env}" "DOTNET_USE_POLLING_FILE_WATCHER=true"$
 
   # verify npm is available
   local image_npm_version=$(docker_run ${IMAGE_NAME} 'npm --version')
@@ -326,7 +326,7 @@ test_config_1() {
   # DOTNET_RM_SRC=true
   # The application folder contains a file and folder that starts with a '.', we verify that *all* files are removed.
   assert_contains "${s2i_build}" "Removing sources..."
-  assert_contains "${src_folder_content}" "."$'\n'".."
+  assert_not_contains "${src_folder_content}" "[^.]"
 }
 
 test_config_2() {

--- a/2.2/build/test/testcommon
+++ b/2.2/build/test/testcommon
@@ -23,17 +23,24 @@ assert_contains() {
   local actual="$1"
   local expected="$2"
 
-  if ! echo "${actual}" | grep -q "${expected}"; then
+  if ! echo "${actual}" | grep -qP "${expected}"; then
     error "'${actual}' does not contain '${expected}'"
     exit 1
   fi
+}
+
+assert_contains_multiline() {
+  local actual=$(echo "$1" | tr -d '\r' | tr '\n' ' ')
+  local expected=$(echo "$2" | tr -d '\r' | tr '\n' ' ')
+
+  assert_contains "${actual}" "${expected}"
 }
 
 assert_not_contains() {
   local actual="$1"
   local unexpected="$2"
 
-  if echo "${actual}" | grep -q "${unexpected}"; then
+  if echo "${actual}" | grep -qP "${unexpected}"; then
     error "'${actual}' contains '${unexpected}'"
     exit 1
   fi

--- a/2.2/runtime/Dockerfile.rhel7
+++ b/2.2/runtime/Dockerfile.rhel7
@@ -26,7 +26,7 @@ LABEL io.k8s.description="Platform for running .NET Core 2.2 applications" \
 LABEL name="dotnet/dotnet-22-runtime-rhel7" \
       com.redhat.component="rh-dotnet22-runtime-container" \
       version="2.2" \
-      release="6" \
+      release="8" \
       architecture="x86_64"
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.

--- a/2.2/runtime/test/run
+++ b/2.2/runtime/test/run
@@ -36,7 +36,7 @@ test_dotnet() {
   assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Host"
   assert_contains "$(docker run --rm ${IMAGE_NAME} dotnet)" "Usage: dotnet"
   # Check version
-  assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version: ${dotnet_version}"$
+  assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version: ${dotnet_version}$"
 }
 
 test_envvars() {

--- a/2.2/runtime/test/run
+++ b/2.2/runtime/test/run
@@ -26,7 +26,7 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
 dotnet_version_series="2.2"
-dotnet_version_suffix="105"
+dotnet_version_suffix="4"
 dotnet_version="${dotnet_version_series}.${dotnet_version_suffix}"
 
 test_dotnet() {
@@ -36,7 +36,7 @@ test_dotnet() {
   assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Host"
   assert_contains "$(docker run --rm ${IMAGE_NAME} dotnet)" "Usage: dotnet"
   # Check version
-  assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version  : ${dotnet_version}"$'\r\n'
+  assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version: ${dotnet_version}"$
 }
 
 test_envvars() {

--- a/2.2/runtime/test/testcommon
+++ b/2.2/runtime/test/testcommon
@@ -23,17 +23,24 @@ assert_contains() {
   local actual="$1"
   local expected="$2"
 
-  if ! echo "${actual}" | grep -q "${expected}"; then
+  if ! echo "${actual}" | grep -qP "${expected}"; then
     error "'${actual}' does not contain '${expected}'"
     exit 1
   fi
+}
+
+assert_contains_multiline() {
+  local actual=$(echo "$1" | tr -d '\r' | tr '\n' ' ')
+  local expected=$(echo "$2" | tr -d '\r' | tr '\n' ' ')
+
+  assert_contains "${actual}" "${expected}"
 }
 
 assert_not_contains() {
   local actual="$1"
   local unexpected="$2"
 
-  if echo "${actual}" | grep -q "${unexpected}"; then
+  if echo "${actual}" | grep -qP "${unexpected}"; then
     error "'${actual}' contains '${unexpected}'"
     exit 1
   fi


### PR DESCRIPTION
Update Dockerfiles and tests for new dotnet versions, which include:

2.1.10 Runtime
2.1.10 ASP.NET Core
2.1.506 SDK
2.2.4 Runtime
2.2.4 ASP.Net Core
2.2.106 SDK

This also includes a version bump to the older versions for a new CVE respin.

This also fixes some tests for the 2.1 and 2.2 containers that would always pass because of how grep handles a literal newline in the regular expression.