### PR TITLE
Create environment file

### DIFF
--- a/6.0/build/s2i/environment
+++ b/6.0/build/s2i/environment
@@ -1,0 +1,1 @@
+DOTNET_STARTUP_PROJECT=app/app.csproj


### PR DESCRIPTION
Fix to resolve the S2I assemble error
***********************************************
Error: DOTNET_STARTUP_PROJECT has no project file
You can specify the startup project by adding an '.s2i/environment' file to the source repository.
The source repository contains the following projects:
- app/app.csproj
Update the '.s2i/environment' file to specify the project you want to publish, for example DOTNET_STARTUP_PROJECT=app/app.csproj.
error: build error: error building at STEP "RUN /usr/libexec/s2i/assemble": error while running runtime: exit status 1