### PR TITLE
Enable use of 'dotnet' in Dockerfile RUN instructions on scl-based images.

### DIFF
--- a/2.1/build/test/testcommon
+++ b/2.1/build/test/testcommon
@@ -41,15 +41,15 @@ fi
 
 _PODMAN_PATH=$(command -v podman)
 _DOCKER_PATH=$(command -v docker)
-if [ -f "$_DOCKER_PATH" ] && [[ "$(docker --version)" != *podman* ]]; then
-  info "Using docker"
-  USING_PODMAN=""
-elif [ -f "$_PODMAN_PATH" ]; then
+if [ -f "$_PODMAN_PATH" ]; then
   info "Using podman"
   docker() {
     $_PODMAN_PATH "$@"
   }
   USING_PODMAN=y
+elif [ -f "$_DOCKER_PATH" ]; then
+  info "Using docker"
+  USING_PODMAN=""
 else
   error "docker/podman are not on PATH. Please install podman or docker."
   exit 1

--- a/2.1/runtime/Dockerfile
+++ b/2.1/runtime/Dockerfile
@@ -48,6 +48,9 @@ COPY ./contrib/ /opt/app-root
 
 COPY ./root/usr/bin /usr/bin
 
+# Make dotnet command available even when scl is not enabled.
+RUN ln -s /opt/app-root/etc/scl_enable_dotnet /usr/bin/dotnet
+
 RUN yum install -y centos-release-dotnet && \
     INSTALL_PKGS="rh-dotnet21-dotnet-runtime-2.1 nss_wrapper tar unzip" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/2.1/runtime/Dockerfile.rhel7
+++ b/2.1/runtime/Dockerfile.rhel7
@@ -48,6 +48,9 @@ COPY ./contrib/ /opt/app-root
 
 COPY ./root/usr/bin /usr/bin
 
+# Make dotnet command available even when scl is not enabled.
+RUN ln -s /opt/app-root/etc/scl_enable_dotnet /usr/bin/dotnet
+
 RUN INSTALL_PKGS="rh-dotnet21-dotnet-runtime-2.1 nss_wrapper tar unzip" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \

--- a/2.1/runtime/contrib/etc/scl_enable_dotnet
+++ b/2.1/runtime/contrib/etc/scl_enable_dotnet
@@ -1,0 +1,3 @@
+#!/usr/bin/sh
+
+scl enable ${ENABLED_COLLECTIONS} -- dotnet "$@"

--- a/2.1/runtime/test/run
+++ b/2.1/runtime/test/run
@@ -174,6 +174,28 @@ EOF
   popd >/dev/null
 }
 
