### PR TITLE
Install rh-nodejs10 instead of rh-nodejs8.

### DIFF
--- a/2.1/build/Dockerfile
+++ b/2.1/build/Dockerfile
@@ -26,7 +26,7 @@ USER 0
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
-    INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1 rsync" && \
+    INSTALL_PKGS="rh-nodejs10-npm rh-nodejs10-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1 rsync" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
@@ -43,7 +43,7 @@ WORKDIR /opt/app-root/src
 # the permissions on those too.
 RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
-ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8" \
+ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs10" \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version

--- a/2.1/build/Dockerfile.rhel7
+++ b/2.1/build/Dockerfile.rhel7
@@ -25,7 +25,7 @@ USER 0
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
 COPY ./s2i/bin/ /usr/libexec/s2i
 
-RUN INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1 rsync" && \
+RUN INSTALL_PKGS="rh-nodejs10-npm rh-nodejs10-nodejs-nodemon rh-dotnet21-dotnet-sdk-2.1 rsync" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \
@@ -44,7 +44,7 @@ WORKDIR /opt/app-root/src
 # the permissions on those too.
 RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
-ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8" \
+ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs10" \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -36,7 +36,7 @@ source ${test_dir}/testcommon
 # Versions of Microsoft.AspNetCore.{All,App} packages that are known by latest RHEL sdk.
 aspnet_latest_app_version=2.1.11
 aspnet_latest_all_version=2.1.11
-npm_version=5.6.0
+npm_version=6.4.1
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 # sdk version supported on CentOS
 sdk_version=2.1.505

--- a/2.2/build/Dockerfile
+++ b/2.2/build/Dockerfile
@@ -26,7 +26,7 @@ USER 0
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
-    INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet22-dotnet-sdk-2.2 rsync" && \
+    INSTALL_PKGS="rh-nodejs10-npm rh-nodejs10-nodejs-nodemon rh-dotnet22-dotnet-sdk-2.2 rsync" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
@@ -43,7 +43,7 @@ WORKDIR /opt/app-root/src
 # the permissions on those too.
 RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
-ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8" \
+ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs10" \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version

--- a/2.2/build/Dockerfile.rhel7
+++ b/2.2/build/Dockerfile.rhel7
@@ -25,7 +25,7 @@ USER 0
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
 COPY ./s2i/bin/ /usr/libexec/s2i
 
-RUN INSTALL_PKGS="rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-dotnet22-dotnet-sdk-2.2 rsync" && \
+RUN INSTALL_PKGS="rh-nodejs10-npm rh-nodejs10-nodejs-nodemon rh-dotnet22-dotnet-sdk-2.2 rsync" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \
@@ -44,7 +44,7 @@ WORKDIR /opt/app-root/src
 # the permissions on those too.
 RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
-ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs8" \
+ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs10" \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version

--- a/2.2/build/s2i/bin/run
+++ b/2.2/build/s2i/bin/run
@@ -6,7 +6,7 @@ if [ "$DEV_MODE" == true ]; then
     # Also ignore '.s2i' since we can't handle changes in there.
     # note: nodemon ignores the following folders by default: '.git', '.nyc_output',
     #         '.sass-cache', 'bower_components', 'coverage', 'node_modules'.
-    DEV_MODE_IGNORE="bin obj wwwroot .s2i"
+    DEV_MODE_IGNORE="bin/ obj/ wwwroot/ .s2i/"
     for IGNORE in $DEV_MODE_IGNORE; do
         NODEMON_OPTIONS="$NODEMON_OPTIONS --ignore $IGNORE"
     done

--- a/2.2/build/test/run
+++ b/2.2/build/test/run
@@ -137,7 +137,7 @@ test_image() {
 
   # verify npm is available
   local image_npm_version=$(docker_run ${IMAGE_NAME} 'npm --version')
-  assert_equal "${image_npm_version}" "5.6.0"
+  assert_equal "${image_npm_version}" "6.4.1"
 }
 
 test_consoleapp() {


### PR DESCRIPTION
rh-nodejs8 does not update its modules, which can have critical CVEs against them.

It is also going EOL soon.

So this will install rh-nodejs10, and should update all of the tests to work with the new version of npm that comes with it.