### PR TITLE
Use qualified image names.

### DIFF
--- a/6.0/build/test/run
+++ b/6.0/build/test/run
@@ -30,11 +30,11 @@ STOP_ON_ERROR=${STOP_ON_ERROR:-true}
 IMAGE_OS=${IMAGE_OS:-RHEL8}
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
-  IMAGE_NAME=${IMAGE_NAME:-ubi8/dotnet-60}
-  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-ubi8/dotnet-60-runtime}
+  IMAGE_NAME=${IMAGE_NAME:-localhost/ubi8/dotnet-60}
+  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-localhost/ubi8/dotnet-60-runtime}
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
-  IMAGE_NAME=${IMAGE_NAME:-fedora/dotnet-60}
-  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-fedora/dotnet-60-runtime}
+  IMAGE_NAME=${IMAGE_NAME:-localhost/fedora/dotnet-60}
+  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-localhost/fedora/dotnet-60-runtime}
 fi
 OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 

--- a/6.0/build/test/testcommon
+++ b/6.0/build/test/testcommon
@@ -263,7 +263,7 @@ container_url() {
 
 s2i_image_tag() {
   local app="$1"
-  echo "${IMAGE_NAME}-${app}"
+  echo "localhost/${IMAGE_NAME}-${app}"
 }
 
 s2i_build_core() {

--- a/6.0/runtime/test/run
+++ b/6.0/runtime/test/run
@@ -27,9 +27,9 @@ STOP_ON_ERROR=${STOP_ON_ERROR:-true}
 IMAGE_OS=${IMAGE_OS:-RHEL8}
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
-  IMAGE_NAME=${IMAGE_NAME:-ubi8/dotnet-60-runtime}
+  IMAGE_NAME=${IMAGE_NAME:-localhost/ubi8/dotnet-60-runtime}
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
-  IMAGE_NAME=${IMAGE_NAME:-fedora/dotnet-60-runtime}
+  IMAGE_NAME=${IMAGE_NAME:-localhost/fedora/dotnet-60-runtime}
 fi
 OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 

--- a/6.0/runtime/test/testcommon
+++ b/6.0/runtime/test/testcommon
@@ -263,7 +263,7 @@ container_url() {
 
 s2i_image_tag() {
   local app="$1"
-  echo "${IMAGE_NAME}-${app}"
+  echo "localhost/${IMAGE_NAME}-${app}"
 }
 
 s2i_build_core() {

--- a/7.0/build/test/run
+++ b/7.0/build/test/run
@@ -30,11 +30,11 @@ STOP_ON_ERROR=${STOP_ON_ERROR:-true}
 IMAGE_OS=${IMAGE_OS:-RHEL8}
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
-  IMAGE_NAME=${IMAGE_NAME:-ubi8/dotnet-70}
-  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-ubi8/dotnet-70-runtime}
+  IMAGE_NAME=${IMAGE_NAME:-localhost/ubi8/dotnet-70}
+  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-localhost/ubi8/dotnet-70-runtime}
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
-  IMAGE_NAME=${IMAGE_NAME:-fedora/dotnet-70}
-  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-fedora/dotnet-70-runtime}
+  IMAGE_NAME=${IMAGE_NAME:-localhost/fedora/dotnet-70}
+  RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-localhost/fedora/dotnet-70-runtime}
 fi
 OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 

--- a/7.0/build/test/testcommon
+++ b/7.0/build/test/testcommon
@@ -263,7 +263,7 @@ container_url() {
 
 s2i_image_tag() {
   local app="$1"
-  echo "${IMAGE_NAME}-${app}"
+  echo "localhost/${IMAGE_NAME}-${app}"
 }
 
 s2i_build_core() {

--- a/7.0/runtime/test/run
+++ b/7.0/runtime/test/run
@@ -27,9 +27,9 @@ STOP_ON_ERROR=${STOP_ON_ERROR:-true}
 IMAGE_OS=${IMAGE_OS:-RHEL8}
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
-  IMAGE_NAME=${IMAGE_NAME:-ubi8/dotnet-70-runtime}
+  IMAGE_NAME=${IMAGE_NAME:-localhost/ubi8/dotnet-70-runtime}
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
-  IMAGE_NAME=${IMAGE_NAME:-fedora/dotnet-70-runtime}
+  IMAGE_NAME=${IMAGE_NAME:-localhost/fedora/dotnet-70-runtime}
 fi
 OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 

--- a/7.0/runtime/test/testcommon
+++ b/7.0/runtime/test/testcommon
@@ -263,7 +263,7 @@ container_url() {
 
 s2i_image_tag() {
   local app="$1"
-  echo "${IMAGE_NAME}-${app}"
+  echo "localhost/${IMAGE_NAME}-${app}"
 }
 
 s2i_build_core() {

--- a/build.sh
+++ b/build.sh
@@ -114,8 +114,8 @@ elif [ "$IMAGE_OS" = "FEDORA" ]; then
 fi
 
 for v in ${VERSIONS}; do
-  build_name="${image_prefix}/$(base_image_name ${v})${image_postfix}"
-  runtime_name="${image_prefix}/$(base_image_name ${v})-runtime${image_postfix}"
+  build_name="localhost/${image_prefix}/$(base_image_name ${v})${image_postfix}"
+  runtime_name="localhost/${image_prefix}/$(base_image_name ${v})-runtime${image_postfix}"
 
   # Build the runtime image
   build_image "${v}/runtime" "${docker_filename}" "${runtime_name}"


### PR DESCRIPTION
The latest version of source-to-image trips over the short names.