### PR TITLE
Update imagestreams and README for 6.0.

### DIFF
--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -204,7 +204,7 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET Runtime (Latest)",
-                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
                             "supports": "dotnet-runtime"
@@ -214,7 +214,43 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "5.0-ubi8"
+                            "name": "6.0-ubi8"
+                        }
+                    },
+                    {
+                        "name": "6.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
+                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports": "dotnet-runtime",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+                        }
+                    },
+                    {
+                        "name": "6.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
+                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "supports": "dotnet-runtime",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
                         }
                     },
                     {

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -23,20 +23,62 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET (Latest)",
-                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major versions updates.",
+                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
                             "tags": "builder,.net,dotnet,dotnetcore,hidden",
                             "supports": "dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnet-5.0"
+                            "sampleRef": "dotnet-6.0"
                         },
                         "referencePolicy": {
                             "type": "Local"
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "5.0-ubi8"
+                            "name": "6.0-ubi8"
+                        }
+                    },
+                    {
+                        "name": "6.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 (UBI 8)",
+                            "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,dotnet60",
+                            "supports": "dotnet:6.0,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-6.0",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+                        }
+                    },
+                    {
+                        "name": "6.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 (UBI 8)",
+                            "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet60,hidden",
+                            "supports": "dotnet:6.0,dotnet",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnetcore-6.0",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
                         }
                     },
                     {
@@ -162,7 +204,7 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET Runtime (Latest)",
-                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
                             "iconClass": "icon-dotnet",
                             "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
                             "supports": "dotnet-runtime"
@@ -172,7 +214,43 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "5.0-ubi8"
+                            "name": "6.0-ubi8"
+                        }
+                    },
+                    {
+                        "name": "6.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
+                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+                            "supports": "dotnet-runtime",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+                        }
+                    },
+                    {
+                        "name": "6.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
+                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "supports": "dotnet-runtime",
+                            "version": "6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
                         }
                     },
                     {


### PR DESCRIPTION
Add missing dotnet-runtime tags for 6.0.
Add 6.0 to the _centos streams. These are used by OKD.

@yselkowitz this fixes the issues you reported in https://github.com/redhat-developer/s2i-dotnetcore/pull/392#issuecomment-967081406.