### PR TITLE
dotnet restore failing should be an error in assemble

### DIFF
--- a/3.1/build/s2i/bin/assemble
+++ b/3.1/build/s2i/bin/assemble
@@ -218,11 +218,7 @@ if [ "$BUILD_TYPE" == "source" ]; then
     DOTNET_PUBLISH_OPTIONS="$DOTNET_PUBLISH_OPTIONS -r linux-x64 /p:PublishReadyToRun=true"
   fi
   echo "---> Restoring application dependencies..."
-  if dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION ; then
-      echo "Restore completed successfully"
-  else
-      echo "Error during restore"
-  fi
+  dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION
   echo "---> Publishing application..."
   dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" $VERBOSITY_OPTION \
          $DOTNET_PUBLISH_OPTIONS -o "$DOTNET_APP_PATH"

--- a/3.1/build/test/run
+++ b/3.1/build/test/run
@@ -336,7 +336,8 @@ test_config_1() {
   # DOTNET_ASSEMBLY_NAME=SampleApp
   assert_contains "${s2i_build}" "/opt/app-root/src/src/app/bin/Debug/netcoreapp3.1/SampleApp.dll"
   # DOTNET_RESTORE_SOURCES=https://api.nuget.org/v3/index.json https://www.myget.org/F/s2i-dotnetcore
-  assert_contains "${s2i_build}" "Restore completed" # Includes S2iDotNetCoreDummy from myget.org.
+  assert_contains "${s2i_build}" 'Restored /opt/app-root/src/src/app/app.csproj \(in [[:digit:]]+\.[[:digit:]]+ sec\)' # Includes S2iDotNetCoreDummy from myget.org.
+
   # DOTNET_PACK=true
   assert_contains "${s2i_build}" "Packing application..."
   assert_equal "${packed_app}" "/opt/app-root/app.tar.gz"

--- a/5.0/build/s2i/bin/assemble
+++ b/5.0/build/s2i/bin/assemble
@@ -218,11 +218,7 @@ if [ "$BUILD_TYPE" == "source" ]; then
     DOTNET_PUBLISH_OPTIONS="$DOTNET_PUBLISH_OPTIONS -r linux-x64 /p:PublishReadyToRun=true"
   fi
   echo "---> Restoring application dependencies..."
-  if dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION ; then
-      echo "Restore completed successfully"
-  else
-      echo "Error during restore"
-  fi
+  dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION
   echo "---> Publishing application..."
   dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" $VERBOSITY_OPTION \
          $DOTNET_PUBLISH_OPTIONS -o "$DOTNET_APP_PATH"

--- a/5.0/build/test/run
+++ b/5.0/build/test/run
@@ -329,7 +329,7 @@ test_config_1() {
   # DOTNET_ASSEMBLY_NAME=SampleApp
   assert_contains "${s2i_build}" "/opt/app-root/src/src/app/bin/Debug/net5.0/SampleApp.dll"
   # DOTNET_RESTORE_SOURCES=https://api.nuget.org/v3/index.json https://www.myget.org/F/s2i-dotnetcore
-  assert_contains "${s2i_build}" "Restore completed" # Includes S2iDotNetCoreDummy from myget.org.
+  assert_contains "${s2i_build}" 'Restored /opt/app-root/src/src/app/app.csproj \(in [[:digit:]]+\.[[:digit:]]+ sec\)' # Includes S2iDotNetCoreDummy from myget.org.
   # DOTNET_PACK=true
   assert_contains "${s2i_build}" "Packing application..."
   assert_equal "${packed_app}" "/opt/app-root/app.tar.gz"

--- a/6.0/build/s2i/bin/assemble
+++ b/6.0/build/s2i/bin/assemble
@@ -223,11 +223,7 @@ if [ "$BUILD_TYPE" == "source" ]; then
     fi
   fi
   echo "---> Restoring application dependencies..."
-  if dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION ; then
-      echo "Restore completed successfully"
-  else
-      echo "Error during restore"
-  fi
+  dotnet restore "$DOTNET_STARTUP_PROJECT" $RESTORE_OPTIONS $VERBOSITY_OPTION
   echo "---> Publishing application..."
   dotnet publish "$DOTNET_STARTUP_PROJECT" -f "$DOTNET_FRAMEWORK" -c "$DOTNET_CONFIGURATION" $VERBOSITY_OPTION \
          $DOTNET_PUBLISH_OPTIONS -o "$DOTNET_APP_PATH"

--- a/6.0/build/test/run
+++ b/6.0/build/test/run
@@ -331,7 +331,7 @@ test_config_1() {
   # DOTNET_ASSEMBLY_NAME=SampleApp
   assert_contains "${s2i_build}" "/opt/app-root/src/src/app/bin/Debug/net6.0/SampleApp.dll"
   # DOTNET_RESTORE_SOURCES=https://api.nuget.org/v3/index.json https://www.myget.org/F/s2i-dotnetcore
-  assert_contains "${s2i_build}" "Restore completed" # Includes S2iDotNetCoreDummy from myget.org.
+  assert_contains "${s2i_build}" 'Restored /opt/app-root/src/src/app/app.csproj \(in [[:digit:]]+\.[[:digit:]]+ sec\)' # Includes S2iDotNetCoreDummy from myget.org.
   # DOTNET_PACK=true
   assert_contains "${s2i_build}" "Packing application..."
   assert_equal "${packed_app}" "/opt/app-root/app.tar.gz"


### PR DESCRIPTION
Currently, dotnet restore is an if condition check, which may result in the assemble scripts continuing to run even if the restore operation fails. This is unexpected and not desired. Fix that to make the assemble script fail if dotnet restore fails.

And fix the tests to rely on the messages printed out by dotnet restore, instead of something shown by the assemble script.