### PR TITLE
Mark latest imagestreams as hidden

### DIFF
--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -25,7 +25,7 @@
                             "openshift.io/display-name": ".NET Core (Latest)",
                             "description": "Build and run .NET Core applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore",
+                            "tags": "builder,.net,dotnet,dotnetcore,hidden",
                             "supports": "dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
                             "sampleContextDir": "app",

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -25,7 +25,7 @@
                             "openshift.io/display-name": ".NET Core (Latest)",
                             "description": "Build and run .NET Core applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore",
+                            "tags": "builder,.net,dotnet,dotnetcore,hidden",
                             "supports": "dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
                             "sampleContextDir": "app",

--- a/dotnet_imagestreams_fedora.json
+++ b/dotnet_imagestreams_fedora.json
@@ -25,7 +25,7 @@
                             "openshift.io/display-name": ".NET Core (Latest)",
                             "description": "Build and run .NET Core applications on Fedora. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore",
+                            "tags": "builder,.net,dotnet,dotnetcore,hidden",
                             "supports": "dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
                             "sampleContextDir": "app",

--- a/dotnet_imagestreams_rhel8.json
+++ b/dotnet_imagestreams_rhel8.json
@@ -25,7 +25,7 @@
                             "openshift.io/display-name": ".NET Core (Latest)",
                             "description": "Build and run .NET Core applications on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore",
+                            "tags": "builder,.net,dotnet,dotnetcore,hidden",
                             "supports": "dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
                             "sampleContextDir": "app",


### PR DESCRIPTION
.NET application source code includes a hardcoded version in
TargetFramework, so unlike other SCLs, using a floating tag
won't consistently work.

Closes: https://github.com/redhat-developer/s2i-dotnetcore/issues/336