### PR TITLE
9.0: update imagestreams*.json.

### DIFF
--- a/dotnet_imagestreams.json
+++ b/dotnet_imagestreams.json
@@ -15,8 +15,7 @@
             "metadata": {
                 "name": "dotnet",
                 "annotations": {
-                    "openshift.io/display-name": ".NET",
-                    "openshift.io/provider-display-name": "Red Hat"
+                    "openshift.io/display-name": ".NET"
                 }
             },
             "spec": {
@@ -25,104 +24,153 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET (Latest)",
-                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major versions updates.",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major version updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,hidden",
+                            "tags": "builder,dotnet,hidden",
                             "supports": "dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnet-8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "sampleRef": "dotnet-9.0"
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "8.0-ubi8"
-                        }
-                    },
-                    {
-                        "name": "8.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 8 (UBI 8)",
-                            "description": "Build and run .NET 8 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet80",
-                            "supports": "dotnet:8.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnet-8.0",
-                            "version": "8.0"
+                            "name": "9.0-ubi8"
                         },
                         "referencePolicy": {
                             "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
-                        }
-                    },
-                    {
-                        "name": "8.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 8 (UBI 8)",
-                            "description": "Build and run .NET 8 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet80,hidden",
-                            "supports": "dotnet:8.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-8.0",
-                            "version": "8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
                         }
                     },
                     {
                         "name": "6.0-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 6 (UBI 8)",
-                            "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",
+                            "openshift.io/display-name": ".NET 6.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 6.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet60",
-                            "supports": "dotnet:6.0,dotnet",
+                            "tags": "builder,dotnet",
+                            "version": "6.0",
+                            "supports": "dotnet,dotnet:6.0",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnet-6.0",
-                            "version": "6.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "sampleRef": "dotnet-6.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     },
                     {
                         "name": "6.0",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 6 (UBI 8)",
-                            "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",
+                            "openshift.io/display-name": ".NET 6.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 6.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet60,hidden",
-                            "supports": "dotnet:6.0,dotnet",
+                            "tags": "builder,dotnet,hidden",
+                            "version": "6.0",
+                            "supports": "dotnet,dotnet:6.0",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-6.0",
-                            "version": "6.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "sampleRef": "dotnet-6.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "8.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 8.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 8.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet",
+                            "version": "8.0",
+                            "supports": "dotnet,dotnet:8.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-8.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "8.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 8.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 8.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet,hidden",
+                            "version": "8.0",
+                            "supports": "dotnet,dotnet:8.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-8.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 9.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet",
+                            "version": "9.0",
+                            "supports": "dotnet,dotnet:9.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 9.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet,hidden",
+                            "version": "9.0",
+                            "supports": "dotnet,dotnet:9.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     }
                 ]
