### PR TITLE
[APPSVC-991] Use groupified apiVersion in imagestreams

### DIFF
--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -1,6 +1,6 @@
 {
     "kind": "ImageStreamList",
-    "apiVersion": "v1",
+    "apiVersion": "image.openshift.io/v1",
     "metadata": {
         "name": "dotnet-image-streams",
         "annotations": {
@@ -10,7 +10,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "dotnet",
                 "annotations": {
@@ -191,7 +191,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "dotnet-runtime",
                 "annotations": {

--- a/dotnet_imagestreams_aarch64.json
+++ b/dotnet_imagestreams_aarch64.json
@@ -1,6 +1,6 @@
 {
     "kind": "ImageStreamList",
-    "apiVersion": "v1",
+    "apiVersion": "image.openshift.io/v1",
     "metadata": {
         "name": "dotnet-image-streams",
         "annotations": {
@@ -10,7 +10,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "dotnet",
                 "annotations": {
@@ -86,7 +86,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "dotnet-runtime",
                 "annotations": {

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -1,6 +1,6 @@
 {
     "kind": "ImageStreamList",
-    "apiVersion": "v1",
+    "apiVersion": "image.openshift.io/v1",
     "metadata": {
         "name": "dotnet-image-streams",
         "annotations": {
@@ -10,7 +10,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "dotnet",
                 "annotations": {
@@ -191,7 +191,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "dotnet-runtime",
                 "annotations": {

--- a/dotnet_imagestreams_s390x.json
+++ b/dotnet_imagestreams_s390x.json
@@ -1,6 +1,6 @@
 {
     "kind": "ImageStreamList",
-    "apiVersion": "v1",
+    "apiVersion": "image.openshift.io/v1",
     "metadata": {
         "name": "dotnet-image-streams",
         "annotations": {
@@ -10,7 +10,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "dotnet",
                 "annotations": {
@@ -86,7 +86,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "dotnet-runtime",
                 "annotations": {


### PR DESCRIPTION
Non-groupified APIs were deprecated in OCP 4.7.

This PR only handles the imagestreams which are bundled in OpenShift.  If any of the other imagestreams or templates are meant to still be used, they should also be similarly updated.  A complete API list is available at https://docs.openshift.com/container-platform/4.9/rest_api/index.html .