### PR TITLE
Misc. Container Updates

### DIFF
--- a/3.1/build/.gitignore
+++ b/3.1/build/.gitignore
@@ -1,0 +1,1 @@
+test/split_build

--- a/3.1/build/Dockerfile.rhel8
+++ b/3.1/build/Dockerfile.rhel8
@@ -3,7 +3,8 @@ FROM ubi8/dotnet-31-runtime
 # applications.
 
 ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/node_modules/.bin:/opt/app-root/.dotnet/tools/:${PATH} \
-    STI_SCRIPTS_PATH=/usr/libexec/s2i
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    NODEJS_VERSION=14
 
 LABEL io.k8s.description="Platform for building and running .NET Core 3.1 applications" \
       io.openshift.tags="builder,.net,dotnet,dotnetcore,dotnet-31"
@@ -26,6 +27,7 @@ USER 0
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 RUN INSTALL_PKGS="npm nodejs-nodemon dotnet-sdk-3.1 rsync procps-ng findutils" && \
+    yum -y module enable nodejs:$NODEJS_VERSION && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \

--- a/3.1/build/Dockerfile.rhel8
+++ b/3.1/build/Dockerfile.rhel8
@@ -3,8 +3,7 @@ FROM ubi8/dotnet-31-runtime
 # applications.
 
 ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/node_modules/.bin:/opt/app-root/.dotnet/tools/:${PATH} \
-    STI_SCRIPTS_PATH=/usr/libexec/s2i \
-    NODEJS_VERSION=14
+    STI_SCRIPTS_PATH=/usr/libexec/s2i
 
 LABEL io.k8s.description="Platform for building and running .NET Core 3.1 applications" \
       io.openshift.tags="builder,.net,dotnet,dotnetcore,dotnet-31"
@@ -27,7 +26,7 @@ USER 0
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 RUN INSTALL_PKGS="npm nodejs-nodemon dotnet-sdk-3.1 rsync procps-ng findutils" && \
-    yum -y module enable nodejs:$NODEJS_VERSION && \
+    yum -y module enable nodejs:14 && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \

--- a/3.1/build/test/asp-net-hello-world-envvar/.s2i/environment
+++ b/3.1/build/test/asp-net-hello-world-envvar/.s2i/environment
@@ -5,6 +5,6 @@ DOTNET_ASSEMBLY_NAME=SampleApp
 DOTNET_RESTORE_SOURCES=https://api.nuget.org/v3/index.json https://www.myget.org/F/s2i-dotnetcore
 DOTNET_PACK=true
 DOTNET_NPM_TOOLS=bower gulp
-DOTNET_TOOLS=dotnet-symbol@1.0.5 dotnet-serve
+DOTNET_TOOLS=dotnet-symbol@1.0.5 dotnet-serve@1.8.34
 DOTNET_RM_SRC=true
 DOTNET_INFO=true

--- a/3.1/build/test/asp-net-hello-world-envvar/.s2i/environment
+++ b/3.1/build/test/asp-net-hello-world-envvar/.s2i/environment
@@ -5,6 +5,6 @@ DOTNET_ASSEMBLY_NAME=SampleApp
 DOTNET_RESTORE_SOURCES=https://api.nuget.org/v3/index.json https://www.myget.org/F/s2i-dotnetcore
 DOTNET_PACK=true
 DOTNET_NPM_TOOLS=bower gulp
-DOTNET_TOOLS=dotnet-symbol@1.0.5 dotnet-serve@1.8.34
+DOTNET_TOOLS=dotnet-symbol@1.0.5 dotnet-rpm
 DOTNET_RM_SRC=true
 DOTNET_INFO=true

