### PR TITLE
Set up tests to be run via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ "8.0", "9.0" ]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Download s2i
+        run: |
+          set -euo pipefail
+          mkdir source-to-image
+          pushd source-to-image
+          wget --no-verbose https://github.com/openshift/source-to-image/releases/download/v1.4.0/source-to-image-v1.4.0-d3544c7e-linux-amd64.tar.gz
+          tar xf source-to-image-v1.4.0-d3544c7e-linux-amd64.tar.gz
+          popd
+      - name: Print Diagnostics
+        run: |
+          PATH=$PATH:$(pwd)/source-to-image/
+          uname -a
+          cat /etc/os-release
+          docker --version
+          podman --version
+          s2i version
+      - name: Build
+        run: |
+          PATH=$PATH:$(pwd)/source-to-image/
+          ./build.sh --ci ${{ matrix.version }}

--- a/8.0/build/test/testcommon
+++ b/8.0/build/test/testcommon
@@ -59,7 +59,7 @@ assert_contains() {
   local actual="$1"
   local expected="$2"
 
-  if ! echo "${actual}" | grep -qP -- "${expected}"; then
+  if ! echo "${actual}" | grep -P -- "${expected}" >/dev/null; then
     error "'${actual}' does not contain '${expected}'"
     error_exit 1
   fi
@@ -76,7 +76,7 @@ assert_not_contains() {
   local actual="$1"
   local unexpected="$2"
 
-  if echo "${actual}" | grep -qP -- "${unexpected}"; then
+  if echo "${actual}" | grep -P -- "${unexpected}" >/dev/null; then
     error "'${actual}' contains '${unexpected}'"
     error_exit 1
   fi

--- a/8.0/runtime/test/testcommon
+++ b/8.0/runtime/test/testcommon
@@ -59,7 +59,7 @@ assert_contains() {
   local actual="$1"
   local expected="$2"
 
-  if ! echo "${actual}" | grep -qP -- "${expected}"; then
+  if ! echo "${actual}" | grep -P -- "${expected}" >/dev/null; then
     error "'${actual}' does not contain '${expected}'"
     error_exit 1
   fi
@@ -76,7 +76,7 @@ assert_not_contains() {
   local actual="$1"
   local unexpected="$2"
 
-  if echo "${actual}" | grep -qP -- "${unexpected}"; then
+  if echo "${actual}" | grep -P -- "${unexpected}" >/dev/null; then
     error "'${actual}' contains '${unexpected}'"
     error_exit 1
   fi

--- a/9.0/build/test/testcommon
+++ b/9.0/build/test/testcommon
@@ -59,7 +59,7 @@ assert_contains() {
   local actual="$1"
   local expected="$2"
 
-  if ! echo "${actual}" | grep -qP -- "${expected}"; then
+  if ! echo "${actual}" | grep -P -- "${expected}" >/dev/null; then
     error "'${actual}' does not contain '${expected}'"
     error_exit 1
   fi
@@ -76,7 +76,7 @@ assert_not_contains() {
   local actual="$1"
   local unexpected="$2"
 
-  if echo "${actual}" | grep -qP -- "${unexpected}"; then
+  if echo "${actual}" | grep -P -- "${unexpected}" >/dev/null; then
     error "'${actual}' contains '${unexpected}'"
     error_exit 1
   fi

--- a/9.0/runtime/test/testcommon
+++ b/9.0/runtime/test/testcommon
@@ -59,7 +59,7 @@ assert_contains() {
   local actual="$1"
   local expected="$2"
 
-  if ! echo "${actual}" | grep -qP -- "${expected}"; then
+  if ! echo "${actual}" | grep -P -- "${expected}" >/dev/null; then
     error "'${actual}' does not contain '${expected}'"
     error_exit 1
   fi
@@ -76,7 +76,7 @@ assert_not_contains() {
   local actual="$1"
   local unexpected="$2"
 
-  if echo "${actual}" | grep -qP -- "${unexpected}"; then
+  if echo "${actual}" | grep -P -- "${unexpected}" >/dev/null; then
     error "'${actual}' contains '${unexpected}'"
     error_exit 1
   fi


### PR DESCRIPTION
This allows us to shift-left and test the container images on every change to this repo.

The test-matrix will need to be updated for every future version of .NET.

This only tests things on Intel (x86_64). It would be nice to test on other architectures (aarch64, ppc64le, s390x), but there doesn't seem to be an obvious way to do that via GitHub actions. Perhaps we can find an alternative service later and add that.

This does use a hardcoded version of s2i. It will need to be updated in the future. I was trying to use the latest version, but the currently-latest version doesn't have usable binaries avalabile as part of the release:
https://github.com/openshift/source-to-image/releases/tag/v1.5.0

It's not obvious, but both podman and docker binaries are installed in the GitHub runner. The build script prints the following to identify what's going on:

    [INFO] Using podman

While running tests, I observed a numger of `broken pipe` errors. I replaced `grep -q` with `grep >/dev/null` to make `grep` stop from exiting on first match, prematurely closing the pipe.