### PR TITLE
Have dockerfile-run tests create their needed folders.

### DIFF
--- a/2.1/runtime/test/run
+++ b/2.1/runtime/test/run
@@ -177,7 +177,10 @@ EOF
 test_run_dotnet_in_dockerfile() {
   test_start
 
-  pushd ${test_dir}/dockerfile-run-dotnet >/dev/null
+  local build_dir="${test_dir}/dockerfile-run-dotnet"
+  rm -rf "$build_dir"
+  mkdir "$build_dir"
+  pushd "$build_dir" > /dev/null
 
   # build image from Dockerfile that uses the 'dotnet' command on a RUN instruction.
   cat >Dockerfile <<EOF

--- a/3.1/runtime/test/run
+++ b/3.1/runtime/test/run
@@ -178,7 +178,10 @@ EOF
 test_run_dotnet_in_dockerfile() {
   test_start
 
-  pushd ${test_dir}/dockerfile-run-dotnet >/dev/null
+  local build_dir="${test_dir}/dockerfile-run-dotnet"
+  rm -rf "$build_dir"
+  mkdir "$build_dir"
+  pushd "$build_dir" > /dev/null
 
   # build image from Dockerfile that uses the 'dotnet' command on a RUN instruction.
   cat >Dockerfile <<EOF


### PR DESCRIPTION
This test currently does not create its own folder, nor is that folder (being normally empty) an existing part of the file tree.

Because the test also creates a dockerfile, this has a fun side effect of overwriting the dockerfile in the base folder for the container if you run the tests from there.

This should prevent that from happening.