--- a/3.1/build/test/run
+++ b/3.1/build/test/run
@@ -315,6 +315,8 @@ test_config_1() {
   local serve_path=$(docker_run ${image} bash -c "command -v dotnet-serve")
   local packed_app=$(docker_run ${image} ls /opt/app-root/app.tar.gz)
   local src_folder_content=$(docker_run ${image} ls -a /opt/app-root/src)
+  # ;true is there because 'npm ls' can error, for some random reason
+  local npm_packages=$(docker_run ${image} bash -c "npm ls; true")
   # start container
   local container=$(docker_run_d ${image})
   local url=$(container_url ${container})
@@ -338,8 +340,8 @@ test_config_1() {
   assert_contains "${s2i_build}" "Packing application..."
   assert_equal "${packed_app}" "/opt/app-root/app.tar.gz"
   # DOTNET_NPM_TOOLS=bower gulp
-  assert_contains "${s2i_build}" "bower@"
-  assert_contains "${s2i_build}" "gulp@"
+  assert_contains "${npm_packages}" "bower@"
+  assert_contains "${npm_packages}" "gulp@"
   assert_equal "${bower_path}" "/opt/app-root/node_modules/.bin/bower"
   # DOTNET_TOOLS=dotnet-symbol@1.0.5 dotnet-serve
   assert_equal "${watch_path}" "/opt/app-root/.dotnet/tools/dotnet-symbol"

--- a/3.1/build/test/run
+++ b/3.1/build/test/run
@@ -312,7 +312,7 @@ test_config_1() {
   # find bower and packed all
   local bower_path=$(docker_run ${image} bash -c "command -v bower")
   local watch_path=$(docker_run ${image} bash -c "command -v dotnet-symbol")
-  local serve_path=$(docker_run ${image} bash -c "command -v dotnet-serve")
+  local dotnetrpm_path=$(docker_run ${image} bash -c "command -v dotnet-rpm")
   local packed_app=$(docker_run ${image} ls /opt/app-root/app.tar.gz)
   local src_folder_content=$(docker_run ${image} ls -a /opt/app-root/src)
   # ;true is there because 'npm ls' can error, for some random reason
@@ -345,7 +345,7 @@ test_config_1() {
   assert_equal "${bower_path}" "/opt/app-root/node_modules/.bin/bower"
   # DOTNET_TOOLS=dotnet-symbol@1.0.5 dotnet-serve
   assert_equal "${watch_path}" "/opt/app-root/.dotnet/tools/dotnet-symbol"
-  assert_equal "${serve_path}" "/opt/app-root/.dotnet/tools/dotnet-serve"
+  assert_equal "${dotnetrpm_path}" "/opt/app-root/.dotnet/tools/dotnet-rpm"
   assert_contains "${s2i_build}" "Tool 'dotnet-symbol' \(version '1.0.5'\) was successfully installed."
   # DOTNET_RM_SRC=true
   # The application folder contains a file and folder that starts with a '.', we verify that *all* files are removed.

--- a/3.1/build/test/run
+++ b/3.1/build/test/run
@@ -56,14 +56,13 @@ sdk_version=3.1.116
 npm_version=6.14.11
 elif [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8
-sdk_version=3.1.118
+sdk_version=3.1.119
 elif [ "$IMAGE_OS" = "RHEL7" ]; then
 # sdk version supported on RHEL7
-sdk_version=3.1.118
-npm_version=6.14.11
+sdk_version=3.1.119
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 # sdk version supported on Fedora
-sdk_version=3.1.118
+sdk_version=3.1.119
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"

--- a/3.1/runtime/.gitignore
+++ b/3.1/runtime/.gitignore
@@ -1,0 +1,2 @@
+test/dockerfile-run-dotnet/
+test/precompiled/

--- a/3.1/runtime/test/run
+++ b/3.1/runtime/test/run
@@ -46,11 +46,11 @@ dotnet_version_series="3.1"
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 dotnet_version="3.1.16"
 elif [ "$IMAGE_OS" = "RHEL8" ]; then
-dotnet_version="3.1.18"
+dotnet_version="3.1.19"
 elif [ "$IMAGE_OS" = "RHEL7" ]; then
-dotnet_version="3.1.18"
+dotnet_version="3.1.19"
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
-dotnet_version="3.1.18"
+dotnet_version="3.1.19"
 fi
 
 test_dotnet() {

--- a/5.0/build/.gitignore
+++ b/5.0/build/.gitignore
@@ -1,0 +1,1 @@
+test/split_build

--- a/5.0/build/Dockerfile.rhel8
+++ b/5.0/build/Dockerfile.rhel8
@@ -3,7 +3,8 @@ FROM ubi8/dotnet-50-runtime
 # applications.
 
 ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/node_modules/.bin:/opt/app-root/.dotnet/tools/:${PATH} \
-    STI_SCRIPTS_PATH=/usr/libexec/s2i
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    NODEJS_VERSION=14
 
 LABEL io.k8s.description="Platform for building and running .NET 5 applications" \
       io.openshift.tags="builder,.net,dotnet,dotnetcore,dotnet-50"
@@ -26,6 +27,7 @@ USER 0
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 RUN INSTALL_PKGS="npm nodejs-nodemon dotnet-sdk-5.0 rsync procps-ng findutils" && \
+    yum -y module enable nodejs:$NODEJS_VERSION && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \

--- a/5.0/build/Dockerfile.rhel8
+++ b/5.0/build/Dockerfile.rhel8
@@ -3,8 +3,7 @@ FROM ubi8/dotnet-50-runtime
 # applications.
 
 ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/node_modules/.bin:/opt/app-root/.dotnet/tools/:${PATH} \
-    STI_SCRIPTS_PATH=/usr/libexec/s2i \
-    NODEJS_VERSION=14
+    STI_SCRIPTS_PATH=/usr/libexec/s2i
 
 LABEL io.k8s.description="Platform for building and running .NET 5 applications" \
       io.openshift.tags="builder,.net,dotnet,dotnetcore,dotnet-50"
@@ -27,7 +26,7 @@ USER 0
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 RUN INSTALL_PKGS="npm nodejs-nodemon dotnet-sdk-5.0 rsync procps-ng findutils" && \
-    yum -y module enable nodejs:$NODEJS_VERSION && \
+    yum -y module enable nodejs:14 && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \

--- a/5.0/build/test/run
+++ b/5.0/build/test/run
@@ -50,12 +50,13 @@ npm_version=6.14.13
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 # sdk version supported on CentOS
 sdk_version=5.0.205
+npm_version=6.14.14
 elif [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8
-sdk_version=5.0.206
+sdk_version=5.0.207
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 # sdk version supported on Fedora
-sdk_version=5.0.206
+sdk_version=5.0.205
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"

--- a/5.0/build/test/run
+++ b/5.0/build/test/run
@@ -308,6 +308,8 @@ test_config_1() {
   local serve_path=$(docker_run ${image} bash -c "command -v dotnet-serve")
   local packed_app=$(docker_run ${image} ls /opt/app-root/app.tar.gz)
   local src_folder_content=$(docker_run ${image} ls -a /opt/app-root/src)
+  # ;true is there because 'npm ls' can error, for some random reason
+  local npm_packages=$(docker_run ${image} bash -c "npm ls; true")
   # start container
   local container=$(docker_run_d ${image})
   local url=$(container_url ${container})
@@ -331,7 +333,7 @@ test_config_1() {
   assert_contains "${s2i_build}" "Packing application..."
   assert_equal "${packed_app}" "/opt/app-root/app.tar.gz"
   # DOTNET_NPM_TOOLS=gulp
-  assert_contains "${s2i_build}" "gulp@"
+  assert_contains "${npm_packages}" "gulp@"
   # DOTNET_TOOLS=dotnet-symbol@1.0.5 dotnet-serve
   assert_equal "${watch_path}" "/opt/app-root/.dotnet/tools/dotnet-symbol"
   assert_equal "${serve_path}" "/opt/app-root/.dotnet/tools/dotnet-serve"

--- a/5.0/runtime/.gitignore
+++ b/5.0/runtime/.gitignore
@@ -1,0 +1,2 @@
+test/dockerfile-run-dotnet/
+test/precompiled/

--- a/5.0/runtime/test/run
+++ b/5.0/runtime/test/run
@@ -44,9 +44,9 @@ dotnet_version_series="5.0"
 if [ "$IMAGE_OS" = "CENTOS" ]; then
 dotnet_version="5.0.8"
 elif [ "$IMAGE_OS" = "RHEL8" ]; then
-dotnet_version="5.0.9"
+dotnet_version="5.0.10"
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
-dotnet_version="5.0.9"
+dotnet_version="5.0.8"
 fi
 
 test_dotnet() {


### PR DESCRIPTION
The commit titles are pretty on point. This:
##### Updated Expected Versions
##### Created some .gitignore files
The tests tend to create some empty dirs that sit around. They're harmless, but I like not seeing them in the `git status` reports.
##### Specified nodejS module for RHEL8 containers
Something like this is necessary to change the module/stream used in rhel 8 to get newer versions of nodeJS. As a bonus, it makes it more obvious which nodeJS version we're using.
##### Changed DOTNET TOOL tests for how new npm versions work
When running tests for some beta images, I noticed that these tests failed because the new version of npm no longer spits out the package name that was installed after it is done. I fixed this by doing an `npm ls` call to get the list of npm packages, and seeing if our installed package was listed there. Unfortunately, `npm ls` throws an error (about 'extraneous' packages?), for no real reason that I can understand. It's seriously weird.