### PR TITLE
Add explicit license label instead of inheriting it fro the base image.

### DIFF
--- a/3.1/build/Dockerfile.rhel8
+++ b/3.1/build/Dockerfile.rhel8
@@ -11,6 +11,7 @@ LABEL io.k8s.description="Platform for building and running .NET Core 3.1 applic
 # Labels consumed by Red Hat build service
 LABEL name="ubi8/dotnet-31" \
       com.redhat.component="dotnet-31-container" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       version="3.1" \
       release="1" \
       architecture="x86_64"

--- a/3.1/runtime/Dockerfile.rhel8
+++ b/3.1/runtime/Dockerfile.rhel8
@@ -26,6 +26,7 @@ LABEL io.k8s.description="Platform for running .NET Core 3.1 applications" \
 # Labels consumed by Red Hat build service
 LABEL name="ubi8/dotnet-31-runtime" \
       com.redhat.component="dotnet-31-runtime-container" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       version="3.1" \
       release="1" \
       architecture="x86_64"

--- a/6.0/build/Dockerfile.rhel8
+++ b/6.0/build/Dockerfile.rhel8
@@ -14,6 +14,7 @@ LABEL io.k8s.description="Platform for building and running .NET 6 applications"
 # Labels consumed by Red Hat build service
 LABEL name="ubi8/dotnet-60" \
       com.redhat.component="dotnet-60-container" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       version="6.0" \
       release="1"
 

--- a/6.0/runtime/Dockerfile.rhel8
+++ b/6.0/runtime/Dockerfile.rhel8
@@ -26,6 +26,7 @@ LABEL io.k8s.description="Platform for running .NET 6 applications" \
 # Labels consumed by Red Hat build service
 LABEL name="ubi8/dotnet-60-runtime" \
       com.redhat.component="dotnet-60-runtime-container" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       version="6.0" \
       release="1"
 

--- a/7.0/build/Dockerfile.rhel8
+++ b/7.0/build/Dockerfile.rhel8
@@ -14,6 +14,7 @@ LABEL io.k8s.description="Platform for building and running .NET 7 applications"
 # Labels consumed by Red Hat build service
 LABEL name="ubi8/dotnet-70" \
       com.redhat.component="dotnet-70-container" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       version="7.0" \
       release="2"
 

--- a/7.0/runtime/Dockerfile.rhel8
+++ b/7.0/runtime/Dockerfile.rhel8
@@ -26,6 +26,7 @@ LABEL io.k8s.description="Platform for running .NET 7 applications" \
 # Labels consumed by Red Hat build service
 LABEL name="ubi8/dotnet-70-runtime" \
       com.redhat.component="dotnet-70-runtime-container" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       version="7.0" \
       release="2"
 


### PR DESCRIPTION
This was requested by the RHEL container program.