+test_run_dotnet_in_dockerfile() {
+  test_start
+
+  pushd ${test_dir}/dockerfile-run-dotnet >/dev/null
+
+  # build image from Dockerfile that uses the 'dotnet' command on a RUN instruction.
+  cat >Dockerfile <<EOF
+FROM ${IMAGE_NAME}
+RUN dotnet --info
+EOF
+  local image=$(docker_build .)
+  local output=$(docker_run ${image})
+
+  # cleanup
+  docker_rmi ${image}
+
+  # verify the image build produced a working image
+  assert_contains "$output" "This is a runtime image for .NET Core"
+
+  popd >/dev/null
+}
+
 test_s2i_usage() {
   test_start
 
@@ -216,6 +238,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_aspnet
   test_s2i_usage
   test_s2i_build
+  test_run_dotnet_in_dockerfile
 fi
 
 if [ "$STOP_ON_ERROR" != "true" ]; then

--- a/2.1/runtime/test/testcommon
+++ b/2.1/runtime/test/testcommon
@@ -41,15 +41,15 @@ fi
 
 _PODMAN_PATH=$(command -v podman)
 _DOCKER_PATH=$(command -v docker)
-if [ -f "$_DOCKER_PATH" ] && [[ "$(docker --version)" != *podman* ]]; then
-  info "Using docker"
-  USING_PODMAN=""
-elif [ -f "$_PODMAN_PATH" ]; then
+if [ -f "$_PODMAN_PATH" ]; then
   info "Using podman"
   docker() {
     $_PODMAN_PATH "$@"
   }
   USING_PODMAN=y
+elif [ -f "$_DOCKER_PATH" ]; then
+  info "Using docker"
+  USING_PODMAN=""
 else
   error "docker/podman are not on PATH. Please install podman or docker."
   exit 1

--- a/3.1/build/test/run
+++ b/3.1/build/test/run
@@ -51,6 +51,7 @@ npm_version=6.9.0
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 # sdk version supported on CentOS
 sdk_version=3.1.100
+npm_version=6.13.4
 elif [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8
 sdk_version=3.1.101

--- a/3.1/build/test/testcommon
+++ b/3.1/build/test/testcommon
@@ -41,15 +41,15 @@ fi
 
 _PODMAN_PATH=$(command -v podman)
 _DOCKER_PATH=$(command -v docker)
-if [ -f "$_DOCKER_PATH" ] && [[ "$(docker --version)" != *podman* ]]; then
-  info "Using docker"
-  USING_PODMAN=""
-elif [ -f "$_PODMAN_PATH" ]; then
+if [ -f "$_PODMAN_PATH" ]; then
   info "Using podman"
   docker() {
     $_PODMAN_PATH "$@"
   }
   USING_PODMAN=y
+elif [ -f "$_DOCKER_PATH" ]; then
+  info "Using docker"
+  USING_PODMAN=""
 else
   error "docker/podman are not on PATH. Please install podman or docker."
   exit 1

--- a/3.1/runtime/Dockerfile
+++ b/3.1/runtime/Dockerfile
@@ -45,6 +45,9 @@ COPY ./contrib/ /opt/app-root
 
 COPY ./root/usr/bin /usr/bin
 
+# Make dotnet command available even when scl is not enabled.
+RUN ln -s /opt/app-root/etc/scl_enable_dotnet /usr/bin/dotnet
+
 RUN yum install -y centos-release-dotnet && \
     INSTALL_PKGS="rh-dotnet31-aspnetcore-runtime-3.1 nss_wrapper tar unzip" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/3.1/runtime/Dockerfile.rhel7
+++ b/3.1/runtime/Dockerfile.rhel7
@@ -45,6 +45,9 @@ COPY ./contrib/ /opt/app-root
 
 COPY ./root/usr/bin /usr/bin
 
+# Make dotnet command available even when scl is not enabled.
+RUN ln -s /opt/app-root/etc/scl_enable_dotnet /usr/bin/dotnet
+
 RUN INSTALL_PKGS="rh-dotnet31-aspnetcore-runtime-3.1 nss_wrapper tar unzip" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \

--- a/3.1/runtime/contrib/etc/scl_enable_dotnet
+++ b/3.1/runtime/contrib/etc/scl_enable_dotnet
@@ -1,0 +1,3 @@
+#!/usr/bin/sh
+
+scl enable ${ENABLED_COLLECTIONS} -- dotnet "$@"

--- a/3.1/runtime/test/run
+++ b/3.1/runtime/test/run
@@ -175,6 +175,28 @@ EOF
   popd >/dev/null
 }
 
+test_run_dotnet_in_dockerfile() {
+  test_start
+
+  pushd ${test_dir}/dockerfile-run-dotnet >/dev/null
+
+  # build image from Dockerfile that uses the 'dotnet' command on a RUN instruction.
+  cat >Dockerfile <<EOF
+FROM ${IMAGE_NAME}
+RUN dotnet --info
+EOF
+  local image=$(docker_build .)
+  local output=$(docker_run ${image})
+
+  # cleanup
+  docker_rmi ${image}
+
+  # verify the image build produced a working image
+  assert_contains "$output" "This is a runtime image for .NET Core"
+
+  popd >/dev/null
+}
+
 test_s2i_usage() {
   test_start
 
@@ -217,6 +239,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_aspnet
   test_s2i_usage
   test_s2i_build
+  test_run_dotnet_in_dockerfile
 fi
 
 if [ "$STOP_ON_ERROR" != "true" ]; then

--- a/3.1/runtime/test/testcommon
+++ b/3.1/runtime/test/testcommon
@@ -41,15 +41,15 @@ fi
 
 _PODMAN_PATH=$(command -v podman)
 _DOCKER_PATH=$(command -v docker)
-if [ -f "$_DOCKER_PATH" ] && [[ "$(docker --version)" != *podman* ]]; then
-  info "Using docker"
-  USING_PODMAN=""
-elif [ -f "$_PODMAN_PATH" ]; then
+if [ -f "$_PODMAN_PATH" ]; then
   info "Using podman"
   docker() {
     $_PODMAN_PATH "$@"
   }
   USING_PODMAN=y
+elif [ -f "$_DOCKER_PATH" ]; then
+  info "Using docker"
+  USING_PODMAN=""
 else
   error "docker/podman are not on PATH. Please install podman or docker."
   exit 1


### PR DESCRIPTION
The 'dotnet' command cannot be used directly from Dockerfile RUN instructions
because the scl is not enabled.

This adds a script named 'dotnet' on PATH which enables the scl and invoke
'dotnet' in it. Once the scl is enabled, the 'dotnet' host takes preference
over the script because it is earlier on the PATH variable.