### PR TITLE
Refactor build script to accept arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ The images support OpenShift [source-to-image](https://github.com/openshift/sour
 Building
 ----------------
 
+You can build (and test) the images by executing the `build.sh` script and pass it the versions to build.
+
 ```
 $ git clone https://github.com/redhat-developer/s2i-dotnetcore.git
-$ ./build.sh 7.0
+$ ./build.sh 6.0 7.0
 ```
 
 To override the default basis of the image, you can use the `--base-os` argument. For example: `--base-os fedora` or `--base-os rhel8`.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ Building
 
 ```
 $ git clone https://github.com/redhat-developer/s2i-dotnetcore.git
-$ sudo VERSIONS=7.0 ./build.sh
+$ ./build.sh 7.0
 ```
 
-To override the default basis of the image, set `IMAGE_OS` to the desired base system, such as `IMAGE_OS=FEDORA` or `IMAGE_OS=RHEL8`.
+To override the default basis of the image, you can use the `--base-os` argument. For example: `--base-os fedora` or `--base-os rhel8`.
+
+For an overview of all build script arguments, run: `./build.sh --help`.
 
 Installing
 ----------------

--- a/build.sh
+++ b/build.sh
@@ -23,28 +23,12 @@ print_usage()
 RUN_TESTS=true
 DOTNET_TARBALL=
 CI=false
-if [ $# -eq 0 ]; then
-  # backwards compatibility: accept arguments through environment variables.
-  DEBUG=${DEBUG:-}
-  if [ "${DEBUG}" == "true" ]; then
-    set -x
-  fi
-  BASE_OS=$(echo "${IMAGE_OS:-}" | tr '[:upper:]' '[:lower:]')
-  VERSIONS="${VERSIONS:-}"
-  TEST_PORT="${TEST_PORT:-}"
-  RUN_BUILD=
-  if [ "${FORCE:-}" != "false" ]; then
-    RUN_BUILD=true
-  fi
-  STOP_ON_ERROR=${STOP_ON_ERROR:-true}
-else
-  DEBUG=
-  BASE_OS=
-  VERSIONS=""
-  TEST_PORT=8080
-  RUN_BUILD=true
-  STOP_ON_ERROR=true
-fi
+DEBUG=
+BASE_OS=
+VERSIONS=""
+TEST_PORT=8080
+RUN_BUILD=true
+STOP_ON_ERROR=true
 
 while [ $# -ne 0 ]
 do
@@ -138,10 +122,6 @@ build_image() {
   local name=$3
 
   if [ "$RUN_BUILD" == "false" ]; then
-    return
-  fi
-
-  if [ "$RUN_BUILD" == "" ] && image_exists ${name}; then
     return
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ print_usage()
     echo "  --test-port <port>       Local TCP port used for tests"
     echo "  --debug                  Print the bash script commands before executing them"
     echo "  --dotnet-tarball <url>   Tarball containing a .NET SDK to be used instead of distro packages"
-    echo "  --ci                     Indicates the .NET version built is an unreleased CI version"
+    echo "  --ci                     Indicates the build is a CI/dev version."
 }
 
 RUN_TESTS=true

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,7 @@ print_usage()
     echo ""
     echo "Arguments:"
     echo "  --base-os   <os>         Choose between different Dockerfiles"
+    echo "  --continue-on-error      Don't stop executing tests when an error occurs"
     echo "  --no-build               Skip building the image"
     echo "  --no-test                Skip running the tests"
     echo "  --test-port <port>       Local TCP port used for tests"
@@ -35,12 +36,14 @@ if [ $# -eq 0 ]; then
   if [ "${FORCE:-}" != "false" ]; then
     RUN_BUILD=true
   fi
+  STOP_ON_ERROR=${STOP_ON_ERROR:-true}
 else
   DEBUG=
   BASE_OS=
   VERSIONS=""
   TEST_PORT=8080
   RUN_BUILD=true
+  STOP_ON_ERROR=true
 fi
 
 while [ $# -ne 0 ]
@@ -68,6 +71,9 @@ do
         --debug)
             set -x
             DEBUG=true
+            ;;
+        --continue-on-error)
+            STOP_ON_ERROR=false
             ;;
         --ci)
             CI=true
@@ -163,7 +169,7 @@ test_images() {
   local image_os=$(echo "$base_os" | tr '[:lower:]' '[:upper:]')
 
   echo "Running tests..."
-  DEBUG=$DEBUG IMAGE_OS=${image_os} SKIP_VERSION_CHECK=$CI IMAGE_NAME=${test_image} RUNTIME_IMAGE_NAME=${runtime_image} ${path}/run
+  STOP_ON_ERROR=$STOP_ON_ERROR DEBUG=$DEBUG IMAGE_OS=${image_os} SKIP_VERSION_CHECK=$CI IMAGE_NAME=${test_image} RUNTIME_IMAGE_NAME=${runtime_image} ${path}/run
   check_result_msg $? "Tests FAILED!"
 }
 

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 print_usage()
 {
-    echo "Usage: $0 <VERSION>..."
+    echo "Usage: $0 [<VERSION>...]"
     echo "Build Container images and run tests."
     echo ""
     echo "Arguments:"
@@ -92,9 +92,9 @@ done
 
 VERSIONS=$(echo "$VERSIONS" | xargs)
 
+# default to building the currently supported versions.
 if [ -z "$VERSIONS" ]; then
-  echo "error: no versions specified" 2>&1
-  exit 1
+  VERSIONS="6.0 7.0"
 fi
 
 # Use podman instead of docker when available.


### PR DESCRIPTION
The build script can be invoked with one (or more) version(s) to be tested.

For example:
./build.sh 6.0

It's possible to opt-out of the image build and test runs using the '--no-build' and '--no-test' arguments.

For a full list of arguments, run './build.sh --help'.