### PR TITLE
7.0: update command to install timezones.

### DIFF
--- a/7.0/runtime/Dockerfile.rhel8
+++ b/7.0/runtime/Dockerfile.rhel8
@@ -54,7 +54,7 @@ RUN INSTALL_PKGS="aspnetcore-runtime-7.0 nss_wrapper findutils shadow-utils tar 
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
 # ubi-minimal doesn't include timezones, restore them.
-    microdnf reinstall tzdata -y && \
+    microdnf update tzdata -y && \
     microdnf clean all -y && \
  # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*


### PR DESCRIPTION
A new version of tzdata is available ('tzdata-2023c'), we need to use the 'update' command instead of the 'reinstall' command to retrieve the timezone data.

cc @omajid @aslicerh 