### PR TITLE
Fix condition in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,7 +70,7 @@ build_image() {
   local path=$1
   local docker_filename=$2
   local name=$3
-  if $FORCE -o ! image_exists ${name}; then
+  if $FORCE || ! image_exists ${name}; then
     echo "Building Docker image ${name} ..."
     if [ ! -d "${path}" ]; then
       echo "No directory found at given location '${path}'. Skipping this image."


### PR DESCRIPTION
build.sh should use '||' not '-o'. Surprisingly, works correctly in 3 out of 4 use cases anyway. :/

-o should only be used inside of '[ ]'