### PR TITLE
Do not run rpm --verify

### DIFF
--- a/8.0/build/Dockerfile.rhel8
+++ b/8.0/build/Dockerfile.rhel8
@@ -38,7 +38,6 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 RUN [ -n "${DOTNET_TARBALL}" ] || ( \
     INSTALL_PKGS="dotnet-sdk-8.0 procps-ng" && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
     microdnf clean all -y && \
 # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/* )
@@ -46,7 +45,6 @@ RUN [ -n "${DOTNET_TARBALL}" ] || ( \
 RUN [ -z "${DOTNET_TARBALL}" ] || ( \
     INSTALL_PKGS="procps-ng" && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
     microdnf clean all -y && \
 # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/* )

--- a/8.0/runtime/Dockerfile.rhel8
+++ b/8.0/runtime/Dockerfile.rhel8
@@ -58,7 +58,6 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 RUN [ -n "${DOTNET_TARBALL}" ] || ( \
     INSTALL_PKGS="aspnetcore-runtime-8.0 findutils shadow-utils tar gzip" && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
 # ubi-minimal doesn't include timezones, restore them.
     ( microdnf reinstall tzdata -y || microdnf update tzdata -y ) && \
     microdnf clean all -y && \

--- a/9.0/build/Dockerfile.rhel8
+++ b/9.0/build/Dockerfile.rhel8
@@ -44,7 +44,6 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 RUN [ -n "${DOTNET_TARBALL}" ] || ( \
     INSTALL_PKGS="dotnet-sdk-9.0 procps-ng" && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
     microdnf clean all -y && \
 # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/* )
@@ -52,7 +51,6 @@ RUN [ -n "${DOTNET_TARBALL}" ] || ( \
 RUN [ -z "${DOTNET_TARBALL}" ] || ( \
     INSTALL_PKGS="procps-ng" && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
     microdnf clean all -y && \
 # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/* )

--- a/9.0/runtime/Dockerfile.rhel8
+++ b/9.0/runtime/Dockerfile.rhel8
@@ -48,7 +48,6 @@ COPY ./root/usr/bin /usr/bin
 RUN [ -n "${DOTNET_TARBALL}" ] || ( \
     INSTALL_PKGS="aspnetcore-runtime-9.0 findutils shadow-utils tar gzip" && \
     microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
 # ubi-minimal doesn't include timezones, restore them.
     ( microdnf reinstall tzdata -y || microdnf update tzdata -y ) && \
     microdnf clean all -y && \


### PR DESCRIPTION
It seems to have become a recommendation since: https://github.com/sclorg/s2i-perl-container/pull/67. That was when yum would report success even if some packages could not be installed. `rpm -v` would act as a sanity check and confirm that the packages were actually installed.

But modern versions of dnf and microdnf are much better about this and error out when packages can't be installed. We don't need to `rpm -v` or `rpm --verify` anymore.