### PR TITLE
Use declarative object configuration for k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ used with newer versions of .NET Core.
 If a template is not on your OpenShift installation, you can import it:
 
 ```
-oc create -f <template.json>
+oc apply -f <template.json>
 ```
 
 To instantiate a template you can use the `oc new-app` command:
@@ -160,7 +160,7 @@ ASP.NET Core NuGet packages. Using these streams results in improved build speed
 
 You can add these imagestreams by running:
 ```
-oc create -f https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/templates/aspnet-2.x.json
+oc apply -f https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/templates/aspnet-2.x.json
 ```
 
 After the file is imported in OpenShift, OpenShift will build the `aspnet:2.1` images. This will take a few minutes. Once that is

--- a/install-imagestreams.ps1
+++ b/install-imagestreams.ps1
@@ -119,25 +119,6 @@ function GetCurrentNamespace()
     }
 }
 
-function HasDotnetImagestreams()
-{
-    $exitcode, $stdout, $stderr = Execute "oc.exe" "get -n $Namespace is dotnet"
-
-    If ($exitcode -ne 0)
-    {
-        If ($stderr -like '*NotFound*')
-        {
-            return $false
-        }
-        Else
-        {
-            throw "Cannot determine if the project already contains dotnet imagestreams."
-        }
-    }
-
-    return $true
-}
-
 function HasSecretForRegistry()
 {
     $exitcode, $stdout, $stderr = Execute "oc.exe" "get secret -o name -n $namespace"
@@ -263,13 +244,5 @@ If ( $create_secret -eq $true)
 }
 
 # Install/update imagestreams
-If (HasDotnetImagestreams)
-{
-    Say "Updating image streams:"
-    ExecuteCheckSuccess "oc.exe" "replace -n $namespace -f $imagestreams_url"
-}
-Else
-{
-    Say "Installing image streams:"
-    ExecuteCheckSuccess "oc.exe" "create -n $namespace -f $imagestreams_url"
-}
+Say "Updating image streams:"
+ExecuteCheckSuccess "oc.exe" "apply -n $namespace -f $imagestreams_url"

--- a/install-imagestreams.sh
+++ b/install-imagestreams.sh
@@ -68,18 +68,6 @@ get_current_namespace() {
     echo "$project"
 }
 
-has_dotnet_imagestream() {
-    local streams;
-    if ! streams=$(oc get -n "$namespace" is dotnet 2>&1); then
-        if [[ "$streams" == *"NotFound"* ]]; then
-            return 1
-        fi
-        say_err "Cannot determine if the project already contains dotnet imagestreams."
-        exit 1
-    fi
-    return 0
-}
-
 has_secret_for_registry() {
     local secret_names;
     if ! secret_names=$(oc get secret -o name -n "$namespace"); then
@@ -265,10 +253,5 @@ if [ "$create_secret" == true ]; then
 fi
 
 # Install/update imagestreams
-if has_dotnet_imagestream; then
-    say "Updating image streams:"
-    oc replace -n "$namespace" -f "$imagestreams_url"
-else
-    say "Installing image streams:"
-    oc create -n "$namespace" -f "$imagestreams_url"
-fi
+say "Updating image streams:"
+oc apply -n "$namespace" -f "$imagestreams_url"


### PR DESCRIPTION
Kubernetes has 3 separate modes: `create`/`replace` are imperative mode and `apply` is declarative mode. (The third mode is imperative commands like `kubectl create`/`kubectl run`/`kubectl set`).

`oc apply` (or `kubectl apply`) is similar to `oc create` or `oc replace`, with one advantage being that it mutates the user's current setup. It doesn't error out like `oc create` if the objects alreadyexist. Unlike `oc replace`, the user's current setup is not deleted: apply retains observed changes.

`kubectl apply` is the recommended way to manage applications: https://kubernetes.io/docs/reference/kubectl/cheatsheet/#apply

For a comparison and advantages/disadvantages of imperative vs declarative approach, see: https://kubernetes.io/docs/concepts/overview/working-with-objects/object-management/