@@ -134,8 +182,7 @@
             "metadata": {
                 "name": "dotnet-runtime",
                 "annotations": {
-                    "openshift.io/display-name": ".NET Core Runtime",
-                    "openshift.io/provider-display-name": "Red Hat"
+                    "openshift.io/display-name": ".NET Runtime"
                 }
             },
             "spec": {
@@ -144,89 +191,132 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET Runtime (Latest)",
-                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major version updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "tags": "dotnet-runtime,hidden",
                             "supports": "dotnet-runtime"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "8.0-ubi8"
-                        }
-                    },
-                    {
-                        "name": "8.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 8 Runtime (UBI 8)",
-                            "description": "Run .NET 8 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports": "dotnet-runtime",
-                            "version": "8.0"
+                            "name": "9.0-ubi8"
                         },
                         "referencePolicy": {
                             "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
-                        }
-                    },
-                    {
-                        "name": "8.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 8 Runtime (UBI 8)",
-                            "description": "Run .NET 8 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-                            "supports": "dotnet-runtime",
-                            "version": "8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
                         }
                     },
                     {
                         "name": "6.0-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
-                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",
+                            "openshift.io/display-name": ".NET 6.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 6.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports": "dotnet-runtime",
-                            "version": "6.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "tags": "dotnet-runtime",
+                            "version": "6.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:6.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     },
                     {
                         "name": "6.0",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
-                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",
+                            "openshift.io/display-name": ".NET 6.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 6.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-                            "supports": "dotnet-runtime",
-                            "version": "6.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "tags": "dotnet-runtime,hidden",
+                            "version": "6.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:6.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "8.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 8.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 8.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime",
+                            "version": "8.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:8.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "8.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 8.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 8.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime,hidden",
+                            "version": "8.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:8.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 9.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime",
+                            "version": "9.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90-runtime:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 9.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime,hidden",
+                            "version": "9.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90-runtime:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     }
                 ]

--- a/dotnet_imagestreams_aarch64.json
+++ b/dotnet_imagestreams_aarch64.json
@@ -15,8 +15,7 @@
             "metadata": {
                 "name": "dotnet",
                 "annotations": {
-                    "openshift.io/display-name": ".NET",
-                    "openshift.io/provider-display-name": "Red Hat"
+                    "openshift.io/display-name": ".NET"
                 }
             },
             "spec": {
@@ -25,104 +24,153 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET (Latest)",
-                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major versions updates.",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major version updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,hidden",
+                            "tags": "builder,dotnet,hidden",
                             "supports": "dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnet-8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "sampleRef": "dotnet-9.0"
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "8.0-ubi8"
-                        }
-                    },
-                    {
-                        "name": "8.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 8 (UBI 8)",
-                            "description": "Build and run .NET 8 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet80",
-                            "supports": "dotnet:8.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnet-8.0",
-                            "version": "8.0"
+                            "name": "9.0-ubi8"
                         },
                         "referencePolicy": {
                             "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
-                        }
-                    },
-                    {
-                        "name": "8.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 8 (UBI 8)",
-                            "description": "Build and run .NET 8 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet80,hidden",
-                            "supports": "dotnet:8.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-8.0",
-                            "version": "8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
                         }
                     },
                     {
                         "name": "6.0-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 6 (UBI 8)",
-                            "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",
+                            "openshift.io/display-name": ".NET 6.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 6.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet60",
-                            "supports": "dotnet:6.0,dotnet",
+                            "tags": "builder,dotnet",
+                            "version": "6.0",
+                            "supports": "dotnet,dotnet:6.0",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnet-6.0",
-                            "version": "6.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "sampleRef": "dotnet-6.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     },
                     {
                         "name": "6.0",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 6 (UBI 8)",
-                            "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",
+                            "openshift.io/display-name": ".NET 6.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 6.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet60,hidden",
-                            "supports": "dotnet:6.0,dotnet",
+                            "tags": "builder,dotnet,hidden",
+                            "version": "6.0",
+                            "supports": "dotnet,dotnet:6.0",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-6.0",
-                            "version": "6.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "sampleRef": "dotnet-6.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "8.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 8.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 8.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet",
+                            "version": "8.0",
+                            "supports": "dotnet,dotnet:8.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-8.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "8.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 8.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 8.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet,hidden",
+                            "version": "8.0",
+                            "supports": "dotnet,dotnet:8.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-8.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 9.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet",
+                            "version": "9.0",
+                            "supports": "dotnet,dotnet:9.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 9.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet,hidden",
+                            "version": "9.0",
+                            "supports": "dotnet,dotnet:9.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     }
                 ]
