### PR TITLE
Reduce image size by not installing weak dependencies.

### DIFF
--- a/3.1/build/Dockerfile.fedora
+++ b/3.1/build/Dockerfile.fedora
@@ -25,7 +25,7 @@ USER 0
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
 COPY ./s2i/bin/ /usr/libexec/s2i
 
-RUN INSTALL_PKGS="npm dotnet-sdk-3.1 rsync procps-ng findutils" && \
+RUN INSTALL_PKGS="npm nodejs-nodemon dotnet-sdk-3.1 rsync procps-ng findutils" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \

--- a/6.0/build/Dockerfile.fedora
+++ b/6.0/build/Dockerfile.fedora
@@ -28,14 +28,14 @@ USER 0
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
 COPY ./s2i/bin/ /usr/libexec/s2i
 
-# TODO: use Fedora packages.
-# RUN INSTALL_PKGS="npm dotnet-sdk-6.0 rsync procps-ng findutils" && \
-#     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-#     rpm -V $INSTALL_PKGS && \
-#     yum clean all -y && \
-# # yum cache files may still exist (and quite large in size)
-#     rm -rf /var/cache/yum/*
-RUN yum install -y npm nodejs-nodemon rsync procps-ng findutils
+# TODO: use .NET package (dotnet-sdk-6.0).
+RUN INSTALL_PKGS="npm nodejs-nodemon rsync procps-ng findutils" && \
+    yum -y module enable nodejs:14 && \
+    yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y && \
+# yum cache files may still exist (and quite large in size)
+    rm -rf /var/cache/yum/*
 
 # Directory with the sources is set as the working directory.
 RUN mkdir /opt/app-root/src

--- a/6.0/build/Dockerfile.rhel8
+++ b/6.0/build/Dockerfile.rhel8
@@ -28,15 +28,14 @@ USER 0
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
 COPY ./s2i/bin/ /usr/libexec/s2i
 
-# TODO: use RHEL packages.
-# RUN INSTALL_PKGS="npm nodejs-nodemon dotnet-sdk-6.0 rsync procps-ng findutils" && \
-#     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-#     rpm -V $INSTALL_PKGS && \
-#     yum clean all -y && \
-# # yum cache files may still exist (and quite large in size)
-#     rm -rf /var/cache/yum/*
-RUN yum -y module enable nodejs:14 && \
-    yum install -y npm nodejs-nodemon rsync procps-ng findutils
+# TODO: use .NET package (dotnet-sdk-6.0).
+RUN INSTALL_PKGS="npm nodejs-nodemon rsync procps-ng findutils" && \
+    yum -y module enable nodejs:14 && \
+    yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y && \
+# yum cache files may still exist (and quite large in size)
+    rm -rf /var/cache/yum/*
 
 # Directory with the sources is set as the working directory.
 RUN mkdir /opt/app-root/src

--- a/6.0/build/s2i/bin/_devmode_run
+++ b/6.0/build/s2i/bin/_devmode_run
@@ -50,4 +50,4 @@ cd "$DOTNET_STARTUP_PROJECT_DIR"
 echo "---> Restoring application dependencies..."
 dotnet restore "$DOTNET_STARTUP_PROJECT_NAME" $RESTORE_OPTIONS
 echo "---> Running application..."
-exec dotnet run -p "$DOTNET_STARTUP_PROJECT_NAME" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION"
+exec dotnet run --project "$DOTNET_STARTUP_PROJECT_NAME" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION"

--- a/6.0/build/test/run
+++ b/6.0/build/test/run
@@ -48,7 +48,7 @@ source ${test_dir}/testcommon
 if [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8
 sdk_version=6.0.100-rc.1.21458.32
-npm_version=6.14.13
+npm_version=6.14.14
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 # sdk version supported on Fedora
 sdk_version=6.0.100-rc.1.21458.32

--- a/6.0/build/test/run
+++ b/6.0/build/test/run
@@ -700,11 +700,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_vb
   test_published_files
   test_aspnetapp
-if [ "$IMAGE_OS" != "FEDORA" ]; then
-  # Fedora doesn't have a nodemon package.
-  # TODO: look into installing it with 'npm install' when DEV_MODE == true.
   test_devmode
-fi
   test_split_build
   test_templates
   test_user

--- a/6.0/runtime/Dockerfile.fedora
+++ b/6.0/runtime/Dockerfile.fedora
@@ -46,19 +46,18 @@ COPY ./root/usr/bin /usr/bin
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
 COPY ./s2i/bin/ /usr/libexec/s2i
 
-# TODO: use Fedora packages.
-# RUN INSTALL_PKGS="aspnetcore-runtime-6.0 nss_wrapper tar unzip findutils" && \
-#     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-#     rpm -V $INSTALL_PKGS && \
-#     yum clean all -y && \
-# # yum cache files may still exist (and quite large in size)
-#     rm -rf /var/cache/yum/*
+# TODO: use .NET package (aspnetcore-runtime-6.0).
+ENV DOTNET_ROOT=/opt/dotnet
 RUN curl https://download.visualstudio.microsoft.com/download/pr/4880c5a4-9c22-47a7-b298-651f1294a385/795f7828d8684059705e625b33027f89/dotnet-sdk-6.0.100-rc.1.21458.32-linux-x64.tar.gz -o /tmp/dotnet.tar.gz && \
     mkdir /opt/dotnet && \
     tar -xf /tmp/dotnet.tar.gz -C /opt/dotnet && \
     ln -s /opt/dotnet/dotnet /usr/bin/dotnet && \
-    yum install -y nss_wrapper tar unzip findutils libicu
-ENV DOTNET_ROOT=/opt/dotnet
+    INSTALL_PKGS="nss_wrapper tar unzip findutils libicu" && \
+    yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y && \
+# yum cache files may still exist (and quite large in size)
+    rm -rf /var/cache/yum/*
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/opt/app-root

--- a/6.0/runtime/Dockerfile.rhel8
+++ b/6.0/runtime/Dockerfile.rhel8
@@ -46,18 +46,18 @@ COPY ./root/usr/bin /usr/bin
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
 COPY ./s2i/bin/ /usr/libexec/s2i
 
-# TODO: use Fedora packages.
-# RUN INSTALL_PKGS="aspnetcore-runtime-6.0 nss_wrapper tar unzip" && \
-#     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-#     rpm -V $INSTALL_PKGS && \
-#     yum clean all -y && \
-# # yum cache files may still exist (and quite large in size)
-#     rm -rf /var/cache/yum/*
+# TODO: use .NET package (aspnetcore-runtime-6.0).
 RUN curl https://download.visualstudio.microsoft.com/download/pr/4880c5a4-9c22-47a7-b298-651f1294a385/795f7828d8684059705e625b33027f89/dotnet-sdk-6.0.100-rc.1.21458.32-linux-x64.tar.gz -o /tmp/dotnet.tar.gz && \
     mkdir /opt/dotnet && \
     tar -xf /tmp/dotnet.tar.gz -C /opt/dotnet && \
     ln -s /opt/dotnet/dotnet /usr/bin/dotnet && \
-    yum install -y nss_wrapper tar unzip findutils libicu
+    INSTALL_PKGS="nss_wrapper tar unzip findutils libicu" && \
+    yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y && \
+# yum cache files may still exist (and quite large in size)
+    rm -rf /var/cache/yum/*
+
 ENV DOTNET_ROOT=/opt/dotnet
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/6.0/runtime/Dockerfile.rhel8
+++ b/6.0/runtime/Dockerfile.rhel8
@@ -47,6 +47,7 @@ COPY ./root/usr/bin /usr/bin
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 # TODO: use .NET package (aspnetcore-runtime-6.0).
+ENV DOTNET_ROOT=/opt/dotnet
 RUN curl https://download.visualstudio.microsoft.com/download/pr/4880c5a4-9c22-47a7-b298-651f1294a385/795f7828d8684059705e625b33027f89/dotnet-sdk-6.0.100-rc.1.21458.32-linux-x64.tar.gz -o /tmp/dotnet.tar.gz && \
     mkdir /opt/dotnet && \
     tar -xf /tmp/dotnet.tar.gz -C /opt/dotnet && \
@@ -58,7 +59,7 @@ RUN curl https://download.visualstudio.microsoft.com/download/pr/4880c5a4-9c22-4
 # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*
 
-ENV DOTNET_ROOT=/opt/dotnet
+
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/opt/app-root


### PR DESCRIPTION
For the runtime image this removes the cmake and some perl-* dependencies of nss_wrapper.
Neither are needed.
The installed size is reduced by 36M.

For the sdk image this removes the nodejs-docs and nodejs-full-i18n depedencies of nodejs.
The docs are not needed to build applications, and the internationalization is not needed
to build JavaScript front-ends.
The installed size is reduced by 68M.