### PR TITLE
copr repo no longer needed for installing .NET Core on Fedora image

### DIFF
--- a/3.1/runtime/Dockerfile.fedora
+++ b/3.1/runtime/Dockerfile.fedora
@@ -46,9 +46,7 @@ COPY ./root/usr/bin /usr/bin
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
 COPY ./s2i/bin/ /usr/libexec/s2i
 
-RUN dnf install -y 'dnf-command(copr)' && \
-    dnf copr -y enable @dotnet-sig/dotnet-preview && \
-    INSTALL_PKGS="aspnetcore-runtime-3.1 nss_wrapper tar unzip findutils" && \
+RUN INSTALL_PKGS="aspnetcore-runtime-3.1 nss_wrapper tar unzip findutils" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \


### PR DESCRIPTION
cc @omajid 