### PR TITLE
Bump the NodeJS version in the .NET 6 container to NodeJS v18.

### DIFF
--- a/6.0/build/Dockerfile.rhel8
+++ b/6.0/build/Dockerfile.rhel8
@@ -29,7 +29,7 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 # - npm: provides SDK for building NodeJS web front-ends.
 # - procps-ng: provides 'pidof' which is needed by the 'odo' Devfile to find the running 'dotnet' process.
 RUN INSTALL_PKGS="dotnet-sdk-6.0 npm procps-ng" && \
-    yum -y module enable nodejs:16 && \
+    yum -y module enable nodejs:18 && \
     yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \

--- a/6.0/build/test/packages.rhel8.x86_64.list
+++ b/6.0/build/test/packages.rhel8.x86_64.list
@@ -213,7 +213,6 @@ python3-setuptools-wheel
 python3-six
 python3-subscription-manager-rhsm
 python3-syspurpose
-python3-systemd
 python3-urllib3
 readline
 redhat-release

--- a/6.0/build/test/run
+++ b/6.0/build/test/run
@@ -43,8 +43,8 @@ source "${test_dir}/testcommon"
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8
-sdk_version=6.0.116
-npm_version=8.19.3
+sdk_version=6.0.120
+npm_version=9.5.0
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 # sdk version supported on Fedora
 sdk_version=6.0.116

--- a/6.0/runtime/test/packages.rhel8.x86_64.list
+++ b/6.0/runtime/test/packages.rhel8.x86_64.list
@@ -203,7 +203,6 @@ python3-setuptools-wheel
 python3-six
 python3-subscription-manager-rhsm
 python3-syspurpose
-python3-systemd
 python3-urllib3
 readline
 redhat-release

--- a/6.0/runtime/test/run
+++ b/6.0/runtime/test/run
@@ -39,7 +39,7 @@ source "${test_dir}/testcommon"
 dotnet_version_series="6.0"
 
 if [ "$IMAGE_OS" = "RHEL8" ]; then
-dotnet_version="6.0.16"
+dotnet_version="6.0.20"
 elif [ "$IMAGE_OS" = "FEDORA" ]; then
 dotnet_version="6.0.16"
 fi


### PR DESCRIPTION
- Remove python3-systemd from the expected package list.
- Bump the expected versions to 6.0.20/6.0.120