### PR TITLE
Update Dockerfiles and tests for new dotnet versions, which include:

### DIFF
--- a/2.1/build/Dockerfile.rhel7
+++ b/2.1/build/Dockerfile.rhel7
@@ -12,7 +12,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 2.1 applic
 LABEL name="dotnet/dotnet-21-rhel7" \
       com.redhat.component="rh-dotnet21-container" \
       version="2.1" \
-      release="19" \
+      release="27" \
       architecture="x86_64"
 
 # Labels consumed by Eclipse JBoss OpenShift plugin
@@ -48,8 +48,8 @@ ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs10" \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version
-    LatestPatchVersionForAspNetCoreApp2_1=2.1.11 \
-    LatestPatchVersionForAspNetCoreAll2_1=2.1.11
+    LatestPatchVersionForAspNetCoreApp2_1=2.1.13 \
+    LatestPatchVersionForAspNetCoreAll2_1=2.1.13
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.1/build/Dockerfile.rhel8
+++ b/2.1/build/Dockerfile.rhel8
@@ -6,13 +6,14 @@ ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/node_m
     STI_SCRIPTS_PATH=/usr/libexec/s2i
 
 LABEL io.k8s.description="Platform for building and running .NET Core 2.1 applications" \
-      io.openshift.tags="builder,.net,dotnet,dotnetcore,dotnet-21"
+      io.openshift.tags="builder,.net,dotnet,dotnetcore,dotnet-21" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 
 # Labels consumed by Red Hat build service
 LABEL name="ubi8/dotnet-21" \
       com.redhat.component="dotnet-21-container" \
       version="2.1" \
-      release="13" \
+      release="34" \
       architecture="x86_64"
 
 # Labels consumed by Eclipse JBoss OpenShift plugin
@@ -45,8 +46,8 @@ RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 # Needed for the `dotnet watch` to detect changes in a container
 ENV  DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version
-    LatestPatchVersionForAspNetCoreApp2_1=2.1.11 \
-    LatestPatchVersionForAspNetCoreAll2_1=2.1.11
+    LatestPatchVersionForAspNetCoreApp2_1=2.1.13 \
+    LatestPatchVersionForAspNetCoreAll2_1=2.1.13
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -52,15 +52,14 @@ aspnet_latest_app_version=2.1.9
 aspnet_latest_all_version=2.1.9
 elif [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8
-sdk_version=2.1.507
-aspnet_latest_app_version=2.1.11
-aspnet_latest_all_version=2.1.11
+sdk_version=2.1.509
+aspnet_latest_app_version=2.1.13
+aspnet_latest_all_version=2.1.13
 elif [ "$IMAGE_OS" = "RHEL7" ]; then
 # sdk version supported on RHEL7
-sdk_version=2.1.507
-aspnet_latest_app_version=2.1.11
-aspnet_latest_all_version=2.1.11
-npm_version=5.6.0
+sdk_version=2.1.509
+aspnet_latest_app_version=2.1.13
+aspnet_latest_all_version=2.1.13
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"

--- a/2.1/runtime/Dockerfile.rhel7
+++ b/2.1/runtime/Dockerfile.rhel7
@@ -26,7 +26,7 @@ LABEL io.k8s.description="Platform for running .NET Core 2.1 applications" \
 LABEL name="dotnet/dotnet-21-runtime-rhel7" \
       com.redhat.component="rh-dotnet21-runtime-container" \
       version="2.1" \
-      release="19" \
+      release="27" \
       architecture="x86_64"
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.

--- a/2.1/runtime/Dockerfile.rhel8
+++ b/2.1/runtime/Dockerfile.rhel8
@@ -20,14 +20,15 @@ LABEL io.k8s.description="Platform for running .NET Core 2.1 applications" \
       io.openshift.tags="runtime,.net,dotnet,dotnetcore,dotnet21-runtime" \
       io.openshift.expose-services="8080:http" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
-      io.s2i.scripts-url=image:///usr/libexec/s2i
+      io.s2i.scripts-url=image:///usr/libexec/s2i \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 
 
 # Labels consumed by Red Hat build service
 LABEL name="ubi8/dotnet-21-runtime" \
       com.redhat.component="dotnet-21-runtime-container" \
       version="2.1" \
-      release="13" \
+      release="34" \
       architecture="x86_64"
 
 # Don't download/extract docs for nuget packages

--- a/2.1/runtime/test/run
+++ b/2.1/runtime/test/run
@@ -42,9 +42,9 @@ dotnet_version_series=2.1
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 dotnet_version=2.1.9
 elif [ "$IMAGE_OS" = "RHEL8" ]; then
-dotnet_version=2.1.11
+dotnet_version=2.1.13
 elif [ "$IMAGE_OS" = "RHEL7" ]; then
-dotnet_version=2.1.11
+dotnet_version=2.1.13
 fi
 
 test_dotnet() {

--- a/2.2/build/Dockerfile.rhel7
+++ b/2.2/build/Dockerfile.rhel7
@@ -12,7 +12,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 2.2 applic
 LABEL name="dotnet/dotnet-22-rhel7" \
       com.redhat.component="rh-dotnet22-container" \
       version="2.2" \
-      release="9" \
+      release="16" \
       architecture="x86_64"
 
 # Labels consumed by Eclipse JBoss OpenShift plugin
@@ -48,8 +48,8 @@ ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs10" \
 # Needed for the `dotnet watch` to detect changes in a container.
     DOTNET_USE_POLLING_FILE_WATCHER=true \
 # Make all sdks aware of the latest ASP.NET Core version
-    LatestPatchVersionForAspNetCoreApp2_2=2.2.5 \
-    LatestPatchVersionForAspNetCoreAll2_2=2.2.5
+    LatestPatchVersionForAspNetCoreApp2_2=2.2.7 \
+    LatestPatchVersionForAspNetCoreAll2_2=2.2.7
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.2/build/test/run
+++ b/2.2/build/test/run
@@ -49,9 +49,9 @@ aspnet_latest_app_version=2.2.3
 aspnet_latest_all_version=2.2.3
 elif [ "$IMAGE_OS" = "RHEL7" ]; then
 # sdk version supported on RHEL7
-sdk_version=2.2.107
-aspnet_latest_app_version=2.2.5
-aspnet_latest_all_version=2.2.5
+sdk_version=2.2.109
+aspnet_latest_app_version=2.2.7
+aspnet_latest_all_version=2.2.7
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"

--- a/2.2/runtime/Dockerfile.rhel7
+++ b/2.2/runtime/Dockerfile.rhel7
@@ -26,7 +26,7 @@ LABEL io.k8s.description="Platform for running .NET Core 2.2 applications" \
 LABEL name="dotnet/dotnet-22-runtime-rhel7" \
       com.redhat.component="rh-dotnet22-runtime-container" \
       version="2.2" \
-      release="9" \
+      release="16" \
       architecture="x86_64"
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.

--- a/2.2/runtime/test/run
+++ b/2.2/runtime/test/run
@@ -40,7 +40,7 @@ dotnet_version_series="2.2"
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 dotnet_version="2.2.3"
 elif [ "$IMAGE_OS" = "RHEL7" ]; then
-dotnet_version="2.2.5"
+dotnet_version="2.2.7"
 fi
 
 test_dotnet() {


### PR DESCRIPTION
Update Dockerfiles and tests for new dotnet versions, which include:

2.1.13 runtime
2.1.13 ASP.NET Core
2.1.509 SDK
2.2.7 runtime
2.2.7 ASP.NET Core
2.2.109 SDK

- - - - -

This also includes some syncing with RH containers, which includes a new label for rhel8 containers.