### PR TITLE
.NET 8: remove glibc-langpack-en package.

### DIFF
--- a/8.0/build/Dockerfile.rhel8
+++ b/8.0/build/Dockerfile.rhel8
@@ -35,9 +35,8 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 # Install packages:
 # - dotnet-sdk--*: provides the .NET SDK.
 # - procps-ng: provides 'pidof' which is needed by the 'odo' Devfile to find the running 'dotnet' process.
-# - glibc-langpack-en: stop bash from printing warnings about the 'en_US' locale when invoked through an MSBuild Exec Task.
 RUN [ -n "${DOTNET_TARBALL}" ] || ( \
-    INSTALL_PKGS="dotnet-sdk-8.0 procps-ng glibc-langpack-en" && \
+    INSTALL_PKGS="dotnet-sdk-8.0 procps-ng" && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     microdnf clean all -y && \
@@ -45,7 +44,7 @@ RUN [ -n "${DOTNET_TARBALL}" ] || ( \
     rm -rf /var/cache/yum/* )
 # Tarball install (in the runtime base image)
 RUN [ -z "${DOTNET_TARBALL}" ] || ( \
-    INSTALL_PKGS="procps-ng glibc-langpack-en" && \
+    INSTALL_PKGS="procps-ng" && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     microdnf clean all -y && \


### PR DESCRIPTION
We've added this package to workaround an issue with MSBuild. The issue was fixed upstream for .NET 8.0.201, and we've backported that fix in our 8.0.1xx SDK.