### PR TITLE
Restructure imagestreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For example, to install the `rhel7` based images and add a secret for authentica
 ```sh
 $ wget https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/install-imagestreams.sh
 $ chmod +x install-imagestreams.sh
-$ ./install-imagestreams.sh --os rhel7 -u <subscription_username> -p <subscription_password>
+$ ./install-imagestreams.sh --os rhel -u <subscription_username> -p <subscription_password>
 ```
 
 You can run `./install-imagestreams.sh --help` for more information.
@@ -59,11 +59,11 @@ You can run `./install-imagestreams.sh --help` for more information.
 
 script: https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/install-imagestreams.ps1
 
-For example, to install the `rhel7` based images and add a secret for authenticating against the `registry.redhat.io` registry:
+For example, to install the `rhel` based images and add a secret for authenticating against the `registry.redhat.io` registry:
 
 ```sh
 PS > Invoke-WebRequest https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/install-imagestreams.ps1 -UseBasicParsing -OutFile install-imagestreams.ps1
-PS > .\install-imagestreams.ps1 -OS rhel7 -User <subscription_username> -Password <subscription_password>
+PS > .\install-imagestreams.ps1 -OS rhel -User <subscription_username> -Password <subscription_password>
 ```
 
 Running scripts may be prohibited by the `ExecutionPolicy`, you can relax the policy by running: `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force`

--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -23,7 +23,7 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core (Latest)",
-                            "description": "Build and run .NET Core applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
+                            "description": "Build and run .NET Core applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore",
                             "supports": "dotnet",
@@ -36,13 +36,34 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "3.1"
+                            "name": "3.1-ubi8"
                         }
                     },
                     {
-                        "name": "3.1",
+                        "name": "3.1-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core 3.1",
+                            "openshift.io/display-name": ".NET Core 3.1 (UBI 8)",
+                            "description": "Build and run .NET Core 3.1 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,dotnet31",
+                            "supports": "dotnet:3.1,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-3.1",
+                            "version": "3.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-31:3.1"
+                        }
+                    },
+                    {
+                        "name": "3.1-el7",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 3.1 (RHEL 7)",
                             "description": "Build and run .NET Core 3.1 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet31",
@@ -61,12 +82,75 @@
                         }
                     },
                     {
+                        "name": "3.1",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 3.1",
+                            "description": "Build and run .NET Core 3.1 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet31,hidden",
+                            "supports": "dotnet:3.1,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-3.1",
+                            "version": "3.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/dotnet/dotnet-31-rhel7:3.1"
+                        }
+                    },
+                    {
+                        "name": "2.1-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 2.1 (UBI 8)",
+                            "description": "Build and run .NET Core 2.1 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,dotnet21",
+                            "supports": "dotnet:2.1,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-2.1",
+                            "version": "2.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-21:2.1"
+                        }
+                    },
+                    {
+                        "name": "2.1-el7",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 2.1 (RHEL 7)",
+                            "description": "Build and run .NET Core 2.1 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet21",
+                            "supports": "dotnet:2.1,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-2.1",
+                            "version": "2.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/dotnet/dotnet-21-rhel7:2.1"
+                        }
+                    },
+                    {
                         "name": "2.1",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.1",
                             "description": "Build and run .NET Core 2.1 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet21",
+                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet21,hidden",
                             "supports": "dotnet:2.1,dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
                             "sampleContextDir": "app",
@@ -99,7 +183,7 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core Runtime (Latest)",
-                            "description": "Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+                            "description": "Run .NET Core applications on UBI. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime"
@@ -109,13 +193,31 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "3.1"
+                            "name": "3.1-ubi8"
                         }
                     },
                     {
-                        "name": "3.1",
+                        "name": "3.1-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core 3.1 Runtime",
+                            "openshift.io/display-name": ".NET Core 3.1 Runtime (UBI 8)",
+                            "description": "Run .NET Core applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports": "dotnet-runtime",
+                            "version": "3.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-31-runtime:3.1"
+                        }
+                    },
+                    {
+                        "name": "3.1-el7",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 3.1 Runtime (RHEL 7)",
                             "description": "Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
@@ -131,12 +233,66 @@
                         }
                     },
                     {
+                        "name": "3.1",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 3.1 Runtime",
+                            "description": "Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "supports": "dotnet-runtime",
+                            "version": "3.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/dotnet/dotnet-31-runtime-rhel7:3.1"
+                        }
+                    },
+                    {
+                        "name": "2.1-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 2.1 Runtime (UBI 8)",
+                            "description": "Run .NET Core applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports": "dotnet-runtime",
+                            "version": "2.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-21-runtime:2.1"
+                        }
+                    },
+                    {
+                        "name": "2.1-el7",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 2.1 Runtime (RHEL 7)",
+                            "description": "Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports": "dotnet-runtime",
+                            "version": "2.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/dotnet/dotnet-21-runtime-rhel7:2.1"
+                        }
+                    },
+                    {
                         "name": "2.1",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.1 Runtime",
                             "description": "Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
                             "supports": "dotnet-runtime",
                             "version": "2.1"
                         },

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -23,7 +23,7 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core (Latest)",
-                            "description": "Build and run .NET Core applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
+                            "description": "Build and run .NET Core applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore",
                             "supports": "dotnet",
