### PR TITLE
Update .NET 7 builds and tests for RHEL 8.8

### DIFF
--- a/6.0/build/test/run
+++ b/6.0/build/test/run
@@ -47,7 +47,7 @@ sdk_version=6.0.116
 npm_version=8.19.3
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 # sdk version supported on Fedora
-sdk_version=6.0.113
+sdk_version=6.0.116
 npm_version=8.15.0
 fi
 

--- a/6.0/runtime/test/run
+++ b/6.0/runtime/test/run
@@ -41,7 +41,7 @@ dotnet_version_series="6.0"
 if [ "$IMAGE_OS" = "RHEL8" ]; then
 dotnet_version="6.0.16"
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
-dotnet_version="6.0.13"
+dotnet_version="6.0.16"
 fi
 
 test_dotnet() {

--- a/7.0/build/test/packages.rhel8.x86_64.list
+++ b/7.0/build/test/packages.rhel8.x86_64.list
@@ -103,6 +103,7 @@ nodejs
 npm
 npth
 nss_wrapper
+nss_wrapper-libs
 openldap
 openssl
 openssl-libs

--- a/7.0/build/test/run
+++ b/7.0/build/test/run
@@ -43,11 +43,11 @@ source "${test_dir}/testcommon"
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8
-sdk_version=7.0.103
-npm_version=8.19.2
+sdk_version=7.0.105
+npm_version=9.5.0
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 # sdk version supported on Fedora
-sdk_version=7.0.102
+sdk_version=7.0.105
 npm_version=8.15.0
 fi
 

--- a/7.0/runtime/test/packages.rhel8.x86_64.list
+++ b/7.0/runtime/test/packages.rhel8.x86_64.list
@@ -95,6 +95,7 @@ ncurses-libs
 nettle
 npth
 nss_wrapper
+nss_wrapper-libs
 openldap
 openssl-libs
 p11-kit

--- a/7.0/runtime/test/run
+++ b/7.0/runtime/test/run
@@ -39,9 +39,9 @@ source "${test_dir}/testcommon"
 dotnet_version_series="7.0"
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
-dotnet_version="7.0.3"
+dotnet_version="7.0.5"
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
-dotnet_version="7.0.2"
+dotnet_version="7.0.5"
 fi
 
 test_dotnet() {


### PR DESCRIPTION
This makes the following pass:

    $ IMAGE_OS=RHEL8 ./build.sh