### PR TITLE
Get tests to pass on Fedora

### DIFF
--- a/3.1/build/s2i/bin/assemble
+++ b/3.1/build/s2i/bin/assemble
@@ -218,7 +218,11 @@ if [ "$BUILD_TYPE" == "source" ]; then
     DOTNET_PUBLISH_OPTIONS="$DOTNET_PUBLISH_OPTIONS -r linux-x64 /p:PublishReadyToRun=true"
   fi
   echo "---> Restoring application dependencies..."
-  dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION
+  if dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION ; then
+      echo "Restore completed successfully"
+  else
+      echo "Error during restore"
+  fi
   echo "---> Publishing application..."
   dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" $VERBOSITY_OPTION \
          $DOTNET_PUBLISH_OPTIONS -o "$DOTNET_APP_PATH"

--- a/3.1/build/test/run
+++ b/3.1/build/test/run
@@ -62,7 +62,8 @@ elif [ "$IMAGE_OS" = "RHEL7" ]; then
 sdk_version=3.1.119
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 # sdk version supported on Fedora
-sdk_version=3.1.119
+sdk_version=3.1.417
+npm_version=8.3.1
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"

--- a/3.1/runtime/test/run
+++ b/3.1/runtime/test/run
@@ -50,7 +50,7 @@ dotnet_version="3.1.19"
 elif [ "$IMAGE_OS" = "RHEL7" ]; then
 dotnet_version="3.1.19"
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
-dotnet_version="3.1.19"
+dotnet_version="3.1.23"
 fi
 
 test_dotnet() {

--- a/5.0/build/test/run
+++ b/5.0/build/test/run
@@ -56,7 +56,8 @@ elif [ "$IMAGE_OS" = "RHEL8" ]; then
 sdk_version=5.0.207
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 # sdk version supported on Fedora
-sdk_version=5.0.205
+sdk_version=5.0.206
+npm_version=8.3.1
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"

--- a/5.0/runtime/test/run
+++ b/5.0/runtime/test/run
@@ -46,7 +46,7 @@ dotnet_version="5.0.8"
 elif [ "$IMAGE_OS" = "RHEL8" ]; then
 dotnet_version="5.0.10"
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
-dotnet_version="5.0.8"
+dotnet_version="5.0.9"
 fi
 
 test_dotnet() {

--- a/6.0/build/Dockerfile.fedora
+++ b/6.0/build/Dockerfile.fedora
@@ -28,8 +28,7 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 # - dotnet-sdk--*: provides the .NET SDK.
 # - npm: provides SDK for building NodeJS web front-ends.
 # - procps-ng: provides 'pidof' which is needed by the 'odo' Devfile to find the running 'dotnet' process.
-RUN INSTALL_PKGS="dotnet-sdk-6.0 npm procps-ng" && \
-    yum -y module enable nodejs:14 && \
+RUN INSTALL_PKGS="npm nodejs-nodemon dotnet-sdk-6.0 rsync procps-ng findutils" && \
     yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \

--- a/6.0/build/test/run
+++ b/6.0/build/test/run
@@ -51,8 +51,8 @@ sdk_version=6.0.100
 npm_version=6.14.11
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 # sdk version supported on Fedora
-sdk_version=6.0.100-rc.1.21458.32
-npm_version=6.14.15
+sdk_version=6.0.103
+npm_version=8.3.1
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"

--- a/6.0/runtime/test/run
+++ b/6.0/runtime/test/run
@@ -42,9 +42,9 @@ source ${test_dir}/testcommon
 dotnet_version_series="6.0"
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
-dotnet_version="6.0.0-rc.1.21451.13"
+dotnet_version="6.0.3"
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
-dotnet_version="6.0.0-rc.1.21451.13"
+dotnet_version="6.0.3"
 fi
 
 test_dotnet() {

--- a/build.sh
+++ b/build.sh
@@ -118,7 +118,7 @@ elif [ "$IMAGE_OS" = "RHEL8" ]; then
   image_prefix="ubi8"
   docker_filename="Dockerfile.rhel8"
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
-  VERSIONS="${VERSIONS:-3.1 5.0}"
+  VERSIONS="${VERSIONS:-3.1 5.0 6.0}"
   image_prefix="fedora"
   docker_filename="Dockerfile.fedora"
 else


### PR DESCRIPTION
Also, enable .NET 6 tests on Fedora.

The 3.1 tests were failing because the output of dotnet restore changed in the 3.1.4xx series to remove a string that the tests were looking for. Adjust that to match what we do in the 5.0 and 6.0 tests and manually add that restore text in the output.

Fix up versions for packages so tests all pass by default.