### PR TITLE
Update package list for RHEL 8.8 release

### DIFF
--- a/6.0/build/test/packages.rhel8.x86_64.list
+++ b/6.0/build/test/packages.rhel8.x86_64.list
@@ -135,6 +135,7 @@ nodejs
 npm
 npth
 nss_wrapper
+nss_wrapper-libs
 openldap
 openssl
 openssl-libs
@@ -212,6 +213,7 @@ python3-setuptools-wheel
 python3-six
 python3-subscription-manager-rhsm
 python3-syspurpose
+python3-systemd
 python3-urllib3
 readline
 redhat-release

--- a/6.0/runtime/test/packages.rhel8.x86_64.list
+++ b/6.0/runtime/test/packages.rhel8.x86_64.list
@@ -127,6 +127,7 @@ ncurses-libs
 nettle
 npth
 nss_wrapper
+nss_wrapper-libs
 openldap
 openssl-libs
 p11-kit
@@ -202,6 +203,7 @@ python3-setuptools-wheel
 python3-six
 python3-subscription-manager-rhsm
 python3-syspurpose
+python3-systemd
 python3-urllib3
 readline
 redhat-release


### PR DESCRIPTION
This change now makes this command work:

    $ IMAGE_OS=RHEL8 VERSIONS=6.0 ./build.sh