### PR TITLE
.NET 7: add missing timezone data.

### DIFF
--- a/7.0/runtime/Dockerfile.rhel8
+++ b/7.0/runtime/Dockerfile.rhel8
@@ -53,6 +53,8 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 RUN INSTALL_PKGS="aspnetcore-runtime-7.0 nss_wrapper findutils shadow-utils tar gzip" && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+# ubi-minimal doesn't include timezones, restore them.
+    microdnf reinstall tzdata -y && \
     microdnf clean all -y && \
  # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*

--- a/7.0/runtime/test/run
+++ b/7.0/runtime/test/run
@@ -39,7 +39,7 @@ source ${test_dir}/testcommon
 dotnet_version_series="7.0"
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
-dotnet_version="7.0.0"
+dotnet_version="7.0.1"
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 dotnet_version="7.0.0"
 fi
@@ -115,6 +115,14 @@ test_data_folder() {
   # check a writable data folder is available
   assert_equal $(docker_run $IMAGE_NAME "stat -c %a /opt/app-root/data") "777"
 }
+
+test_timezones() {
+  test_start
+
+  # verify timezone data is available
+  assert_contains $(docker_run $IMAGE_NAME "stat -c %n /usr/share/zoneinfo/UTC") "/usr/share/zoneinfo/UTC"
+}
+
 
 test_user() {
   test_start
@@ -252,6 +260,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_envvars
   test_default_cmd
   test_data_folder
+  test_timezones
   test_debuggable
   test_user
   test_port


### PR DESCRIPTION
For .NET 7, we switched from the regular ubi base image to ubi-minimal. Unlike the ubi image, the minimal base does not include timezone data by default.

This brings back the timezones.