@@ -134,8 +182,7 @@
             "metadata": {
                 "name": "dotnet-runtime",
                 "annotations": {
-                    "openshift.io/display-name": ".NET Core Runtime",
-                    "openshift.io/provider-display-name": "Red Hat"
+                    "openshift.io/display-name": ".NET Runtime"
                 }
             },
             "spec": {
@@ -144,89 +191,132 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET Runtime (Latest)",
-                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major version updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "tags": "dotnet-runtime,hidden",
                             "supports": "dotnet-runtime"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "8.0-ubi8"
-                        }
-                    },
-                    {
-                        "name": "8.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 8 Runtime (UBI 8)",
-                            "description": "Run .NET 8 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports": "dotnet-runtime",
-                            "version": "8.0"
+                            "name": "9.0-ubi8"
                         },
                         "referencePolicy": {
                             "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
-                        }
-                    },
-                    {
-                        "name": "8.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 8 Runtime (UBI 8)",
-                            "description": "Run .NET 8 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-                            "supports": "dotnet-runtime",
-                            "version": "8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
                         }
                     },
                     {
                         "name": "6.0-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
-                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",
+                            "openshift.io/display-name": ".NET 6.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 6.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports": "dotnet-runtime",
-                            "version": "6.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "tags": "dotnet-runtime",
+                            "version": "6.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:6.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     },
                     {
                         "name": "6.0",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
-                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",
+                            "openshift.io/display-name": ".NET 6.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 6.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-                            "supports": "dotnet-runtime",
-                            "version": "6.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "tags": "dotnet-runtime,hidden",
+                            "version": "6.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:6.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "8.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 8.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 8.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime",
+                            "version": "8.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:8.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "8.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 8.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 8.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime,hidden",
+                            "version": "8.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:8.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 9.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime",
+                            "version": "9.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90-runtime:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 9.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime,hidden",
+                            "version": "9.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90-runtime:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     }
                 ]

--- a/dotnet_imagestreams_ppc64le.json
+++ b/dotnet_imagestreams_ppc64le.json
@@ -15,8 +15,7 @@
             "metadata": {
                 "name": "dotnet",
                 "annotations": {
-                    "openshift.io/display-name": ".NET",
-                    "openshift.io/provider-display-name": "Red Hat"
+                    "openshift.io/display-name": ".NET"
                 }
             },
             "spec": {
@@ -25,62 +24,109 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET (Latest)",
-                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major versions updates.",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major version updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,hidden",
+                            "tags": "builder,dotnet,hidden",
                             "supports": "dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnet-8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "sampleRef": "dotnet-9.0"
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "8.0-ubi8"
+                            "name": "9.0-ubi8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     },
                     {
                         "name": "8.0-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 8 (UBI 8)",
-                            "description": "Build and run .NET 8 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
+                            "openshift.io/display-name": ".NET 8.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 8.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet80",
-                            "supports": "dotnet:8.0,dotnet",
+                            "tags": "builder,dotnet",
+                            "version": "8.0",
+                            "supports": "dotnet,dotnet:8.0",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnet-8.0",
-                            "version": "8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "sampleRef": "dotnet-8.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     },
                     {
                         "name": "8.0",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 8 (UBI 8)",
-                            "description": "Build and run .NET 8 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
+                            "openshift.io/display-name": ".NET 8.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 8.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet80,hidden",
-                            "supports": "dotnet:8.0,dotnet",
+                            "tags": "builder,dotnet,hidden",
+                            "version": "8.0",
+                            "supports": "dotnet,dotnet:8.0",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-8.0",
-                            "version": "8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "sampleRef": "dotnet-8.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 9.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet",
+                            "version": "9.0",
+                            "supports": "dotnet,dotnet:9.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 9.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet,hidden",
+                            "version": "9.0",
+                            "supports": "dotnet,dotnet:9.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     }
                 ]
@@ -92,8 +138,7 @@
             "metadata": {
                 "name": "dotnet-runtime",
                 "annotations": {
-                    "openshift.io/display-name": ".NET Core Runtime",
-                    "openshift.io/provider-display-name": "Red Hat"
+                    "openshift.io/display-name": ".NET Runtime"
                 }
             },
             "spec": {
@@ -102,53 +147,94 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET Runtime (Latest)",
-                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major version updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "tags": "dotnet-runtime,hidden",
                             "supports": "dotnet-runtime"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "8.0-ubi8"
+                            "name": "9.0-ubi8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     },
                     {
                         "name": "8.0-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 8 Runtime (UBI 8)",
-                            "description": "Run .NET 8 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
+                            "openshift.io/display-name": ".NET 8.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 8.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports": "dotnet-runtime",
-                            "version": "8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "tags": "dotnet-runtime",
+                            "version": "8.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:8.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     },
                     {
                         "name": "8.0",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 8 Runtime (UBI 8)",
-                            "description": "Run .NET 8 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
+                            "openshift.io/display-name": ".NET 8.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 8.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-                            "supports": "dotnet-runtime",
-                            "version": "8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "tags": "dotnet-runtime,hidden",
+                            "version": "8.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:8.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 9.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime",
+                            "version": "9.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90-runtime:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 9.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime,hidden",
+                            "version": "9.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90-runtime:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     }
                 ]

--- a/dotnet_imagestreams_s390x.json
+++ b/dotnet_imagestreams_s390x.json
@@ -15,8 +15,7 @@
             "metadata": {
                 "name": "dotnet",
                 "annotations": {
-                    "openshift.io/display-name": ".NET",
-                    "openshift.io/provider-display-name": "Red Hat"
+                    "openshift.io/display-name": ".NET"
                 }
             },
             "spec": {
@@ -25,104 +24,153 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET (Latest)",
-                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major versions updates.",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major version updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,hidden",
+                            "tags": "builder,dotnet,hidden",
                             "supports": "dotnet",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnet-8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "sampleRef": "dotnet-9.0"
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "8.0-ubi8"
-                        }
-                    },
-                    {
-                        "name": "8.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 8 (UBI 8)",
-                            "description": "Build and run .NET 8 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet80",
-                            "supports": "dotnet:8.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnet-8.0",
-                            "version": "8.0"
+                            "name": "9.0-ubi8"
                         },
                         "referencePolicy": {
                             "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
-                        }
-                    },
-                    {
-                        "name": "8.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 8 (UBI 8)",
-                            "description": "Build and run .NET 8 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet80,hidden",
-                            "supports": "dotnet:8.0,dotnet",
-                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-                            "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-8.0",
-                            "version": "8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
                         }
                     },
                     {
                         "name": "6.0-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 6 (UBI 8)",
-                            "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",
+                            "openshift.io/display-name": ".NET 6.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 6.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet60",
-                            "supports": "dotnet:6.0,dotnet",
+                            "tags": "builder,dotnet",
+                            "version": "6.0",
+                            "supports": "dotnet,dotnet:6.0",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnet-6.0",
-                            "version": "6.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "sampleRef": "dotnet-6.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     },
                     {
                         "name": "6.0",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 6 (UBI 8)",
-                            "description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",
+                            "openshift.io/display-name": ".NET 6.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 6.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "builder,.net,dotnet,dotnetcore,dotnet60,hidden",
-                            "supports": "dotnet:6.0,dotnet",
+                            "tags": "builder,dotnet,hidden",
+                            "version": "6.0",
+                            "supports": "dotnet,dotnet:6.0",
                             "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
                             "sampleContextDir": "app",
-                            "sampleRef": "dotnetcore-6.0",
-                            "version": "6.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "sampleRef": "dotnet-6.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "8.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 8.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 8.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet",
+                            "version": "8.0",
+                            "supports": "dotnet,dotnet:8.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-8.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "8.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 8.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 8.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet,hidden",
+                            "version": "8.0",
+                            "supports": "dotnet,dotnet:8.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-8.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-80:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 9.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet",
+                            "version": "9.0",
+                            "supports": "dotnet,dotnet:9.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Build and run .NET 9.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/build/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "builder,dotnet,hidden",
+                            "version": "9.0",
+                            "supports": "dotnet,dotnet:9.0",
+                            "sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+                            "sampleContextDir": "app",
+                            "sampleRef": "dotnet-9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     }
                 ]
@@ -134,8 +182,7 @@
             "metadata": {
                 "name": "dotnet-runtime",
                 "annotations": {
-                    "openshift.io/display-name": ".NET Core Runtime",
-                    "openshift.io/provider-display-name": "Red Hat"
+                    "openshift.io/display-name": ".NET Runtime"
                 }
             },
             "spec": {
@@ -144,89 +191,132 @@
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": ".NET Runtime (Latest)",
-                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major version updates.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+                            "tags": "dotnet-runtime,hidden",
                             "supports": "dotnet-runtime"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "8.0-ubi8"
-                        }
-                    },
-                    {
-                        "name": "8.0-ubi8",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 8 Runtime (UBI 8)",
-                            "description": "Run .NET 8 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports": "dotnet-runtime",
-                            "version": "8.0"
+                            "name": "9.0-ubi8"
                         },
                         "referencePolicy": {
                             "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
-                        }
-                    },
-                    {
-                        "name": "8.0",
-                        "annotations": {
-                            "openshift.io/display-name": ".NET 8 Runtime (UBI 8)",
-                            "description": "Run .NET 8 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
-                            "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-                            "supports": "dotnet-runtime",
-                            "version": "8.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
                         }
                     },
                     {
                         "name": "6.0-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
-                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",
+                            "openshift.io/display-name": ".NET 6.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 6.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-                            "supports": "dotnet-runtime",
-                            "version": "6.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "tags": "dotnet-runtime",
+                            "version": "6.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:6.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     },
                     {
                         "name": "6.0",
                         "annotations": {
-                            "openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
-                            "description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",
+                            "openshift.io/display-name": ".NET 6.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 6.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",
                             "iconClass": "icon-dotnet",
-                            "tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-                            "supports": "dotnet-runtime",
-                            "version": "6.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
+                            "tags": "dotnet-runtime,hidden",
+                            "version": "6.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:6.0"
                         },
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "8.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 8.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 8.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime",
+                            "version": "8.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:8.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "8.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 8.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 8.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/8.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime,hidden",
+                            "version": "8.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:8.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-80-runtime:8.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 9.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime",
+                            "version": "9.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90-runtime:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    },
+                    {
+                        "name": "9.0",
+                        "annotations": {
+                            "openshift.io/display-name": ".NET 9.0 Runtime (UBI 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "description": "Run .NET 9.0 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/9.0/runtime/README.md.",
+                            "iconClass": "icon-dotnet",
+                            "tags": "dotnet-runtime,hidden",
+                            "version": "9.0",
+                            "supports": "dotnet-runtime,dotnet-runtime:9.0"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/dotnet-90-runtime:9.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         }
                     }
                 ]


### PR DESCRIPTION
This updates the imagestreams files. Rather than do a manual copy-paste and update basted on the existing files, I've generated the json from the Helm chart (command: `helm template . | yq -o=json eval`) and copied from that. This eliminates any differences between the Helm Chart definitions and the definitions in this repo.

This is in Draft until the images are published and the definitions can be functionally verified.