### PR TITLE
Fix `null byte in input` warnings when running tests

### DIFF
--- a/6.0/build/test/run
+++ b/6.0/build/test/run
@@ -38,8 +38,8 @@ elif [ "$IMAGE_OS" = "FEDORA" ]; then
 fi
 OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 
-test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
-source ${test_dir}/testcommon
+test_dir="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
+source "${test_dir}/testcommon"
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8

--- a/6.0/runtime/test/run
+++ b/6.0/runtime/test/run
@@ -33,8 +33,8 @@ elif [ "$IMAGE_OS" = "FEDORA" ]; then
 fi
 OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 
-test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
-source ${test_dir}/testcommon
+test_dir="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
+source "${test_dir}/testcommon"
 
 dotnet_version_series="6.0"
 

--- a/7.0/build/test/run
+++ b/7.0/build/test/run
@@ -38,8 +38,8 @@ elif [ "$IMAGE_OS" = "FEDORA" ]; then
 fi
 OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 
-test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
-source ${test_dir}/testcommon
+test_dir="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
+source "${test_dir}/testcommon"
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8

--- a/7.0/runtime/test/run
+++ b/7.0/runtime/test/run
@@ -33,8 +33,8 @@ elif [ "$IMAGE_OS" = "FEDORA" ]; then
 fi
 OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 
-test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
-source ${test_dir}/testcommon
+test_dir="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
+source "${test_dir}/testcommon"
 
 dotnet_version_series="7.0"
 


### PR DESCRIPTION
When running tests, I see several warnings like these:

    6.0/build/test/run: line 41: warning: command substitution: ignored null byte in input

It looks like these are coming from the `readlink -zf ...` command. The `-z` flag tells readlink to end the output with null.

That doesn't seem to be useful for us: we use a single file name as input to readlink, so using null to separate multiple file names in the output is of limited value.