### PR TITLE
Run first actions by invoking 'dotnet help' in build Dockerfile

### DIFF
--- a/3.0/build/Dockerfile
+++ b/3.0/build/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir /opt/app-root/src
 WORKDIR /opt/app-root/src
 
 # Trigger first time actions.
-RUN scl enable rh-dotnet30 -- dotnet help
+RUN dotnet help
 
 # Since $HOME is set to /opt/app-root, the yum install may have created config
 # directories (such as ~/.pki/nssdb) there. These will be owned by root and can

--- a/3.0/build/Dockerfile
+++ b/3.0/build/Dockerfile
@@ -38,6 +38,9 @@ RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
 RUN mkdir /opt/app-root/src
 WORKDIR /opt/app-root/src
 
+# Trigger first time actions.
+RUN scl enable rh-dotnet30 -- dotnet help
+
 # Since $HOME is set to /opt/app-root, the yum install may have created config
 # directories (such as ~/.pki/nssdb) there. These will be owned by root and can
 # cause actions that work on all of /opt/app-root to fail. So we need to fix

--- a/3.0/build/Dockerfile.rhel7
+++ b/3.0/build/Dockerfile.rhel7
@@ -40,7 +40,7 @@ RUN mkdir /opt/app-root/src
 WORKDIR /opt/app-root/src
 
 # Trigger first time actions.
-RUN scl enable rh-dotnet30 -- dotnet help
+RUN dotnet help
 
 # Since $HOME is set to /opt/app-root, the yum install may have created config
 # directories (such as ~/.pki/nssdb) there. These will be owned by root and can

--- a/3.0/build/Dockerfile.rhel7
+++ b/3.0/build/Dockerfile.rhel7
@@ -39,6 +39,9 @@ RUN INSTALL_PKGS="rh-nodejs10-npm rh-nodejs10-nodejs-nodemon rh-dotnet22-dotnet-
 RUN mkdir /opt/app-root/src
 WORKDIR /opt/app-root/src
 
+# Trigger first time actions.
+RUN scl enable rh-dotnet30 -- dotnet help
+
 # Since $HOME is set to /opt/app-root, the yum install may have created config
 # directories (such as ~/.pki/nssdb) there. These will be owned by root and can
 # cause actions that work on all of /opt/app-root to fail. So we need to fix

--- a/3.0/build/Dockerfile.rhel8
+++ b/3.0/build/Dockerfile.rhel8
@@ -37,6 +37,9 @@ RUN INSTALL_PKGS="npm nodejs-nodemon dotnet-sdk-2.1 rsync procps-ng findutils" &
 RUN mkdir /opt/app-root/src
 WORKDIR /opt/app-root/src
 
+# Trigger first time actions.
+RUN dotnet help
+
 # Since $HOME is set to /opt/app-root, the yum install may have created config
 # directories (such as ~/.pki/nssdb) there. These will be owned by root and can
 # cause actions that work on all of /opt/app-root to fail. So we need to fix

--- a/3.0/build/test/run
+++ b/3.0/build/test/run
@@ -131,6 +131,10 @@ test_image() {
   # verify npm is available
   local image_npm_version=$(docker_run ${IMAGE_NAME} 'npm --version')
   assert_equal "${image_npm_version}" "${npm_version}"
+
+  # verify First time actions have occurred.
+  local dotnet_help=$(docker_run ${IMAGE_NAME} 'dotnet help')
+  assert_not_contains "${dotnet_help}" "Welcome"
 }
 
 test_consoleapp() {

--- a/3.0/build/test/run
+++ b/3.0/build/test/run
@@ -132,7 +132,7 @@ test_image() {
   local image_npm_version=$(docker_run ${IMAGE_NAME} 'npm --version')
   assert_equal "${image_npm_version}" "${npm_version}"
 
-  # verify First time actions have occurred.
+  # verify no 'Welcome' message appears, due to running first time actions in build Dockerfile.
   local dotnet_help=$(docker_run ${IMAGE_NAME} 'dotnet help')
   assert_not_contains "${dotnet_help}" "Welcome"
 }

--- a/3.0/runtime/Dockerfile
+++ b/3.0/runtime/Dockerfile
@@ -35,9 +35,6 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 # Don't download/extract docs for nuget packages
 ENV NUGET_XMLDOC_MODE=skip
 
-# Don't do initially populate of package cache
-ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-
 ## By default, ASP.NET Core runs on port 5000. We configure it to match
 ## the container port.
 ENV ASPNETCORE_URLS=http://*:8080

--- a/3.0/runtime/Dockerfile.rhel7
+++ b/3.0/runtime/Dockerfile.rhel7
@@ -35,9 +35,6 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 # Don't download/extract docs for nuget packages
 ENV NUGET_XMLDOC_MODE=skip
 
-# Don't do initially populate of package cache
-ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-
 ## By default, ASP.NET Core runs on port 5000. We configure it to match
 ## the container port.
 ENV ASPNETCORE_URLS=http://*:8080

--- a/3.0/runtime/Dockerfile.rhel8
+++ b/3.0/runtime/Dockerfile.rhel8
@@ -33,9 +33,6 @@ LABEL name="ubi8/dotnet-30-runtime" \
 # Don't download/extract docs for nuget packages
 ENV NUGET_XMLDOC_MODE=skip
 
-# Don't do initially populate of package cache
-ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-
 ## By default, ASP.NET Core runs on port 5000. We configure it to match
 ## the container port.
 ENV ASPNETCORE_URLS=http://*:8080


### PR DESCRIPTION
The first time the .NET Core sdk is used it prints a 'Welcome' message
and generates some files and folders under ~/.dotnet.

Previous versions of .NET Core supported suppressing the message
by setting DOTNET_SKIP_FIRST_TIME_EXPERIENCE. This is no longer supported.

Fixes https://github.com/redhat-developer/s2i-dotnetcore/issues/296