### PR TITLE
Change base64 option to --decode to support both Linux and Mac

### DIFF
--- a/install-imagestreams.sh
+++ b/install-imagestreams.sh
@@ -101,7 +101,7 @@ has_secret_for_registry() {
                 continue
                 ;;
         esac
-        data=$(echo "$data" | base64 -d)
+        data=$(echo "$data" | base64 --decode)
         if [[ "$data" == *"\"$registry\""* ]]; then
             return 0
         fi


### PR DESCRIPTION
As Linux utilize base64 with `-d`  for decode and Mac `-D` , I propose to change to `--decode` as it works for both platforms.

On Linux 
$ uname -a
Linux hostname 3.10.0-1062.el7.x86_64 #1 SMP Thu Jul 18 20:25:13 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
$
 base64 --help
Usage: base64 [OPTION]... [FILE]
Base64 encode or decode FILE, or standard input, to standard output.

Mandatory arguments to long options are mandatory for short options too.
   **-d, --decode          decode data** 
  -i, --ignore-garbage  when decoding, ignore non-alphabet characters
  -w, --wrap=COLS       wrap encoded lines after COLS character (default 76).
                          Use 0 to disable line wrapping

      --help     display this help and exit
      --version  output version information and exit

On Mac
$ uname -a
Darwin ovpn-112-11.ams2.redhat.com 18.7.0 Darwin Kernel Version 18.7.0: Tue Aug 20 16:57:14 PDT 2019; root:xnu-4903.271.2~2/RELEASE_X86_64 x86_64

$ base64 --help
Usage:	base64 [-hvD] [-b num] [-i in_file] [-o out_file]
  -h, --help     display this message
  **-D, --decode   decodes input**
  -b, --break    break encoded string into num character lines
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)