### PR TITLE
Remove .NET 5 imagestreams

### DIFF
--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -82,48 +82,6 @@
                         }
                     },
                     {
-                        "name": "5.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 5 (UBI 8)",
-                            "description": "Build and run .NET 5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet50",
-                            "supports": "dotnet:5.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnet-5.0",
-                            "version": "5.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-50:5.0"
-                        }
-                    },
-                    {
-                        "name": "5.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 5 (UBI 8)",
-                            "description": "Build and run .NET 5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet50,hidden",
-                            "supports": "dotnet:5.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-5.0",
-                            "version": "5.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-50:5.0"
-                        }
-                    },
-                    {
                         "name": "3.1-ubi8",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 3.1 (UBI 8)",
@@ -251,42 +209,6 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
-                        }
-                    },
-                    {
-                        "name": "5.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 5 Runtime (UBI 8)",
-                            "description": "Run .NET 5 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports": "dotnet-runtime",
-                            "version": "5.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-50-runtime:5.0"
-                        }
-                    },
-                    {
-                        "name": "5.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 5 Runtime (UBI 8)",
-                            "description": "Run .NET 5 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-                            "supports": "dotnet-runtime",
-                            "version": "5.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-50-runtime:5.0"
                         }
                     },
                     {

--- a/dotnet_imagestreams_centos.json
+++ b/dotnet_imagestreams_centos.json
@@ -82,48 +82,6 @@
                         }
                     },
                     {
-                        "name": "5.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 5 (UBI 8)",
-                            "description": "Build and run .NET 5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet50",
-                            "supports": "dotnet:5.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnet-5.0",
-                            "version": "5.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-50:5.0"
-                        }
-                    },
-                    {
-                        "name": "5.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 5 (UBI 8)",
-                            "description": "Build and run .NET 5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,rh-dotnet50,hidden",
-                            "supports": "dotnet:5.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-5.0",
-                            "version": "5.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-50:5.0"
-                        }
-                    },
-                    {
                         "name": "3.1-ubi8",
                         "annotations": {
                             "openshift.io/display-name": ".NET Core 3.1 (UBI 8)",
@@ -251,42 +209,6 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
-                        }
-                    },
-                    {
-                        "name": "5.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 5 Runtime (UBI 8)",
-                            "description": "Run .NET 5 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports": "dotnet-runtime",
-                            "version": "5.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-50-runtime:5.0"
-                        }
-                    },
-                    {
-                        "name": "5.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 5 Runtime (UBI 8)",
-                            "description": "Run .NET 5 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/5.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-                            "supports": "dotnet-runtime",
-                            "version": "5.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-50-runtime:5.0"
                         }
                     },
                     {


### PR DESCRIPTION
.NET 5 just went out of support.

https://access.redhat.com/support/policy/updates/net-core
