### PR TITLE
Use Microsoft rc1 build

### DIFF
--- a/6.0/build/test/run
+++ b/6.0/build/test/run
@@ -45,14 +45,14 @@ OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 source ${test_dir}/testcommon
 
-npm_version=6.14.13
-
 if [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8
-sdk_version=6.0.100-preview.7.21379.14
+sdk_version=6.0.100-rc.1.21458.32
+npm_version=6.14.13
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 # sdk version supported on Fedora
-sdk_version=6.0.100-preview.7.21379.14
+sdk_version=6.0.100-rc.1.21458.32
+npm_version=6.14.15
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"

--- a/6.0/runtime/Dockerfile.fedora
+++ b/6.0/runtime/Dockerfile.fedora
@@ -53,7 +53,7 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 #     yum clean all -y && \
 # # yum cache files may still exist (and quite large in size)
 #     rm -rf /var/cache/yum/*
-RUN curl https://download.visualstudio.microsoft.com/download/pr/ce3fd989-b69d-439a-9cac-09ad40597db8/2848d49480b6e7b1b2a18cfa46d724e2/dotnet-sdk-6.0.100-preview.7.21379.14-linux-x64.tar.gz -o /tmp/dotnet.tar.gz && \
+RUN curl https://download.visualstudio.microsoft.com/download/pr/4880c5a4-9c22-47a7-b298-651f1294a385/795f7828d8684059705e625b33027f89/dotnet-sdk-6.0.100-rc.1.21458.32-linux-x64.tar.gz -o /tmp/dotnet.tar.gz && \
     mkdir /opt/dotnet && \
     tar -xf /tmp/dotnet.tar.gz -C /opt/dotnet && \
     ln -s /opt/dotnet/dotnet /usr/bin/dotnet && \

--- a/6.0/runtime/Dockerfile.rhel8
+++ b/6.0/runtime/Dockerfile.rhel8
@@ -53,7 +53,7 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 #     yum clean all -y && \
 # # yum cache files may still exist (and quite large in size)
 #     rm -rf /var/cache/yum/*
-RUN curl https://download.visualstudio.microsoft.com/download/pr/ce3fd989-b69d-439a-9cac-09ad40597db8/2848d49480b6e7b1b2a18cfa46d724e2/dotnet-sdk-6.0.100-preview.7.21379.14-linux-x64.tar.gz -o /tmp/dotnet.tar.gz && \
+RUN curl https://download.visualstudio.microsoft.com/download/pr/4880c5a4-9c22-47a7-b298-651f1294a385/795f7828d8684059705e625b33027f89/dotnet-sdk-6.0.100-rc.1.21458.32-linux-x64.tar.gz -o /tmp/dotnet.tar.gz && \
     mkdir /opt/dotnet && \
     tar -xf /tmp/dotnet.tar.gz -C /opt/dotnet && \
     ln -s /opt/dotnet/dotnet /usr/bin/dotnet && \

--- a/6.0/runtime/test/run
+++ b/6.0/runtime/test/run
@@ -42,9 +42,9 @@ source ${test_dir}/testcommon
 dotnet_version_series="6.0"
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
-dotnet_version="6.0.0-preview.7.21377.19"
+dotnet_version="6.0.0-rc.1.21451.13"
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
-dotnet_version="6.0.0-preview.7.21377.19"
+dotnet_version="6.0.0-rc.1.21451.13"
 fi
 
 test_dotnet() {


### PR DESCRIPTION
Update to use the Microsoft rc1 build.

Yesterday, the fsharp test was failing because some packages hadn't been uploaded to nuget yet (https://github.com/dotnet/fsharp/issues/12152).

Now all tests pass.

cc @omajid @aslicerh 