### PR TITLE
.NET 7 is now EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The images support OpenShift [source-to-image](https://github.com/openshift/sour
 | Version | OS | Documentation
 |--|--|--|
 | 6.0 | UBI 8, Fedora | [SDK image](6.0/build/README.md) <br/> [Runtime image](6.0/runtime/README.md)
-| 7.0 | UBI 8, Fedora | [SDK image](7.0/build/README.md) <br/> [Runtime image](7.0/runtime/README.md)
 | 8.0 | UBI 8         | [SDK image](8.0/build/README.md) <br/> [Runtime image](8.0/runtime/README.md)
 
 ## EOL Versions
@@ -24,6 +23,7 @@ The images support OpenShift [source-to-image](https://github.com/openshift/sour
 | 3.0 | RHEL 7, UBI 8 | [SDK image](3.0/build/README.md) <br/> [Runtime image](3.0/runtime/README.md)
 | 3.1 | RHEL 7, UBI 8,  <br/> CentOS 7, Fedora | [SDK image](3.1/build/README.md) <br/> [Runtime image](3.1/runtime/README.md)
 | 5.0 | UBI 8, CentOS 7,  <br/> Fedora | [SDK image](5.0/build/README.md) <br/> [Runtime image](5.0/runtime/README.md)
+| 7.0 | UBI 8, Fedora | [SDK image](7.0/build/README.md) <br/> [Runtime image](7.0/runtime/README.md)
 
 Building
 ----------------
@@ -32,7 +32,7 @@ You can build (and test) the images by executing the `build.sh` script and pass 
 
 ```
 $ git clone https://github.com/redhat-developer/s2i-dotnetcore.git
-$ ./build.sh --ci 6.0 7.0
+$ ./build.sh --ci 6.0 8.0
 ```
 
 To override the default basis of the image, you can use the `--base-os` argument. For example: `--base-os fedora` or `--base-os rhel8`.

--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,7 @@ VERSIONS=$(echo "$VERSIONS" | xargs)
 
 # default to building the currently supported versions.
 if [ -z "$VERSIONS" ]; then
-  VERSIONS="6.0 7.0"
+  VERSIONS="6.0 8.0"
 fi
 
 # Use podman instead of docker when available.

--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -84,48 +84,6 @@
                         }
                     },
                     {
-                        "name": "7.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 (UBI 8)",
-                            "description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet70",
-                            "supports": "dotnet:7.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnet-7.0",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-                        }
-                    },
-                    {
-                        "name": "7.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 (UBI 8)",
-                            "description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet70,hidden",
-                            "supports": "dotnet:7.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-7.0",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-                        }
-                    },
-                    {
                         "name": "6.0-ubi8",
                         "annotations": {
                             "openshift.io/display-name": ".NET 6 (UBI 8)",
@@ -233,42 +191,6 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
-                        }
-                    },
-                    {
-                        "name": "7.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-                            "description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports": "dotnet-runtime",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
-                        }
-                    },
-                    {
-                        "name": "7.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-                            "description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-                            "supports": "dotnet-runtime",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
                         }
                     },
                     {

--- a/dotnet_imagestreams_aarch64.json
+++ b/dotnet_imagestreams_aarch64.json
@@ -84,48 +84,6 @@
                         }
                     },
                     {
-                        "name": "7.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 (UBI 8)",
-                            "description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet70",
-                            "supports": "dotnet:7.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnet-7.0",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-                        }
-                    },
-                    {
-                        "name": "7.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 (UBI 8)",
-                            "description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet70,hidden",
-                            "supports": "dotnet:7.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-7.0",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-                        }
-                    },
-                    {
                         "name": "6.0-ubi8",
                         "annotations": {
                             "openshift.io/display-name": ".NET 6 (UBI 8)",
@@ -233,42 +191,6 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
-                        }
-                    },
-                    {
-                        "name": "7.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-                            "description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports": "dotnet-runtime",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
-                        }
-                    },
-                    {
-                        "name": "7.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-                            "description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-                            "supports": "dotnet-runtime",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
                         }
                     },
                     {

--- a/dotnet_imagestreams_ppc64le.json
+++ b/dotnet_imagestreams_ppc64le.json
@@ -82,48 +82,6 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
                         }
-                    },
-                    {
-                        "name": "7.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 (UBI 8)",
-                            "description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet70",
-                            "supports": "dotnet:7.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnet-7.0",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-                        }
-                    },
-                    {
-                        "name": "7.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 (UBI 8)",
-                            "description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet70,hidden",
-                            "supports": "dotnet:7.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-7.0",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-                        }
                     }
                 ]
             }
@@ -191,42 +149,6 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
-                        }
-                    },
-                    {
-                        "name": "7.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-                            "description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports": "dotnet-runtime",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
-                        }
-                    },
-                    {
-                        "name": "7.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-                            "description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-                            "supports": "dotnet-runtime",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
                         }
                     }
                 ]

--- a/dotnet_imagestreams_s390x.json
+++ b/dotnet_imagestreams_s390x.json
@@ -84,48 +84,6 @@
                         }
                     },
                     {
-                        "name": "7.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 (UBI 8)",
-                            "description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet70",
-                            "supports": "dotnet:7.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnet-7.0",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-                        }
-                    },
-                    {
-                        "name": "7.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 (UBI 8)",
-                            "description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet70,hidden",
-                            "supports": "dotnet:7.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-7.0",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-                        }
-                    },
-                    {
                         "name": "6.0-ubi8",
                         "annotations": {
                             "openshift.io/display-name": ".NET 6 (UBI 8)",
@@ -233,42 +191,6 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
-                        }
-                    },
-                    {
-                        "name": "7.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-                            "description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports": "dotnet-runtime",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
-                        }
-                    },
-                    {
-                        "name": "7.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-                            "description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-                            "supports": "dotnet-runtime",
-                            "version": "7.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
                         }
                     },
                     {


### PR DESCRIPTION
- Update README

- Remove 7.0 from imagestreams

- Also update build.sh and test-imagestreams.sh to only build/test supported versions by default.