@@ -33,13 +33,34 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "3.1"
+                            "name": "3.1-ubi8"
                         }
                     },
                     {
-                        "name": "3.1",
+                        "name": "3.1-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core 3.1",
+                            "openshift.io/display-name": ".NET Core 3.1 (UBI 8)",
+                            "description": "Build and run .NET Core 3.1 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,dotnet31",
+                            "supports": "dotnet:3.1,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-3.1",
+                            "version": "3.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-31:3.1"
+                        }
+                    },
+                    {
+                        "name": "3.1-el7",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 3.1 (CentOS 7)",
                             "description": "Build and run .NET Core 3.1 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet31",
@@ -55,12 +76,69 @@
                         }
                     },
                     {
+                        "name": "3.1",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 3.1",
+                            "description": "Build and run .NET Core 3.1 applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet31,hidden",
+                            "supports": "dotnet:3.1,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-3.1",
+                            "version": "3.1"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.centos.org/dotnet/dotnet-31-centos7:latest"
+                        }
+                    },
+                    {
+                        "name": "2.1-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 2.1 (UBI 8)",
+                            "description": "Build and run .NET Core 2.1 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,dotnet21",
+                            "supports": "dotnet:2.1,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-2.1",
+                            "version": "2.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-21:2.1"
+                        }
+                    },
+                    {
+                        "name": "2.1-el7",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 2.1 (CentOS 7)",
+                            "description": "Build and run .NET Core 2.1 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet21",
+                            "supports": "dotnet:2.1,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-2.1",
+                            "version": "2.1"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.centos.org/dotnet/dotnet-21-centos7:latest"
+                        }
+                    },
+                    {
                         "name": "2.1",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.1",
                             "description": "Build and run .NET Core 2.1 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet21",
+                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet21,hidden",
                             "supports": "dotnet:2.1,dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
                             "sampleContextDir": "app",
@@ -97,13 +175,31 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "3.1"
+                            "name": "3.1-ubi8"
                         }
                     },
                     {
-                        "name": "3.1",
+                        "name": "3.1-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core 3.1 Runtime",
+                            "openshift.io/display-name": ".NET Core 3.1 Runtime (UBI 8)",
+                            "description": "Run .NET Core applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports": "dotnet-runtime",
+                            "version": "3.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-31-runtime:3.1"
+                        }
+                    },
+                    {
+                        "name": "3.1-el7",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 3.1 Runtime (CentOS 7)",
                             "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
@@ -116,12 +212,60 @@
                         }
                     },
                     {
+                        "name": "3.1",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 3.1 Runtime",
+                            "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "supports": "dotnet-runtime",
+                            "version": "3.1"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.centos.org/dotnet/dotnet-31-runtime-centos7:latest"
+                        }
+                    },
+                    {
+                        "name": "2.1-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 2.1 Runtime (UBI 8)",
+                            "description": "Run .NET Core applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports": "dotnet-runtime",
+                            "version": "2.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-21-runtime:2.1"
+                        }
+                    },
+                    {
+                        "name": "2.1-el7",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Core 2.1 Runtime (CentOS 7)",
+                            "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports": "dotnet-runtime",
+                            "version": "2.1"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.centos.org/dotnet/dotnet-21-runtime-centos7:latest"
+                        }
+                    },
+                    {
                         "name": "2.1",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.1 Runtime",
                             "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
                             "supports": "dotnet-runtime",
                             "version": "2.1"
                         },

