### PR TITLE
Fix 6.0 tests to work

### DIFF
--- a/6.0/build/test/packages.rhel8.x86_64.list
+++ b/6.0/build/test/packages.rhel8.x86_64.list
@@ -213,6 +213,7 @@ python3-setuptools-wheel
 python3-six
 python3-subscription-manager-rhsm
 python3-syspurpose
+python3-systemd
 python3-urllib3
 readline
 redhat-release

--- a/6.0/runtime/test/packages.rhel8.x86_64.list
+++ b/6.0/runtime/test/packages.rhel8.x86_64.list
@@ -203,6 +203,7 @@ python3-setuptools-wheel
 python3-six
 python3-subscription-manager-rhsm
 python3-syspurpose
+python3-systemd
 python3-urllib3
 readline
 redhat-release


### PR DESCRIPTION
This now makes the following work:

    VERSIONS= IMAGE_OS=RHEL8 SKIP_VERSION_CHECK=true ./build.sh