### PR TITLE
7.0/build: change default CMD to run a shell.

### DIFF
--- a/7.0/build/Dockerfile.fedora
+++ b/7.0/build/Dockerfile.fedora
@@ -56,5 +56,5 @@ ENV  DOTNET_USE_POLLING_FILE_WATCHER=true
 # Run container by default as user with id 1001 (default)
 USER 1001
 
-# Set the default CMD to print the usage of the language image.
-CMD /usr/libexec/s2i/usage
+# Set the default CMD to start a shell.
+CMD /bin/bash

--- a/7.0/build/Dockerfile.rhel8
+++ b/7.0/build/Dockerfile.rhel8
@@ -57,5 +57,5 @@ ENV  DOTNET_USE_POLLING_FILE_WATCHER=true
 # Run container by default as user with id 1001 (default)
 USER 1001
 
-# Set the default CMD to print the usage of the language image.
-CMD /usr/libexec/s2i/usage
+# Set the default CMD to start a shell.
+CMD /bin/bash

--- a/7.0/build/test/run
+++ b/7.0/build/test/run
@@ -96,19 +96,28 @@ test_s2i_usage() {
   assert_contains "$output" "${sample_app_url}"
 }
 
-test_docker_run_usage() {
-  local output=$(docker_run ${IMAGE_NAME})
-
-  # docker run refers to the sample app
-  assert_contains "$output" "${sample_app_url}"
-}
-
 test_usage() {
   test_start
 
   test_s2i_usage
   test_s2i_usage_projfile
-  test_docker_run_usage
+}
+
+test_default_cmd() {
+  test_start
+
+  # verify the default command is bash.
+  local container=$(docker_run_withargs $IMAGE_NAME -td) # use '-t' to stop bash from exiting.
+  local processes=$(docker top $container)
+  # cleanup
+  docker_rm ${container}
+
+  # Ensure there is a single bash process.
+  #  The output of 'docker top' looks like
+  #      USER        PID         PPID        %CPU        ELAPSED           TTY         TIME        COMMAND
+  #      root        1           0           0.000       16m30.479579703s  pts/0       0s          /bin/bash
+  assert_equal $(echo "$processes" | wc -l) "2"
+  assert_contains_multiline "$processes" "/bin/bash"
 }
 
 test_image() {
@@ -637,6 +646,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_image
   test_config
   test_usage
+  test_default_cmd
   if [ "$IMAGE_OS" = "RHEL8" ]; then
     test_repos
   fi


### PR DESCRIPTION
In 6.0 I changed the runtime image to start a shell rather than print instructions (https://github.com/redhat-developer/s2i-dotnetcore/pull/396).
I had assumed this would also affect the build image, but that wasn't so.

This makes the same functional change to the build image.