### PR TITLE
install-imagestreams.ps1: fix help always being printed.

### DIFF
--- a/install-imagestreams.ps1
+++ b/install-imagestreams.ps1
@@ -178,7 +178,7 @@ function HasSecretForRegistry()
     return $false
 }
 
-If ( $args.Count -eq 0 )
+If ( $PSBoundParameters.Values.Count -eq 0 )
 {
     Get-Help $PSCommandPath
     exit


### PR DESCRIPTION
Check the number of bound parameters instead of unbound arguments.

Fixes https://github.com/redhat-developer/s2i-dotnetcore/issues/346.

cc @faysou @omajid