--- a/install-imagestreams.ps1
+++ b/install-imagestreams.ps1
@@ -5,12 +5,12 @@
 .DESCRIPTION
     Install/Update/Remove .NET Core S2I streams.
 
-    Credentials are required for the pulling the rhel7 images. If the project does not contain a secret
+    Credentials are required for the pulling the RHEL images. If the project does not contain a secret
     for pulling the images yet, you can add one by specifying the '-User' and '-Password' options.
     For more information see: https://access.redhat.com/articles/3399531.
 
 .PARAMETER OS
-    Installs image streams based on this distro ('rhel7', 'rhel8', 'centos7', or 'fedora').
+    Installs image streams based on this distro ('rhel', 'centos', or 'fedora').
 
 .PARAMETER Namespace
     Namespace to add imagestreams to. Defaults to current 'oc' project.
@@ -29,9 +29,9 @@
     https://github.com/redhat-developer/s2i-dotnetcore
 
 .EXAMPLE
-    .\install-imagestreams -OS rhel8
+    .\install-imagestreams -OS rhel
 
-    Install RHEL8 based image streams into the current OpenShift 'oc' project.
+    Install RHEL based image streams into the current OpenShift 'oc' project.
 
 .EXAMPLE
 
@@ -203,23 +203,24 @@ if($Remove.IsPresent)
 }
 
 # The OS parameter is required.
-switch ( $OS )
+switch -wildcard ( $OS )
 {
-    "centos7"
+    "centos*"
     {
         $imagestreams_url = "https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/dotnet_imagestreams_centos.json"
         $registry_requires_auth = $false
-    }
-    "rhel7"
-    {
-        $imagestreams_url = "https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/dotnet_imagestreams.json"
-        $registry_requires_auth = $true
-        $registry="registry.redhat.io"
     }
     "rhel8"
     {
         $imagestreams_url = "https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/dotnet_imagestreams_rhel8.json"
         $registry_requires_auth = $false
+        break
+    }
+    "rhel*"
+    {
+        $imagestreams_url = "https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/dotnet_imagestreams.json"
+        $registry_requires_auth = $true
+        $registry="registry.redhat.io"
     }
     "fedora"
     {
@@ -228,7 +229,7 @@ switch ( $OS )
     }
     default
     {
-        throw "Unsupported value for --os: $OS. Valid values are 'centos7', 'rhel7', 'rhel8', and 'fedora'."
+        throw "Unsupported value for --os: $OS. Valid values are 'centos', 'rhel', and 'fedora'."
     }
 }
 

--- a/install-imagestreams.sh
+++ b/install-imagestreams.sh
@@ -45,7 +45,7 @@ show_help() {
     echo "$script_name is a script for installing/updating/removing .NET S2I streams."
     echo ""
     echo "Options:"
-    echo "  --o,--os                           Installs image streams based on this distro ('rhel7', 'rhel8', 'centos7', or 'fedora')."
+    echo "  --o,--os                           Installs image streams based on this distro ('rhel', 'centos', or 'fedora')."
     echo "  --i,--imagestreams                 Installs the imagestreams from the given path."
     echo "  --n,--namespace                    Namespace to add imagestreams to. Defaults to current 'oc' project."
     echo "                                     Set this to 'openshift' to install globally (requires admin priviledges)."
@@ -54,7 +54,7 @@ show_help() {
     echo "  --p,--password                     Password for pulling images from the registry."
     echo "  -?,--?,-h,--help                   Shows this help message."
     echo ""
-    echo "Credentials are required for the pulling the rhel7 images. If the project does not contain a secret"
+    echo "Credentials are required for the pulling the RHEL images. If the project does not contain a secret"
     echo "for pulling the images yet, you can add one by specifying the '--user' and '--password' options."
     echo "For more information see: https://access.redhat.com/articles/3399531."
 }
@@ -151,25 +151,25 @@ do
             shift
             os=$(echo "$1" | tr '[:upper:]' '[:lower:]')
             case "$os" in
-            "centos7")
+            "centos*")
                 imagestreams_url="https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/dotnet_imagestreams_centos.json"
                 registry_requires_auth=false
