### PR TITLE
test: add SKIP_VERSION_CHECK envvar

### DIFF
--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -18,7 +18,9 @@
 #
 # STOP_ON_ERROR determines if the tests should exit on encountering
 # the first error, or keep going and list all failed tests at the end.
-# Defaults to 'true', can be set to 'false'
+# Defaults to 'true', can be set to 'false'.
+#
+# SKIP_VERSION_CHECK environment variable, if 'Y', versions are not checked.
 #
 # Example usage: $ sudo ./test/run
 
@@ -106,7 +108,9 @@ test_s2i_sdk_version()
   docker_rmi ${image}
 
   # verify sdk version
-  assert_contains "${s2i_build}" "SDK Version: ${expected_version}"
+  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+    assert_contains "${s2i_build}" "SDK Version: ${expected_version}"
+  fi
 }
 
 test_s2i_usage() {
@@ -136,7 +140,9 @@ test_image() {
 
   # verify dotnet is available
   local image_dotnet_version=$(docker_run ${IMAGE_NAME} 'dotnet --version')
-  assert_equal "${image_dotnet_version}" "${sdk_version}"
+  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+    assert_equal "${image_dotnet_version}" "${sdk_version}"
+  fi
 
   # Verify $HOME != $CWD. See https://github.com/redhat-developer/s2i-dotnetcore/issues/28
   local working_dir=$(docker_run ${IMAGE_NAME} pwd)
@@ -149,7 +155,10 @@ test_image() {
 
   # verify npm is available
   local image_npm_version=$(docker_run ${IMAGE_NAME} 'npm --version')
-  assert_equal "${image_npm_version}" "${npm_version}"
+
+  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+    assert_equal "${image_npm_version}" "${npm_version}"
+  fi
 }
 
 test_consoleapp() {

--- a/2.1/build/test/run
+++ b/2.1/build/test/run
@@ -20,7 +20,7 @@
 # the first error, or keep going and list all failed tests at the end.
 # Defaults to 'true', can be set to 'false'.
 #
-# SKIP_VERSION_CHECK environment variable, if 'Y', versions are not checked.
+# SKIP_VERSION_CHECK environment variable, if 'true', versions are not checked.
 #
 # Example usage: $ sudo ./test/run
 
@@ -108,7 +108,7 @@ test_s2i_sdk_version()
   docker_rmi ${image}
 
   # verify sdk version
-  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+  if [ "$SKIP_VERSION_CHECK" != "true" ]; then
     assert_contains "${s2i_build}" "SDK Version: ${expected_version}"
   fi
 }
@@ -140,7 +140,7 @@ test_image() {
 
   # verify dotnet is available
   local image_dotnet_version=$(docker_run ${IMAGE_NAME} 'dotnet --version')
-  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+  if [ "$SKIP_VERSION_CHECK" != "true" ]; then
     assert_equal "${image_dotnet_version}" "${sdk_version}"
   fi
 
@@ -156,7 +156,7 @@ test_image() {
   # verify npm is available
   local image_npm_version=$(docker_run ${IMAGE_NAME} 'npm --version')
 
-  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+  if [ "$SKIP_VERSION_CHECK" != "true" ]; then
     assert_equal "${image_npm_version}" "${npm_version}"
   fi
 }

--- a/2.1/runtime/test/run
+++ b/2.1/runtime/test/run
@@ -15,7 +15,9 @@
 #
 # STOP_ON_ERROR determines if the tests should exit on encountering
 # the first error, or keep going and list all failed tests at the end.
-# Defaults to 'true', can be set to 'false'
+# Defaults to 'true', can be set to 'false'.
+#
+# SKIP_VERSION_CHECK environment variable, if 'Y', versions are not checked.
 #
 # Example usage: $ sudo ./test/run
 
@@ -54,7 +56,9 @@ test_dotnet() {
   assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Host"
   assert_contains "$(docker run --rm ${IMAGE_NAME} dotnet)" "Usage: dotnet"
   # Check version
-  assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version: ${dotnet_version}$"
+  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+    assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version: ${dotnet_version}$"
+  fi
 }
 
 test_envvars() {

--- a/2.1/runtime/test/run
+++ b/2.1/runtime/test/run
@@ -17,7 +17,7 @@
 # the first error, or keep going and list all failed tests at the end.
 # Defaults to 'true', can be set to 'false'.
 #
-# SKIP_VERSION_CHECK environment variable, if 'Y', versions are not checked.
+# SKIP_VERSION_CHECK environment variable, if 'true', versions are not checked.
 #
 # Example usage: $ sudo ./test/run
 
@@ -56,7 +56,7 @@ test_dotnet() {
   assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Host"
   assert_contains "$(docker run --rm ${IMAGE_NAME} dotnet)" "Usage: dotnet"
   # Check version
-  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+  if [ "$SKIP_VERSION_CHECK" != "true" ]; then
     assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version: ${dotnet_version}$"
   fi
 }

--- a/3.1/build/test/run
+++ b/3.1/build/test/run
@@ -18,7 +18,9 @@
 #
 # STOP_ON_ERROR determines if the tests should exit on encountering
 # the first error, or keep going and list all failed tests at the end.
-# Defaults to 'true', can be set to 'false'
+# Defaults to 'true', can be set to 'false'.
+#
+# SKIP_VERSION_CHECK environment variable, if 'Y', versions are not checked.
 #
 # Example usage: $ sudo ./test/run
 
@@ -125,7 +127,9 @@ test_image() {
 
   # verify dotnet is available
   local image_dotnet_version=$(docker_run ${IMAGE_NAME} 'dotnet --version')
-  assert_equal "${image_dotnet_version}" "${sdk_version}"
+  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+    assert_equal "${image_dotnet_version}" "${sdk_version}"
+  fi
 
   # Verify $HOME != $CWD. See https://github.com/redhat-developer/s2i-dotnetcore/issues/28
   local working_dir=$(docker_run ${IMAGE_NAME} pwd)
@@ -138,7 +142,9 @@ test_image() {
 
   # verify npm is available
   local image_npm_version=$(docker_run ${IMAGE_NAME} 'npm --version')
-  assert_equal "${image_npm_version}" "${npm_version}"
+  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+    assert_equal "${image_npm_version}" "${npm_version}"
+  fi
 
   # verify no 'Welcome' message appears, due to running first time actions in build Dockerfile.
   local dotnet_help=$(docker_run ${IMAGE_NAME} 'dotnet help')

--- a/3.1/build/test/run
+++ b/3.1/build/test/run
@@ -20,7 +20,7 @@
 # the first error, or keep going and list all failed tests at the end.
 # Defaults to 'true', can be set to 'false'.
 #
-# SKIP_VERSION_CHECK environment variable, if 'Y', versions are not checked.
+# SKIP_VERSION_CHECK environment variable, if 'true', versions are not checked.
 #
 # Example usage: $ sudo ./test/run
 
@@ -127,7 +127,7 @@ test_image() {
 
   # verify dotnet is available
   local image_dotnet_version=$(docker_run ${IMAGE_NAME} 'dotnet --version')
-  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+  if [ "$SKIP_VERSION_CHECK" != "true" ]; then
     assert_equal "${image_dotnet_version}" "${sdk_version}"
   fi
 
@@ -142,7 +142,7 @@ test_image() {
 
   # verify npm is available
   local image_npm_version=$(docker_run ${IMAGE_NAME} 'npm --version')
-  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+  if [ "$SKIP_VERSION_CHECK" != "true" ]; then
     assert_equal "${image_npm_version}" "${npm_version}"
   fi
 

--- a/3.1/runtime/test/run
+++ b/3.1/runtime/test/run
@@ -15,7 +15,9 @@
 #
 # STOP_ON_ERROR determines if the tests should exit on encountering
 # the first error, or keep going and list all failed tests at the end.
-# Defaults to 'true', can be set to 'false'
+# Defaults to 'true', can be set to 'false'.
+#
+# SKIP_VERSION_CHECK environment variable, if 'Y', versions are not checked.
 #
 # Example usage: $ sudo ./test/run
 
@@ -58,7 +60,9 @@ test_dotnet() {
   assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Host"
   assert_contains "$(docker run --rm ${IMAGE_NAME} dotnet)" "Usage: dotnet"
   # Check version
-  assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version: ${dotnet_version}$"
+  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+    assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version: ${dotnet_version}$"
+  fi
 }
 
 test_envvars() {

--- a/3.1/runtime/test/run
+++ b/3.1/runtime/test/run
@@ -17,7 +17,7 @@
 # the first error, or keep going and list all failed tests at the end.
 # Defaults to 'true', can be set to 'false'.
 #
-# SKIP_VERSION_CHECK environment variable, if 'Y', versions are not checked.
+# SKIP_VERSION_CHECK environment variable, if 'true', versions are not checked.
 #
 # Example usage: $ sudo ./test/run
 
@@ -60,7 +60,7 @@ test_dotnet() {
   assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Host"
   assert_contains "$(docker run --rm ${IMAGE_NAME} dotnet)" "Usage: dotnet"
   # Check version
-  if [ "$SKIP_VERSION_CHECK" != "Y" ]; then
+  if [ "$SKIP_VERSION_CHECK" != "true" ]; then
     assert_contains "$(docker_run $IMAGE_NAME "dotnet --info")" "Version: ${dotnet_version}$"
   fi
 }


### PR DESCRIPTION
The versions for Fedora/CentOS are often out-of-date
causing the test suite to fail in CI tests.

This adds an envvar to skip the version checks.