### PR TITLE
8.0: remove Node.js.

### DIFF
--- a/8.0/build/Dockerfile.rhel8
+++ b/8.0/build/Dockerfile.rhel8
@@ -28,10 +28,9 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 
 # Install packages:
 # - dotnet-sdk--*: provides the .NET SDK.
-# - npm: provides SDK for building NodeJS web front-ends.
 # - procps-ng: provides 'pidof' which is needed by the 'odo' Devfile to find the running 'dotnet' process.
 RUN [ -n "${DOTNET_TARBALL}" ] || ( \
-    INSTALL_PKGS="dotnet-sdk-8.0 npm procps-ng" && \
+    INSTALL_PKGS="dotnet-sdk-8.0 procps-ng" && \
     microdnf -y module enable nodejs:18 && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
@@ -40,7 +39,7 @@ RUN [ -n "${DOTNET_TARBALL}" ] || ( \
     rm -rf /var/cache/yum/* )
 # Tarball install (in the runtime base image)
 RUN [ -z "${DOTNET_TARBALL}" ] || ( \
-    INSTALL_PKGS="npm procps-ng" && \
+    INSTALL_PKGS="procps-ng" && \
     microdnf -y module enable nodejs:18 && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/8.0/build/Dockerfile.rhel8
+++ b/8.0/build/Dockerfile.rhel8
@@ -4,7 +4,7 @@ FROM ubi8/dotnet-80-runtime
 
 ARG DOTNET_TARBALL
 
-ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/node_modules/.bin:/opt/app-root/.dotnet/tools/:${PATH} \
+ENV PATH=/opt/app-root/src/.local/bin:/opt/app-root/src/bin:/opt/app-root/.dotnet/tools/:${PATH} \
     STI_SCRIPTS_PATH=/usr/libexec/s2i \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
 # This skips the first time running text
@@ -31,7 +31,6 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 # - procps-ng: provides 'pidof' which is needed by the 'odo' Devfile to find the running 'dotnet' process.
 RUN [ -n "${DOTNET_TARBALL}" ] || ( \
     INSTALL_PKGS="dotnet-sdk-8.0 procps-ng" && \
-    microdnf -y module enable nodejs:18 && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     microdnf clean all -y && \
@@ -40,7 +39,6 @@ RUN [ -n "${DOTNET_TARBALL}" ] || ( \
 # Tarball install (in the runtime base image)
 RUN [ -z "${DOTNET_TARBALL}" ] || ( \
     INSTALL_PKGS="procps-ng" && \
-    microdnf -y module enable nodejs:18 && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     microdnf clean all -y && \

--- a/8.0/build/README.md
+++ b/8.0/build/README.md
@@ -128,11 +128,6 @@ a `.s2i/environment` file inside your source code repository.
     Used to specify a list of .NET tools to install before building the app. It is possible to install a specific version by postpending
     the package name with `@<version>`. Defaults to ``.
 
-* **DOTNET_NPM_TOOLS**
-
-    Used to specify a list of npm packages to install before building the app.
-    Defaults to ``.
-
 * **DOTNET_TEST_PROJECTS**
 
     Used to specify the list of test projects to run. This must be project files or folders containing a
@@ -173,10 +168,6 @@ a `.s2i/environment` file inside your source code repository.
     When set to `true`, the NuGet packages will be kept so they can be re-used for an incremental build.
     Defaults to `false`.
 
-* **NPM_MIRROR**
-
-    Use a custom NPM registry mirror to download packages during the build process.
-
 * **DOTNET_STARTUP_ASSEMBLY**
 
     Used to specify the path of the entrypoint assembly within the source repository. When set,
@@ -190,9 +181,3 @@ a `.s2i/environment` file inside your source code repository.
 
     This is set to `true` to ensure the `dotnet watch` command works in a container. This command is not used by the default scripts.
 
-NPM
----
-
-Typical modern web applications rely on javascript tools to build the front-end.
-The image includes npm (node package manager) to install these tools. Packages can be
-installed by setting `DOTNET_NPM_TOOLS` and by calling `npm install` in the build process.

--- a/8.0/build/s2i/bin/assemble
+++ b/8.0/build/s2i/bin/assemble
@@ -122,28 +122,6 @@ if [ "$BUILD_TYPE" == "source" ]; then
   # Trust certificates from DOTNET_SSL_DIRS.
   source /opt/app-root/etc/trust_ssl_dirs
 
-  # npm
-  if [ ! -z $NPM_MIRROR ]; then
-    echo "---> Setting npm mirror"
-    npm config set registry $NPM_MIRROR
-  fi
-  if [ -n "${DOTNET_NPM_TOOLS}" ]; then
-    echo "---> Installing npm tools..."
-
-    if [ ! -z $HTTP_PROXY ]; then
-      echo "---> Setting npm http proxy"
-      npm config set proxy $HTTP_PROXY
-    fi
-    if [ ! -z $HTTPS_PROXY ]; then
-      echo "---> Setting npm https proxy"
-      npm config set https-proxy $HTTPS_PROXY
-    fi
-
-    pushd /opt/app-root
-    npm install ${DOTNET_NPM_TOOLS}
-    popd
-  fi
-
   # dotnet tools
   if [ -n "${DOTNET_TOOLS}" ]; then
     # Build nuget sources list for when doing the restore

--- a/8.0/build/test/asp-net-hello-world-envvar/.s2i/environment
+++ b/8.0/build/test/asp-net-hello-world-envvar/.s2i/environment
@@ -5,7 +5,6 @@ DOTNET_TEST_PROJECTS=test/test1 test/test2
 DOTNET_ASSEMBLY_NAME=SampleApp
 DOTNET_RESTORE_SOURCES=https://api.nuget.org/v3/index.json https://www.myget.org/F/s2i-dotnetcore
 DOTNET_PACK=true
-DOTNET_NPM_TOOLS=gulp
 DOTNET_TOOLS=dotnet-symbol@1.0.5 dotnet-rpm
 DOTNET_RM_SRC=true
 DOTNET_INFO=true

--- a/8.0/build/test/packages.rhel8.x86_64.list
+++ b/8.0/build/test/packages.rhel8.x86_64.list
@@ -83,11 +83,8 @@ mpfr
 ncurses-base
 ncurses-libs
 nettle
-nodejs
-npm
 npth
 openldap
-openssl
 openssl-libs
 p11-kit
 p11-kit-trust

--- a/8.0/build/test/run
+++ b/8.0/build/test/run
@@ -39,7 +39,6 @@ source "${test_dir}/testcommon"
 if [ "$IMAGE_OS" = "RHEL8" ]; then
 # sdk version supported on RHEL8
 sdk_version=8.0.100-rc.1.23463.5
-npm_version=9.5.1
 fi
 
 sample_app_url="https://github.com/redhat-developer/s2i-dotnetcore-ex.git"
@@ -124,12 +123,6 @@ test_image() {
 
   # Verify the `dotnet watch` command can detect file changes in the container.
   assert_contains "${env}" "DOTNET_USE_POLLING_FILE_WATCHER=true$"
-
-  # verify npm is available
-  local image_npm_version=$(docker_run ${IMAGE_NAME} 'npm --version')
-  if [ "$SKIP_VERSION_CHECK" != "true" ]; then
-    assert_equal "${image_npm_version}" "${npm_version}"
-  fi
 
   # verify no 'Welcome' message appears, due to running first time actions in build Dockerfile.
   local dotnet_help=$(docker_run ${IMAGE_NAME} 'dotnet help')
@@ -267,7 +260,6 @@ test_templates() {
   test_start
 
   # mvc is a pure ASP.NET Core MVC web application
-  # angular and reactredux include a front-end which is built using npm packages.
   local templates=(mvc)
   for template in ${templates[@]}; do
     test_template $template
@@ -293,8 +285,6 @@ test_config_1() {
   local dotnetrpm_path=$(docker_run ${image} bash -c "command -v dotnet-rpm")
   local packed_app=$(docker_run ${image} ls /opt/app-root/app.tar.gz)
   local src_folder_content=$(docker_run ${image} ls -a /opt/app-root/src)
-  # ;true is there because 'npm ls' can error, for some random reason
-  local npm_packages=$(docker_run ${image} bash -c "npm ls; true")
   # start container
   local container=$(docker_run_d ${image})
   local url=$(container_url ${container})
@@ -320,8 +310,6 @@ test_config_1() {
   # DOTNET_PACK=true
   assert_contains "${s2i_build}" "Packing application..."
   assert_equal "${packed_app}" "/opt/app-root/app.tar.gz"
-  # DOTNET_NPM_TOOLS=gulp
-  assert_contains "${npm_packages}" "gulp@"
   # DOTNET_TOOLS=dotnet-symbol@1.0.5 dotnet-serve
   assert_equal "${watch_path}" "/opt/app-root/.dotnet/tools/dotnet-symbol"
   assert_equal "${dotnetrpm_path}" "/opt/app-root/.dotnet/tools/dotnet-rpm"
@@ -626,22 +614,6 @@ test_rpm_packages() {
   assert_equal "$?" 0
 }
 
-test_npm_mirror() {
-  test_start
-
-  local app=asp-net-hello-world
-  local image=$(s2i_image_tag ${app})
-  local enabled_string="---> Setting npm mirror"
-
-  # Check that it isn't setting an npm mirror when it is not specified
-  local s2i_build=$(s2i_build_output_log ${app} ${image})
-  assert_not_contains "${s2i_build}" "${enabled_string}"
-
-  # And check that it is setting an npm mirror when it is specified
-  local s2i_build=$(s2i_build_output_log ${app} ${image} -e NPM_MIRROR='https://TEST.MIRROR')
-  assert_contains "${s2i_build}" "${enabled_string}"
-}
-
 test_rm_tmp_dotnet() {
   test_start
 
@@ -674,7 +646,6 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
     test_rpm_packages
   fi
   test_rm_tmp_dotnet
-  test_npm_mirror
   test_consoleapp
   test_multiframework
   test_fsharp


### PR DESCRIPTION
Node.js was included since .NET Core 1.0 in our images because that was the front-end framework used by the .NET templates at the time and there was no .NET-based alternative available.

For .NET 8, the SDK no longer includes any Node.js-based templates, and the templates use Blazor for the front-end.

In line with these upstream changes, we are removing Node.js from the .NET 8 SDK image.

This is a breaking changes. Users migrating to the .NET 8 image that depend on Node.js will need to adjust their build. One option is to created an image derived from the .NET 8 image and install Node.js. Another option is to change to use a multi-stage build which builds the front-end in a separate stage, which may use the Node.js UBI images.

Fixes https://github.com/redhat-developer/s2i-dotnetcore/issues/384.