-                ;;
-            "rhel7")
-                imagestreams_url="https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/dotnet_imagestreams.json"
-                registry_requires_auth=true
-                registry="registry.redhat.io"
                 ;;
             "rhel8")
                 imagestreams_url="https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/dotnet_imagestreams_rhel8.json"
                 registry_requires_auth=false
+                ;;
+            "rhel*")
+                imagestreams_url="https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/dotnet_imagestreams.json"
+                registry_requires_auth=true
+                registry="registry.redhat.io"
                 ;;
             "fedora")
                 imagestreams_url="https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/dotnet_imagestreams_fedora.json"
                 registry_requires_auth=false
                 ;;
             *)
-                say_err "Unsupported value for --os: '$os'. Valid values are 'centos7', 'rhel7', 'rhel8', and 'fedora'."
+                say_err "Unsupported value for --os: '$os'. Valid values are 'centos', 'rhel', and 'fedora'."
                 exit 1
                 ;;
             esac

--- a/templates/dotnet-pgsql-persistent.json
+++ b/templates/dotnet-pgsql-persistent.json
@@ -320,7 +320,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "openshift",
-                                "name": "postgresql:9.5"
+                                "name": "postgresql:9.6"
                             }
                         }
                     },

--- a/test-imagestreams.sh
+++ b/test-imagestreams.sh
@@ -13,7 +13,7 @@ usage () {
   echo " Usage:"
   echo "      $0"
   echo "      IMAGE_OS=FEDORA $0"
-  echo "      IMAGE_OS=RHEL7 REGISTRY_USERNAME=<user> REGISTRY_PASSWORD=<password> $0"
+  echo "      IMAGE_OS=RHEL REGISTRY_USERNAME=<user> REGISTRY_PASSWORD=<password> $0"
   echo ""
   echo "Test that the imagestreams file is valid by installing it into an OpenShift instance."
   echo ""
@@ -27,7 +27,7 @@ usage () {
   echo ""
   echo "IMAGE_OS            The base os image to use when building"
   echo "                    the containers."
-  echo "                    Options are CENTOS7, RHEL7, RHEL8, and"
+  echo "                    Options are CENTOS, RHEL, and"
   echo "                    FEDORA."
   echo "                    Defaults to match the OS."
   echo ""
@@ -83,22 +83,24 @@ if [[ -z "$IMAGE_OS" ]]; then
 fi
 IMAGE_OS=$(echo "$IMAGE_OS" | tr '[:upper:]' '[:lower:]')
 
-if [[ "$IMAGE_OS" = "centos7" ]]; then
+case "$IMAGE_OS" in
+"centos*")
   VERSIONS="${VERSIONS:-2.1 3.1}"
   imagestreams_file_name=dotnet_imagestreams_centos.json
-elif [[ "$IMAGE_OS" = "fedora" ]]; then
+  ;;
+"fedora")
   VERSIONS="${VERSIONS:-3.1}"
   imagestreams_file_name=dotnet_imagestreams_fedora.json
-elif [[ "$IMAGE_OS" = "rhel7" ]]; then
+  ;;
+"rhel*")
   VERSIONS="${VERSIONS:-2.1 3.1}"
   imagestreams_file_name=dotnet_imagestreams.json
-elif [[ "$IMAGE_OS" = "rhel8" ]]; then
-  VERSIONS="${VERSIONS:-2.1 3.1}"
-  imagestreams_file_name=dotnet_imagestreams_rhel8.json
-else
+  ;;
+*)
   echo 1>&2 "error: Unknown or unsupported OS '$IMAGE_OS'. Set the env var IMAGE_OS to override this."
   exit 1
-fi
+  ;;
+esac
 
 if [[ -z "${TIMEOUT:-}" ]]; then
   TIMEOUT=180


### PR DESCRIPTION
Following the pattern set by the SCLs, imagestreams are now described as
a combination of runtime and underlying OS versions. UBI 8 imagestreams
are offered alongside RHEL/CentOS 7 ones, with latest being moved to UBI 8,
and previously existing imagestream tags kept but hidden for compatibility.