### PR TITLE
8.0: remove unneeded mapping from HTTP_PROXY to http_proxy.

### DIFF
--- a/8.0/runtime/root/usr/bin/container-entrypoint
+++ b/8.0/runtime/root/usr/bin/container-entrypoint
@@ -2,14 +2,6 @@
 
 set -e
 
-# .NET uses libcurl for HTTP handling. libcurl doesn't use 'HTTP_PROXY', but uses 'http_proxy'.
-# libcurl is not using the upper-case to avoid exploiting httpoxy in CGI-like environments (https://httpoxy.org/).
-# CGI-like environments must be fixed for this exploit (https://access.redhat.com/security/vulnerabilities/httpoxy).
-# In an OpenShift context, it is common to use the upper-case 'HTTP_PROXY'.
-if [ -z "$http_proxy" ] && [ ! -z "$HTTP_PROXY" ]; then
-  export http_proxy="${HTTP_PROXY}"
-fi
-
 # Trust certificates from DOTNET_SSL_DIRS.
 if [ -n "$DOTNET_SSL_DIRS" ]; then
   # The main process (PID 1) sets up a certificate folder. The other processes use it.

--- a/8.0/runtime/test/run
+++ b/8.0/runtime/test/run
@@ -65,10 +65,6 @@ test_envvars() {
   # DOTNET_FRAMEWORK
   assert_equal $(docker_get_env $IMAGE_NAME DOTNET_FRAMEWORK) "net${dotnet_version_series}"
 
-  # When HTTP_PROXY is set, we set http_proxy to match (unless it's already set).
-  assert_equal $(docker_run_withargs $IMAGE_NAME "-e HTTP_PROXY=proxy0"                      bash -c 'echo $http_proxy') "proxy0"
-  assert_equal $(docker_run_withargs $IMAGE_NAME "-e HTTP_PROXY=proxy0 -e http_proxy=proxy1" bash -c 'echo $http_proxy') "proxy1"
-
   # .NET determines culture based on LANG. It must be empty/unset to use the 'Invariant' culture
   assert_equal $(docker_get_env $IMAGE_NAME LANG) ""
 


### PR DESCRIPTION
This mapping was needed when .NET's HTTP stack used curl under the hood. The curl handler was removed in .NET 5, so we no longer need this.

Fixes https://github.com/redhat-developer/s2i-dotnetcore/issues/455.