### PR TITLE
Update imagestreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This repo contains a script that helps install/upgrade/remove the imagestreams.
 
 script: https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/install-imagestreams.sh
 
-For example, to install the `rhel7` based images and add a secret for authenticating against the `registry.redhat.io` registry:
+For example, to install the `rhel` based images and add a secret for authenticating against the `registry.redhat.io` registry:
 
 ```sh
 $ wget https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/install-imagestreams.sh

--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "dotnet-image-streams",
         "annotations": {
-            "description": "ImageStream definitions for .NET Core on RHEL 7"
+            "description": "ImageStream definitions for .NET"
         }
     },
     "items": [
@@ -14,7 +14,7 @@
             "metadata": {
                 "name": "dotnet",
                 "annotations": {
-                    "openshift.io/display-name": ".NET Core"
+                    "openshift.io/display-name": ".NET"
                 }
             },
             "spec": {
@@ -22,21 +22,63 @@
                     {
                         "name": "latest",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core (Latest)",
-                            "description": "Build and run .NET Core applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
+                            "openshift.io/display-name": ".NET (Latest)",
+                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,hidden",
                             "supports": "dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-3.1"
+                            "sampleRef": "dotnet-5.0"
                         },
                         "referencePolicy": {
                             "type": "Local"
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "3.1-ubi8"
+                            "name": "5.0-ubi8"
+                        }
+                    },
+                    {
+                        "name": "5.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 5.0 (UBI 8)",
+                            "description": "Build and run .NET 5.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,dotnet50",
+                            "supports": "dotnet:5.0,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-5.0",
+                            "version": "5.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-50:5.0"
+                        }
+                    },
+                    {
+                        "name": "5.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 5.0 (UBI 8)",
+                            "description": "Build and run .NET 5.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet50,hidden",
+                            "supports": "dotnet:5.0,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-5.0",
+                            "version": "5.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-50:5.0"
                         }
                     },
                     {
@@ -47,7 +89,7 @@
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,dotnet31",
                             "supports": "dotnet:3.1,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
                             "sampleRef": "dotnetcore-3.1",
                             "version": "3.1"
@@ -68,7 +110,7 @@
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet31",
                             "supports": "dotnet:3.1,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
                             "sampleRef": "dotnetcore-3.1",
                             "version": "3.1"
@@ -84,12 +126,12 @@
                     {
                         "name": "3.1",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core 3.1",
+                            "openshift.io/display-name": ".NET Core 3.1 (RHEL 7)",
                             "description": "Build and run .NET Core 3.1 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet31,hidden",
                             "supports": "dotnet:3.1,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
                             "sampleRef": "dotnetcore-3.1",
                             "version": "3.1"
@@ -110,7 +152,7 @@
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,dotnet21",
                             "supports": "dotnet:2.1,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
                             "sampleRef": "dotnetcore-2.1",
                             "version": "2.1"
@@ -131,7 +173,7 @@
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet21",
                             "supports": "dotnet:2.1,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
                             "sampleRef": "dotnetcore-2.1",
                             "version": "2.1"
@@ -147,12 +189,12 @@
                     {
                         "name": "2.1",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core 2.1",
+                            "openshift.io/display-name": ".NET Core 2.1 (RHEL 7)",
                             "description": "Build and run .NET Core 2.1 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/build/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet21,hidden",
                             "supports": "dotnet:2.1,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
                             "sampleRef": "dotnetcore-2.1",
                             "version": "2.1"
@@ -182,8 +224,8 @@
                     {
                         "name": "latest",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core Runtime (Latest)",
-                            "description": "Run .NET Core applications on UBI. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+                            "openshift.io/display-name": ".NET Runtime (Latest)",
+                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime"
@@ -193,7 +235,43 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "3.1-ubi8"
+                            "name": "5.0-ubi8"
+                        }
+                    },
+                    {
+                        "name": "5.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 5.0 Runtime (UBI 8)",
+                            "description": "Run .NET applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports": "dotnet-runtime",
+                            "version": "5.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-50-runtime:5.0"
+                        }
+                    },
+                    {
+                        "name": "5.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 5.0 Runtime (UBI 8)",
+                            "description": "Run .NET applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "supports": "dotnet-runtime",
+                            "version": "5.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-50-runtime:5.0"
                         }
                     },
                     {

--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -42,8 +42,8 @@
                     {
                         "name": "5.0-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 5.0 (UBI 8)",
-                            "description": "Build and run .NET 5.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.",
+                            "openshift.io/display-name": ".NET 5 (UBI 8)",
+                            "description": "Build and run .NET 5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,dotnet50",
                             "supports": "dotnet:5.0,dotnet",
@@ -63,8 +63,8 @@
                     {
                         "name": "5.0",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 5.0 (UBI 8)",
-                            "description": "Build and run .NET 5.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.",
+                            "openshift.io/display-name": ".NET 5 (UBI 8)",
+                            "description": "Build and run .NET 5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet50,hidden",
                             "supports": "dotnet:5.0,dotnet",
@@ -227,7 +227,7 @@
                             "openshift.io/display-name": ".NET Runtime (Latest)",
                             "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
                             "supports": "dotnet-runtime"
                         },
                         "referencePolicy": {
@@ -241,8 +241,8 @@
                     {
                         "name": "5.0-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 5.0 Runtime (UBI 8)",
-                            "description": "Run .NET applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.",
+                            "openshift.io/display-name": ".NET 5 Runtime (UBI 8)",
+                            "description": "Run .NET 5 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime",
@@ -259,8 +259,8 @@
                     {
                         "name": "5.0",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 5.0 Runtime (UBI 8)",
-                            "description": "Run .NET applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.",
+                            "openshift.io/display-name": ".NET 5 Runtime (UBI 8)",
+                            "description": "Run .NET 5 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
                             "supports": "dotnet-runtime",
@@ -278,7 +278,7 @@
                         "name": "3.1-ubi8",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 3.1 Runtime (UBI 8)",
-                            "description": "Run .NET Core applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
+                            "description": "Run .NET Core 3.1 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime",
@@ -296,7 +296,7 @@
                         "name": "3.1-el7",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 3.1 Runtime (RHEL 7)",
-                            "description": "Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
+                            "description": "Run .NET Core 3.1 applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime",
@@ -313,8 +313,8 @@
                     {
                         "name": "3.1",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core 3.1 Runtime",
-                            "description": "Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
+                            "openshift.io/display-name": ".NET Core 3.1 Runtime (RHEL 7)",
+                            "description": "Run .NET Core 3.1 applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
                             "supports": "dotnet-runtime",
@@ -332,7 +332,7 @@
                         "name": "2.1-ubi8",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.1 Runtime (UBI 8)",
-                            "description": "Run .NET Core applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
+                            "description": "Run .NET Core 2.1 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime",
@@ -350,7 +350,7 @@
                         "name": "2.1-el7",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.1 Runtime (RHEL 7)",
-                            "description": "Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
+                            "description": "Run .NET Core 2.1 applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime",
@@ -367,8 +367,8 @@
                     {
                         "name": "2.1",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core 2.1 Runtime",
-                            "description": "Run .NET Core applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
+                            "openshift.io/display-name": ".NET Core 2.1 Runtime (RHEL 7)",
+                            "description": "Run .NET Core 2.1 applications on RHEL 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
                             "supports": "dotnet-runtime",

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "dotnet-image-streams",
         "annotations": {
-            "description": "ImageStream definitions for .NET Core on CentOS"
+            "description": "ImageStream definitions for .NET Core on CentOS (Retired)"
         }
     },
     "items": [

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "dotnet-image-streams",
         "annotations": {
-            "description": "ImageStream definitions for .NET Core on CentOS (Retired)"
+            "description": "ImageStream definitions for .NET"
         }
     },
     "items": [
@@ -14,7 +14,7 @@
             "metadata": {
                 "name": "dotnet",
                 "annotations": {
-                    "openshift.io/display-name": ".NET Core"
+                    "openshift.io/display-name": ".NET"
                 }
             },
             "spec": {
@@ -22,18 +22,63 @@
                     {
                         "name": "latest",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core (Latest)",
-                            "description": "Build and run .NET Core applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core available on OpenShift, including major versions updates.",
+                            "openshift.io/display-name": ".NET (Latest)",
+                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,hidden",
                             "supports": "dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-3.1"
+                            "sampleRef": "dotnet-5.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "3.1-ubi8"
+                            "name": "5.0-ubi8"
+                        }
+                    },
+                    {
+                        "name": "5.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 5 (UBI 8)",
+                            "description": "Build and run .NET 5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,dotnet50",
+                            "supports": "dotnet:5.0,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-5.0",
+                            "version": "5.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-50:5.0"
+                        }
+                    },
+                    {
+                        "name": "5.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 5 (UBI 8)",
+                            "description": "Build and run .NET 5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet50,hidden",
+                            "supports": "dotnet:5.0,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-5.0",
+                            "version": "5.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-50:5.0"
                         }
                     },
                     {
@@ -44,7 +89,7 @@
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,dotnet31",
                             "supports": "dotnet:3.1,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
                             "sampleRef": "dotnetcore-3.1",
                             "version": "3.1"
@@ -65,10 +110,13 @@
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet31",
                             "supports": "dotnet:3.1,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
                             "sampleRef": "dotnetcore-3.1",
                             "version": "3.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",
@@ -78,15 +126,18 @@
                     {
                         "name": "3.1",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core 3.1",
-                            "description": "Build and run .NET Core 3.1 applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.",
+                            "openshift.io/display-name": ".NET Core 3.1 (CentOS 7)",
+                            "description": "Build and run .NET Core 3.1 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/build/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet31,hidden",
                             "supports": "dotnet:3.1,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
                             "sampleRef": "dotnetcore-3.1",
                             "version": "3.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",
@@ -101,7 +152,7 @@
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,dotnet21",
                             "supports": "dotnet:2.1,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
                             "sampleRef": "dotnetcore-2.1",
                             "version": "2.1"
@@ -122,10 +173,13 @@
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet21",
                             "supports": "dotnet:2.1,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
                             "sampleRef": "dotnetcore-2.1",
                             "version": "2.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",
@@ -135,15 +189,18 @@
                     {
                         "name": "2.1",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core 2.1",
+                            "openshift.io/display-name": ".NET Core 2.1 (CentOS 7)",
                             "description": "Build and run .NET Core 2.1 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/build/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet21,hidden",
                             "supports": "dotnet:2.1,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex.git",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
                             "sampleRef": "dotnetcore-2.1",
                             "version": "2.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",
@@ -167,22 +224,61 @@
                     {
                         "name": "latest",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core Runtime (Latest)",
-                            "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+                            "openshift.io/display-name": ".NET Runtime (Latest)",
+                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
                             "supports": "dotnet-runtime"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "3.1-ubi8"
+                            "name": "5.0-ubi8"
+                        }
+                    },
+                    {
+                        "name": "5.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 5 Runtime (UBI 8)",
+                            "description": "Run .NET 5 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports": "dotnet-runtime",
+                            "version": "5.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-50-runtime:5.0"
+                        }
+                    },
+                    {
+                        "name": "5.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 5 Runtime (UBI 8)",
+                            "description": "Run .NET 5 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "supports": "dotnet-runtime",
+                            "version": "5.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-50-runtime:5.0"
                         }
                     },
                     {
                         "name": "3.1-ubi8",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 3.1 Runtime (UBI 8)",
-                            "description": "Run .NET Core applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
+                            "description": "Run .NET Core 3.1 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime",
@@ -200,11 +296,14 @@
                         "name": "3.1-el7",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 3.1 Runtime (CentOS 7)",
-                            "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
+                            "description": "Run .NET Core 3.1 applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime",
                             "version": "3.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",
@@ -214,12 +313,15 @@
                     {
                         "name": "3.1",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core 3.1 Runtime",
-                            "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
+                            "openshift.io/display-name": ".NET Core 3.1 Runtime (CentOS 7)",
+                            "description": "Run .NET Core 3.1 applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/3.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
                             "supports": "dotnet-runtime",
                             "version": "3.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",
@@ -230,7 +332,7 @@
                         "name": "2.1-ubi8",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.1 Runtime (UBI 8)",
-                            "description": "Run .NET Core applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
+                            "description": "Run .NET Core 2.1 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime",
@@ -248,11 +350,14 @@
                         "name": "2.1-el7",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 2.1 Runtime (CentOS 7)",
-                            "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
+                            "description": "Run .NET Core 2.1 applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
                             "supports": "dotnet-runtime",
                             "version": "2.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",
@@ -262,12 +367,15 @@
                     {
                         "name": "2.1",
                         "annotations": {
-                            "openshift.io/display-name": ".NET Core 2.1 Runtime",
-                            "description": "Run .NET Core applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
+                            "openshift.io/display-name": ".NET Core 2.1 Runtime (CentOS 7)",
+                            "description": "Run .NET Core 2.1 applications on CentOS 7. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.1/runtime/README.md.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
                             "supports": "dotnet-runtime",
                             "version": "2.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",

--- a/dotnet_imagestreams_fedora.json
+++ b/dotnet_imagestreams_fedora.json
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "dotnet-image-streams",
         "annotations": {
-            "description": "ImageStream definitions for .NET Core on Fedora"
+            "description": "ImageStream definitions for .NET Core on Fedora (Retired)"
         }
     },
     "items": [

--- a/dotnet_imagestreams_rhel8.json
+++ b/dotnet_imagestreams_rhel8.json
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "dotnet-image-streams",
         "annotations": {
-            "description": "ImageStream definitions for .NET Core on RHEL 8"
+            "description": "ImageStream definitions for .NET Core on RHEL 8 (Retired)"
         }
     },
     "items": [


### PR DESCRIPTION
- Add 5.0 images.

- Retire _centos, _fedora, _rhel8 in favor of dotnet_imagestreams ubi8 images.

- Drop .git from s2i-dotnetcore-ex suffix because it breaks OpenShift Console 'Edit Source Code' url
(for example: https://github.com/redhat-developer/s2i-dotnetcore-ex.git/tree/dotnet-5.0).