### PR TITLE
Stop bash from printing locale warnings when invoked through an Exec Task.

### DIFF
--- a/6.0/build/Dockerfile.fedora
+++ b/6.0/build/Dockerfile.fedora
@@ -26,9 +26,10 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 
 # Install packages:
 # - dotnet-sdk--*: provides the .NET SDK.
-# - npm: provides SDK for building NodeJS web front-ends.
+# - nodejs-npm: provides SDK for building NodeJS web front-ends.
 # - procps-ng: provides 'pidof' which is needed by the 'odo' Devfile to find the running 'dotnet' process.
-RUN INSTALL_PKGS="npm nodejs-nodemon dotnet-sdk-6.0 rsync procps-ng findutils" && \
+# - glibc-langpack-en: stop bash from printing warnings about the 'en_US' locale when invoked through an MSBuild Exec Task.
+RUN INSTALL_PKGS="nodejs-npm nodejs-nodemon dotnet-sdk-6.0 rsync procps-ng findutils glibc-langpack-en" && \
     yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \

--- a/6.0/build/Dockerfile.rhel8
+++ b/6.0/build/Dockerfile.rhel8
@@ -28,7 +28,8 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 # - dotnet-sdk--*: provides the .NET SDK.
 # - npm: provides SDK for building NodeJS web front-ends.
 # - procps-ng: provides 'pidof' which is needed by the 'odo' Devfile to find the running 'dotnet' process.
-RUN INSTALL_PKGS="dotnet-sdk-6.0 npm procps-ng" && \
+# - glibc-langpack-en: stop bash from printing warnings about the 'en_US' locale when invoked through an MSBuild Exec Task.
+RUN INSTALL_PKGS="dotnet-sdk-6.0 npm procps-ng glibc-langpack-en" && \
     yum -y module enable nodejs:18 && \
     yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/6.0/build/test/msbuild-exec-task/Program.cs
+++ b/6.0/build/test/msbuild-exec-task/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace HelloWorldSample 
+{
+	public static class Program 
+	{
+		public static void Main() 
+		{
+			Console.WriteLine("Hello World!");
+		}
+	}
+}

--- a/6.0/build/test/msbuild-exec-task/console.csproj
+++ b/6.0/build/test/msbuild-exec-task/console.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <DebugType>portable</DebugType>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <Target Name="RunExecTask" AfterTargets="Build">
+    <!-- Under LogStandardErrorAsError, any standard error output results a failed Task. -->
+    <Exec Command="echo Running RunExecTask" LogStandardErrorAsError="true" />
+  </Target>
+
+</Project>

--- a/6.0/build/test/run
+++ b/6.0/build/test/run
@@ -674,6 +674,27 @@ test_rm_tmp_dotnet() {
   assert_contains "${tmp_dotnet}" "No such file or directory"
 }
 
+test_msbuild_exec_task() {
+  test_start
+
+  # msbuild-exec-task uses an MSBuild Exec Task.
+  # MSBuild Exec sets the en_US locale. This test verifies the locale doesn't cause issues in the container image.
+  # See https://github.com/redhat-developer/s2i-dotnetcore/issues/478.
+  local app=msbuild-exec-task
+
+  # build image
+  local image=$(s2i_image_tag ${app})
+  local s2i_build=$(s2i_build_output_log ${app} ${image})
+
+  # cleanup
+  docker_rmi ${image}
+
+  # verify the Exec task ran
+  assert_contains "${s2i_build}" "Running RunExecTask"
+  # verify the build did not fail
+  assert_completed_build ${image} "${s2i_build}"
+}
+
 info "Testing ${IMAGE_NAME}"
 
 if [ ${OPENSHIFT_ONLY} != true ]; then
@@ -699,6 +720,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_binary
   test_incremental
   test_incremental_without_packages
+  test_msbuild_exec_task
 else
   test_imagestream_sample
 fi

--- a/7.0/build/Dockerfile.fedora
+++ b/7.0/build/Dockerfile.fedora
@@ -26,16 +26,15 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 
 # Install packages:
 # - dotnet-sdk--*: provides the .NET SDK.
-# - npm: provides SDK for building NodeJS web front-ends.
+# - nodejs-npm: provides SDK for building NodeJS web front-ends.
 # - procps-ng: provides 'pidof' which is needed by the 'odo' Devfile to find the running 'dotnet' process.
