### PR TITLE
Add imagestream files for aarch64 and s390x

### DIFF
--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -66,7 +66,7 @@
                             "openshift.io/display-name": ".NET 6 (UBI 8)",
                             "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet60,hidden",
+                            "tags": "builder,.net,dotnet,dotnetcore,dotnet60,hidden",
                             "supports": "dotnet:6.0,dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",

--- a/dotnet_imagestreams_aarch64.json
+++ b/dotnet_imagestreams_aarch64.json
@@ -1,0 +1,155 @@
+{
+    "kind": "ImageStreamList",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "dotnet-image-streams",
+        "annotations": {
+            "description": "ImageStream definitions for .NET"
+        }
+    },
+    "items": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "dotnet",
+                "annotations": {
+                    "openshift.io/display-name": ".NET"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET (Latest)",
+                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major versions updates.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,hidden",
+                            "supports": "dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "6.0-ubi8"
+                        }
+                    },
+                    {
+                        "name": "6.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 (UBI 8)",
+                            "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,dotnet60",
+                            "supports": "dotnet:6.0,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-6.0",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+                        }
+                    },
+                    {
+                        "name": "6.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 (UBI 8)",
+                            "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,dotnet60,hidden",
+                            "supports": "dotnet:6.0,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-6.0",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "dotnet-runtime",
+                "annotations": {
+                    "openshift.io/display-name": ".NET Core Runtime"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Runtime (Latest)",
+                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "supports": "dotnet-runtime"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "6.0-ubi8"
+                        }
+                    },
+                    {
+                        "name": "6.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
+                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports": "dotnet-runtime",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+                        }
+                    },
+                    {
+                        "name": "6.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
+                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "supports": "dotnet-runtime",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -66,7 +66,7 @@
                             "openshift.io/display-name": ".NET 6 (UBI 8)",
                             "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet60,hidden",
+                            "tags": "builder,.net,dotnet,dotnetcore,dotnet60,hidden",
                             "supports": "dotnet:6.0,dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",

--- a/dotnet_imagestreams_s390x.json
+++ b/dotnet_imagestreams_s390x.json
@@ -1,0 +1,155 @@
+{
+    "kind": "ImageStreamList",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "dotnet-image-streams",
+        "annotations": {
+            "description": "ImageStream definitions for .NET"
+        }
+    },
+    "items": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "dotnet",
+                "annotations": {
+                    "openshift.io/display-name": ".NET"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET (Latest)",
+                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major versions updates.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,hidden",
+                            "supports": "dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "6.0-ubi8"
+                        }
+                    },
+                    {
+                        "name": "6.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 (UBI 8)",
+                            "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,dotnet60",
+                            "supports": "dotnet:6.0,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-6.0",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+                        }
+                    },
+                    {
+                        "name": "6.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 (UBI 8)",
+                            "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,dotnet60,hidden",
+                            "supports": "dotnet:6.0,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-6.0",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "dotnet-runtime",
+                "annotations": {
+                    "openshift.io/display-name": ".NET Core Runtime"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET Runtime (Latest)",
+                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "supports": "dotnet-runtime"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "6.0-ubi8"
+                        }
+                    },
+                    {
+                        "name": "6.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
+                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports": "dotnet-runtime",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+                        }
+                    },
+                    {
+                        "name": "6.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
+                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "supports": "dotnet-runtime",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
A separate file with only the 6.0 streams is needed in order to add these to OpenShift for ARM and IBM Z, which do not have the earlier versions.
