### PR TITLE
7.0: remove scripts for RHEL7 software collections.

### DIFF
--- a/7.0/runtime/Dockerfile.fedora
+++ b/7.0/runtime/Dockerfile.fedora
@@ -64,9 +64,6 @@ RUN dnf install -y nss_wrapper tar gzip unzip findutils libicu && \
     ln -s /opt/dotnet/dotnet /usr/bin/dotnet
 ENV DOTNET_ROOT=/opt/dotnet
 
-# Get prefix path and path to scripts rather than hard-code them in scripts
-ENV CONTAINER_SCRIPTS_PATH=/opt/app-root
-
 # Add default user
 RUN mkdir -p ${DOTNET_APP_PATH} ${DOTNET_DATA_PATH} && \
     useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \

--- a/7.0/runtime/Dockerfile.rhel8
+++ b/7.0/runtime/Dockerfile.rhel8
@@ -63,9 +63,6 @@ RUN microdnf install -y nss_wrapper tar gzip unzip findutils shadow-utils libicu
     ln -s /opt/dotnet/dotnet /usr/bin/dotnet
 ENV DOTNET_ROOT=/opt/dotnet
 
-# Get prefix path and path to scripts rather than hard-code them in scripts
-ENV CONTAINER_SCRIPTS_PATH=/opt/app-root
-
 # Add default user
 RUN mkdir -p ${DOTNET_APP_PATH} ${DOTNET_DATA_PATH} && \
     useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \

--- a/7.0/runtime/contrib/etc/scl_enable
+++ b/7.0/runtime/contrib/etc/scl_enable
@@ -1,3 +1,0 @@
-# This will make scl collection binaries work out of box.
-unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable ${ENABLED_COLLECTIONS}

--- a/7.0/runtime/contrib/etc/scl_enable_dotnet
+++ b/7.0/runtime/contrib/etc/scl_enable_dotnet
@@ -1,4 +1,0 @@
-#!/usr/bin/sh
-
-source ${CONTAINER_SCRIPTS_PATH}/etc/scl_enable
-exec dotnet "$@"


### PR DESCRIPTION
We're no longer using these (since 6.0).