### PR TITLE
Switch over to NodeJS 16, as NodeJS 14 is going EOL.

### DIFF
--- a/6.0/build/Dockerfile.rhel8
+++ b/6.0/build/Dockerfile.rhel8
@@ -29,7 +29,7 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 # - npm: provides SDK for building NodeJS web front-ends.
 # - procps-ng: provides 'pidof' which is needed by the 'odo' Devfile to find the running 'dotnet' process.
 RUN INSTALL_PKGS="dotnet-sdk-6.0 npm procps-ng" && \
-    yum -y module enable nodejs:14 && \
+    yum -y module enable nodejs:16 && \
     yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \

--- a/6.0/build/test/run
+++ b/6.0/build/test/run
@@ -43,8 +43,8 @@ source "${test_dir}/testcommon"
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8
-sdk_version=6.0.114
-npm_version=6.14.17
+sdk_version=6.0.116
+npm_version=8.19.3
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 # sdk version supported on Fedora
 sdk_version=6.0.113
@@ -282,12 +282,7 @@ test_templates() {
 
   # mvc is a pure ASP.NET Core MVC web application
   # angular and reactredux include a front-end which is built using npm packages.
-  local templates=(mvc angular)
-  # the angular template fails on aarch64/s390x with node-gyp errors.
-  # https://github.com/redhat-developer/s2i-dotnetcore/pull/446#issuecomment-1423668736
-  if [[ "$(uname -m)" == "aarch64" ]] || [[ "$(uname -m)" == "s390x" ]]; then
-    templates=(mvc)
-  fi
+  local templates=(mvc angular react)
   for template in ${templates[@]}; do
     test_template $template
   done

--- a/6.0/runtime/test/run
+++ b/6.0/runtime/test/run
@@ -39,7 +39,7 @@ source "${test_dir}/testcommon"
 dotnet_version_series="6.0"
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
-dotnet_version="6.0.14"
+dotnet_version="6.0.16"
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 dotnet_version="6.0.13"
 fi


### PR DESCRIPTION
This also fixes the issues with the angular and react templates, even on aarch64 and s390x.