### PR TITLE
Add --no-symlinks to calls to realpath when linking SSL certs.

### DIFF
--- a/7.0/runtime/contrib/etc/trust_ssl_dirs
+++ b/7.0/runtime/contrib/etc/trust_ssl_dirs
@@ -33,7 +33,7 @@ if [ -n "$DOTNET_SSL_DIRS" ]; then
   for SSL_DIR in $_DOTNET_SSL_DIRS; do
     if [ -d "$SSL_DIR" ]; then
       # Create a symbolic link for each certificate in the directory.
-      CERTFILES=(`find -L "$SSL_DIR" -maxdepth 1 -type f -exec realpath {} \;`)
+      CERTFILES=(`find -L "$SSL_DIR" -maxdepth 1 -type f -exec realpath --no-symlinks {} \;`)
       for CERT_FILE in ${CERTFILES[@]}
       do
         ln -s "$CERT_FILE" "$DOTNET_SSL_CERT_DIR/_s2i$CERT_ID"
@@ -41,7 +41,7 @@ if [ -n "$DOTNET_SSL_DIRS" ]; then
       done
     elif [ -f "$SSL_DIR" ]; then
       # Create a symbolic link to the file.
-      CERT_FILE=$(realpath "$SSL_DIR")
+      CERT_FILE=$(realpath --no-symlinks "$SSL_DIR")
       ln -s "$CERT_FILE" "$DOTNET_SSL_CERT_DIR/_s2i$CERT_ID"
       CERT_ID=$((CERT_ID + 1))
     fi


### PR DESCRIPTION
This is in reference to issue #464 .