-# TODO: Use proper packages
-# RUN INSTALL_PKGS="npm nodejs-nodemon dotnet-sdk-7.0 rsync procps-ng findutils" && \
-#     yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False $INSTALL_PKGS && \
-#     rpm -V $INSTALL_PKGS && \
-#     yum clean all -y && \
-# # yum cache files may still exist (and quite large in size)
-#     rm -rf /var/cache/yum/*
-RUN dnf install -y npm nodejs-nodemon rsync procps-ng findutils
+# - glibc-langpack-en: stop bash from printing warnings about the 'en_US' locale when invoked through an MSBuild Exec Task.
+RUN INSTALL_PKGS="nodejs-npm nodejs-nodemon dotnet-sdk-7.0 rsync procps-ng findutils glibc-langpack-en" && \
+    yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y && \
+# yum cache files may still exist (and quite large in size)
+    rm -rf /var/cache/yum/*
 
 # Directory with the sources is set as the working directory.
 RUN mkdir /opt/app-root/src

--- a/7.0/build/Dockerfile.rhel8
+++ b/7.0/build/Dockerfile.rhel8
@@ -28,7 +28,8 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 # - dotnet-sdk--*: provides the .NET SDK.
 # - npm: provides SDK for building NodeJS web front-ends.
 # - procps-ng: provides 'pidof' which is needed by the 'odo' Devfile to find the running 'dotnet' process.
-RUN INSTALL_PKGS="dotnet-sdk-7.0 npm procps-ng" && \
+# - glibc-langpack-en: stop bash from printing warnings about the 'en_US' locale when invoked through an MSBuild Exec Task.
+RUN INSTALL_PKGS="dotnet-sdk-7.0 npm procps-ng glibc-langpack-en" && \
     microdnf -y module enable nodejs:18 && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/7.0/build/test/msbuild-exec-task/Program.cs
+++ b/7.0/build/test/msbuild-exec-task/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace HelloWorldSample 
+{
+	public static class Program 
+	{
+		public static void Main() 
+		{
+			Console.WriteLine("Hello World!");
+		}
+	}
+}

--- a/7.0/build/test/msbuild-exec-task/console.csproj
+++ b/7.0/build/test/msbuild-exec-task/console.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <DebugType>portable</DebugType>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <Target Name="RunExecTask" AfterTargets="Build">
+    <!-- Under LogStandardErrorAsError, any standard error output results a failed Task. -->
+    <Exec Command="echo Running RunExecTask" LogStandardErrorAsError="true" />
+  </Target>
+
+</Project>

--- a/7.0/build/test/run
+++ b/7.0/build/test/run
@@ -683,6 +683,27 @@ test_rm_tmp_dotnet() {
   assert_contains "${tmp_dotnet}" "No such file or directory"
 }
 
+test_msbuild_exec_task() {
+  test_start
+
+  # msbuild-exec-task uses an MSBuild Exec Task.
+  # MSBuild Exec sets the en_US locale. This test verifies the locale doesn't cause issues in the container image.
+  # See https://github.com/redhat-developer/s2i-dotnetcore/issues/478.
+  local app=msbuild-exec-task
+
+  # build image
+  local image=$(s2i_image_tag ${app})
+  local s2i_build=$(s2i_build_output_log ${app} ${image})
+
+  # cleanup
+  docker_rmi ${image}
+
+  # verify the Exec task ran
+  assert_contains "${s2i_build}" "Running RunExecTask"
+  # verify the build did not fail
+  assert_completed_build ${image} "${s2i_build}"
+}
+
 info "Testing ${IMAGE_NAME}"
 
 if [ ${OPENSHIFT_ONLY} != true ]; then
@@ -711,6 +732,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_binary
   test_incremental
   test_incremental_without_packages
+  test_msbuild_exec_task
 else
   test_imagestream_sample
 fi

--- a/7.0/runtime/Dockerfile.fedora
+++ b/7.0/runtime/Dockerfile.fedora
@@ -50,19 +50,12 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 # - aspnetcore-runtime-*: provides the .NET runtime and ASP.NET Core shared framework.
 # - nss_wrapper: used by the 'generate_container_user' script.
 # - findutils: provides 'find' which is used by the 'assemble' script.
-# TODO: Use proper packages
-# RUN INSTALL_PKGS="aspnetcore-runtime-7.0 nss_wrapper findutils" && \
-#     yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False $INSTALL_PKGS && \
-#     rpm -V $INSTALL_PKGS && \
-#     yum clean all -y && \
-# # yum cache files may still exist (and quite large in size)
-#     rm -rf /var/cache/yum/*
-RUN dnf install -y nss_wrapper tar gzip unzip findutils libicu && \
-    curl https://download.visualstudio.microsoft.com/download/pr/bf594dbb-5ec8-486b-8395-95058e719e1c/42e8bc351654ed4c3ccaed58ea9180a1/dotnet-sdk-7.0.100-rc.1.22431.12-linux-x64.tar.gz -o /tmp/dotnet.tar.gz && \
-    mkdir /opt/dotnet && \
-    tar -xf /tmp/dotnet.tar.gz -C /opt/dotnet && \
-    ln -s /opt/dotnet/dotnet /usr/bin/dotnet
-ENV DOTNET_ROOT=/opt/dotnet
+RUN INSTALL_PKGS="aspnetcore-runtime-7.0 nss_wrapper findutils" && \
+    yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y && \
+# yum cache files may still exist (and quite large in size)
+    rm -rf /var/cache/yum/*
 
 # Add default user
 RUN mkdir -p ${DOTNET_APP_PATH} ${DOTNET_DATA_PATH} && \

--- a/8.0/build/Dockerfile.rhel8
+++ b/8.0/build/Dockerfile.rhel8
@@ -35,8 +35,9 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 # Install packages:
 # - dotnet-sdk--*: provides the .NET SDK.
 # - procps-ng: provides 'pidof' which is needed by the 'odo' Devfile to find the running 'dotnet' process.
+# - glibc-langpack-en: stop bash from printing warnings about the 'en_US' locale when invoked through an MSBuild Exec Task.
 RUN [ -n "${DOTNET_TARBALL}" ] || ( \
-    INSTALL_PKGS="dotnet-sdk-8.0 procps-ng" && \
+    INSTALL_PKGS="dotnet-sdk-8.0 procps-ng glibc-langpack-en" && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     microdnf clean all -y && \
@@ -44,7 +45,7 @@ RUN [ -n "${DOTNET_TARBALL}" ] || ( \
     rm -rf /var/cache/yum/* )
 # Tarball install (in the runtime base image)
 RUN [ -z "${DOTNET_TARBALL}" ] || ( \
-    INSTALL_PKGS="procps-ng" && \
+    INSTALL_PKGS="procps-ng glibc-langpack-en" && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     microdnf clean all -y && \

--- a/8.0/build/test/msbuild-exec-task/Program.cs
+++ b/8.0/build/test/msbuild-exec-task/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace HelloWorldSample 
+{
+	public static class Program 
+	{
+		public static void Main() 
+		{
+			Console.WriteLine("Hello World!");
+		}
+	}
+}

--- a/8.0/build/test/msbuild-exec-task/console.csproj
+++ b/8.0/build/test/msbuild-exec-task/console.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <DebugType>portable</DebugType>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <Target Name="RunExecTask" AfterTargets="Build">
+    <!-- Under LogStandardErrorAsError, any standard error output results a failed Task. -->
+    <Exec Command="echo Running RunExecTask" LogStandardErrorAsError="true" />
+  </Target>
+
+</Project>

--- a/8.0/build/test/run
+++ b/8.0/build/test/run
@@ -630,6 +630,27 @@ test_rm_tmp_dotnet() {
   assert_contains "${tmp_dotnet}" "No such file or directory"
 }
 
+test_msbuild_exec_task() {
+  test_start
+
+  # msbuild-exec-task uses an MSBuild Exec Task.
+  # MSBuild Exec sets the en_US locale. This test verifies the locale doesn't cause issues in the container image.
+  # See https://github.com/redhat-developer/s2i-dotnetcore/issues/478.
+  local app=msbuild-exec-task
+
+  # build image
+  local image=$(s2i_image_tag ${app})
+  local s2i_build=$(s2i_build_output_log ${app} ${image})
+
+  # cleanup
+  docker_rmi ${image}
+
+  # verify the Exec task ran
+  assert_contains "${s2i_build}" "Running RunExecTask"
+  # verify the build did not fail
+  assert_completed_build ${image} "${s2i_build}"
+}
+
 info "Testing ${IMAGE_NAME}"
 
 if [ ${OPENSHIFT_ONLY} != true ]; then
@@ -657,6 +678,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_binary
   test_incremental
   test_incremental_without_packages
+  test_msbuild_exec_task
 else
   test_imagestream_sample
 fi


### PR DESCRIPTION
MSBuild Exec Tasks set the locale to en_US. Because that locale is not available in our images, it causes bash to print warnings to standard error. This error output will even cause the Task to fail when it has LogStandardErrorAsError set.

This installs the en_US locale to stop bash from printing these warnings.

Fixes https://github.com/redhat-developer/s2i-dotnetcore/issues/478.