### PR TITLE
Don't create an ASP.NET developer certificate, nor certificate store folders. [6.0]

### DIFF
--- a/6.0/build/Dockerfile.fedora
+++ b/6.0/build/Dockerfile.fedora
@@ -3,7 +3,8 @@ FROM fedora/dotnet-60-runtime
 # applications.
 
 ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/node_modules/.bin:/opt/app-root/.dotnet/tools/:${PATH} \
-    STI_SCRIPTS_PATH=/usr/libexec/s2i
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false
 
 LABEL io.k8s.description="Platform for building and running .NET 6 applications" \
       io.openshift.tags="builder,.net,dotnet,dotnetcore,dotnet-60"

--- a/6.0/build/Dockerfile.rhel8
+++ b/6.0/build/Dockerfile.rhel8
@@ -3,7 +3,8 @@ FROM ubi8/dotnet-60-runtime
 # applications.
 
 ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/node_modules/.bin:/opt/app-root/.dotnet/tools/:${PATH} \
-    STI_SCRIPTS_PATH=/usr/libexec/s2i
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false
 
 LABEL io.k8s.description="Platform for building and running .NET 6 applications" \
       io.openshift.tags="builder,.net,dotnet,dotnetcore,dotnet-60"

--- a/6.0/build/test/run
+++ b/6.0/build/test/run
@@ -138,6 +138,13 @@ test_image() {
   # verify no 'Welcome' message appears, due to running first time actions in build Dockerfile.
   local dotnet_help=$(docker_run ${IMAGE_NAME} 'dotnet help')
   assert_not_contains "${dotnet_help}" "Welcome"
+
+  # Certificate folders created by the 1001 user are not accepted by .NET
+  # when the image runs on OpenShift as another user.
+  # Ensure there are no certificate store folders.
+  # This also ensures the image doesn't include an ASP.NET Core developer certificate.
+  local certificate_stores=$(docker run --rm ${IMAGE_NAME} stat /opt/app-root/.dotnet/corefx/cryptography/x509stores 2>&1)
+  assert_contains "${certificate_stores}" "No such file or directory"
 }
 
 test_consoleapp() {


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/s2i-dotnetcore/issues/369.