### PR TITLE
Update build chainging documentation url

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ variables of the s2i-dotnetcore builder. It also includes a liveness and a readi
 The dotnet-runtime-example template can be used to create a new .NET Core service in OpenShift. It is meant to serve as an example of
 how to create a 'chained build' where one image is used to build an application but the runtime image is used to deploy the application.
 
-For more information on build chaining in OpenShift, [please see this doc](https://docs.openshift.org/latest/dev_guide/builds/advanced_build_operations.html#dev-guide-chaining-builds).
+For more information on build chaining in OpenShift, [please see this doc](https://docs.okd.io/latest/cicd/builds/advanced-build-operations.html#builds-chaining-builds_advanced-build-operations).
 
 **dotnet-pgsql-persistent**
 


### PR DESCRIPTION
The documentation url describing build chaining in OpenShift is outdated.

Existing url: https://docs.openshift.org/latest/dev_guide/builds/advanced_build_operations.html#dev-guide-chaining-builds does not work anymore.

This PR updates the documentation to an working url: https://docs.okd.io/latest/cicd/builds/advanced-build-operations.html#builds-chaining-builds_advanced-build-operations
