### PR TITLE
Make assert for dotnet restore more robust

### DIFF
--- a/3.1/build/test/run
+++ b/3.1/build/test/run
@@ -336,7 +336,7 @@ test_config_1() {
   # DOTNET_ASSEMBLY_NAME=SampleApp
   assert_contains "${s2i_build}" "/opt/app-root/src/src/app/bin/Debug/netcoreapp3.1/SampleApp.dll"
   # DOTNET_RESTORE_SOURCES=https://api.nuget.org/v3/index.json https://www.myget.org/F/s2i-dotnetcore
-  assert_contains "${s2i_build}" 'Restored /opt/app-root/src/src/app/app.csproj \(in [[:digit:]]+\.[[:digit:]]+ sec\)' # Includes S2iDotNetCoreDummy from myget.org.
+  assert_contains "${s2i_build}" 'Restored /opt/app-root/src/src/app/app.csproj \([^)]+\)\.' # Includes S2iDotNetCoreDummy from myget.org.
 
   # DOTNET_PACK=true
   assert_contains "${s2i_build}" "Packing application..."

--- a/5.0/build/test/run
+++ b/5.0/build/test/run
@@ -329,7 +329,7 @@ test_config_1() {
   # DOTNET_ASSEMBLY_NAME=SampleApp
   assert_contains "${s2i_build}" "/opt/app-root/src/src/app/bin/Debug/net5.0/SampleApp.dll"
   # DOTNET_RESTORE_SOURCES=https://api.nuget.org/v3/index.json https://www.myget.org/F/s2i-dotnetcore
-  assert_contains "${s2i_build}" 'Restored /opt/app-root/src/src/app/app.csproj \(in [[:digit:]]+\.[[:digit:]]+ sec\)' # Includes S2iDotNetCoreDummy from myget.org.
+  assert_contains "${s2i_build}" 'Restored /opt/app-root/src/src/app/app.csproj \([^)]+\)\.' # Includes S2iDotNetCoreDummy from myget.org.
   # DOTNET_PACK=true
   assert_contains "${s2i_build}" "Packing application..."
   assert_equal "${packed_app}" "/opt/app-root/app.tar.gz"

--- a/6.0/build/test/run
+++ b/6.0/build/test/run
@@ -331,7 +331,7 @@ test_config_1() {
   # DOTNET_ASSEMBLY_NAME=SampleApp
   assert_contains "${s2i_build}" "/opt/app-root/src/src/app/bin/Debug/net6.0/SampleApp.dll"
   # DOTNET_RESTORE_SOURCES=https://api.nuget.org/v3/index.json https://www.myget.org/F/s2i-dotnetcore
-  assert_contains "${s2i_build}" 'Restored /opt/app-root/src/src/app/app.csproj \(in [[:digit:]]+\.[[:digit:]]+ sec\)' # Includes S2iDotNetCoreDummy from myget.org.
+  assert_contains "${s2i_build}" 'Restored /opt/app-root/src/src/app/app.csproj \([^)]+\)\.' # Includes S2iDotNetCoreDummy from myget.org.
   # DOTNET_PACK=true
   assert_contains "${s2i_build}" "Packing application..."
   assert_equal "${packed_app}" "/opt/app-root/app.tar.gz"


### PR DESCRIPTION
Sometimes, restore can complete in milliseconds. We should handle that output better and not fail the test because of that.