### PR TITLE
Remove LatestPatchVersionForAspNetCore* ENV vars and update expected versions for tests.

### DIFF
--- a/2.1/build/Dockerfile
+++ b/2.1/build/Dockerfile
@@ -45,10 +45,7 @@ RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
 ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs10" \
 # Needed for the `dotnet watch` to detect changes in a container.
-    DOTNET_USE_POLLING_FILE_WATCHER=true \
-# Make all sdks aware of the latest ASP.NET Core version
-    LatestPatchVersionForAspNetCoreApp2_1=2.1.14 \
-    LatestPatchVersionForAspNetCoreAll2_1=2.1.14
+    DOTNET_USE_POLLING_FILE_WATCHER=true
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.1/build/Dockerfile.rhel7
+++ b/2.1/build/Dockerfile.rhel7
@@ -46,10 +46,7 @@ RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
 ENV ENABLED_COLLECTIONS="$ENABLED_COLLECTIONS rh-nodejs10" \
 # Needed for the `dotnet watch` to detect changes in a container.
-    DOTNET_USE_POLLING_FILE_WATCHER=true \
-# Make all sdks aware of the latest ASP.NET Core version
-    LatestPatchVersionForAspNetCoreApp2_1=2.1.15 \
-    LatestPatchVersionForAspNetCoreAll2_1=2.1.15
+    DOTNET_USE_POLLING_FILE_WATCHER=true
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.1/build/Dockerfile.rhel8
+++ b/2.1/build/Dockerfile.rhel8
@@ -44,10 +44,7 @@ WORKDIR /opt/app-root/src
 RUN chown -R 1001:0 /opt/app-root && fix-permissions /opt/app-root
 
 # Needed for the `dotnet watch` to detect changes in a container
-ENV  DOTNET_USE_POLLING_FILE_WATCHER=true \
-# Make all sdks aware of the latest ASP.NET Core version
-    LatestPatchVersionForAspNetCoreApp2_1=2.1.15 \
-    LatestPatchVersionForAspNetCoreAll2_1=2.1.15
+ENV  DOTNET_USE_POLLING_FILE_WATCHER=true
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -43,25 +43,23 @@ OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
-npm_version=6.4.1
+npm_version=6.13.4
 
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 # sdk version supported on CentOS
 sdk_version=2.1.510
 aspnet_latest_app_version=2.1.14
 aspnet_latest_all_version=2.1.14
-npm_version=6.9.0
 elif [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8
-sdk_version=2.1.511
-aspnet_latest_app_version=2.1.15
-aspnet_latest_all_version=2.1.15
-npm_version=6.9.0
+sdk_version=2.1.513
+aspnet_latest_app_version=2.1.17
+aspnet_latest_all_version=2.1.17
 elif [ "$IMAGE_OS" = "RHEL7" ]; then
 # sdk version supported on RHEL7
-sdk_version=2.1.511
-aspnet_latest_app_version=2.1.15
-aspnet_latest_all_version=2.1.15
+sdk_version=2.1.513
+aspnet_latest_app_version=2.1.17
+aspnet_latest_all_version=2.1.17
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -48,18 +48,12 @@ npm_version=6.13.4
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 # sdk version supported on CentOS
 sdk_version=2.1.510
-aspnet_latest_app_version=2.1.14
-aspnet_latest_all_version=2.1.14
 elif [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8
 sdk_version=2.1.513
-aspnet_latest_app_version=2.1.17
-aspnet_latest_all_version=2.1.17
 elif [ "$IMAGE_OS" = "RHEL7" ]; then
 # sdk version supported on RHEL7
 sdk_version=2.1.513
-aspnet_latest_app_version=2.1.17
-aspnet_latest_all_version=2.1.17
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
@@ -606,39 +600,6 @@ test_certificates() {
   assert_equal "$count_with_additional" "$(($default_count + 4))"
 }
 
-test_aspnet_implicit_using_latest()
-{
-  test_start
-
-  # aspnetcoreimplicitversion contains a versionless reference
-  # to the Microsoft.AspNetCore.{App,All} packages.
-  # after the build, the assemble script prints out the resolved versions.
-  local app=aspnetcoreimplicitversion
-  local image=$(s2i_image_tag ${app})
-
-  # verify the versionless references resolved to the latest version.
-  # build image
-  local s2i_build=$(s2i_build_output_log ${app} ${image})
-  # cleanup
-  docker_rmi ${image}
-
-  assert_contains "${s2i_build}" '"Microsoft.AspNetCore.All": "'${aspnet_latest_all_version}'"'
-  assert_contains "${s2i_build}" '"Microsoft.AspNetCore.App": "'${aspnet_latest_app_version}'"'
-
-  # verify aspnet_latest_{app,all}_version have the correct values.
-  # If this fails, the variables in the test and environment variables in the Dockerfiles must be updated.
-  if [ "$IMAGE_OS" != "CENTOS" ]; then
-    info verifying aspnet_latest_{app,all}
-
-    # build image
-    s2i_build=$(s2i_build_output_log ${app} ${image} -e LatestPatchVersionForAspNetCoreApp2_1='' -e LatestPatchVersionForAspNetCoreAll2_1='')
-    # cleanup
-    docker_rmi ${image}
-
-    assert_contains "${s2i_build}" '"Microsoft.AspNetCore.All": "'${aspnet_latest_all_version}'"'
-    assert_contains "${s2i_build}" '"Microsoft.AspNetCore.App": "'${aspnet_latest_app_version}'"'
-  fi
-}
 
 test_binary()
 {
@@ -724,7 +685,6 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_config
   test_usage
   test_s2i_sdk_version $sdk_version
-  test_aspnet_implicit_using_latest
   test_consoleapp
   test_multiframework
   test_fsharp


### PR DESCRIPTION
These were added when there were multiple supported ASP.NET Core versions supported in a single container, which is no longer the case.