### PR TITLE
test: download s2i when it is not available.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,6 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Download s2i
-        run: |
-          set -euo pipefail
-          mkdir source-to-image
-          pushd source-to-image
-          wget --no-verbose https://github.com/openshift/source-to-image/releases/download/v1.4.0/source-to-image-v1.4.0-d3544c7e-linux-amd64.tar.gz
-          tar xf source-to-image-v1.4.0-d3544c7e-linux-amd64.tar.gz
-          popd
       - name: Print Diagnostics
         run: |
           PATH=$PATH:$(pwd)/source-to-image/
@@ -24,7 +16,6 @@ jobs:
           cat /etc/os-release
           docker --version
           podman --version
-          s2i version
       - name: Build
         run: |
           PATH=$PATH:$(pwd)/source-to-image/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 project.lock.json
+.bin/

--- a/8.0/build/test/testcommon
+++ b/8.0/build/test/testcommon
@@ -2,6 +2,11 @@
 # The code is duplicated in both folders because the images are built
 # and tested after copying the sub-directories into a container repo.
 
+SCRIPT_PATH=$(realpath $0)
+SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
+SCRIPT_BIN_DIR="$SCRIPT_DIR/.bin"
+PATH="$SCRIPT_BIN_DIR:$PATH"
+
 TEST_PORT=${TEST_PORT:-8080}
 CURLE_COULNDT_CONNECT=7
 CURLE_RECV_ERROR=56
@@ -33,10 +38,16 @@ error_exit() {
   TEST_FAILURES="${TEST_FAILURES} ${TEST_NAME}:${BASH_LINENO[1]}"
 }
 
-_S2I_PATH=$(command -v s2i)
-if [ -z "$_S2I_PATH" ]; then
-  error "s2i is not on PATH. Please install s2i or download it from https://github.com/openshift/source-to-image."
-  exit 1
+if [ -z "$(command -v s2i)" ]; then
+  info "s2i is not on PATH. A version of s2i will be downloaded to $SCRIPT_BIN_DIR."
+  mkdir -p "$SCRIPT_BIN_DIR"
+  ARCH="$(uname -m)"
+  if [[ "$ARCH" == aarch64 ]]; then
+    ARCH=arm64
+  elif [[ "$ARCH" == x86_64 ]]; then
+    ARCH=amd64
+  fi
+  curl -sL "https://github.com/openshift/source-to-image/releases/download/v1.4.0/source-to-image-v1.4.0-d3544c7e-linux-$ARCH.tar.gz" | tar -xz -C "$SCRIPT_BIN_DIR"
 fi
 
 _PODMAN_PATH=$(command -v podman)

--- a/8.0/runtime/test/testcommon
+++ b/8.0/runtime/test/testcommon
@@ -2,6 +2,11 @@
 # The code is duplicated in both folders because the images are built
 # and tested after copying the sub-directories into a container repo.
 
+SCRIPT_PATH=$(realpath $0)
+SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
+SCRIPT_BIN_DIR="$SCRIPT_DIR/.bin"
+PATH="$SCRIPT_BIN_DIR:$PATH"
+
 TEST_PORT=${TEST_PORT:-8080}
 CURLE_COULNDT_CONNECT=7
 CURLE_RECV_ERROR=56
@@ -33,10 +38,16 @@ error_exit() {
   TEST_FAILURES="${TEST_FAILURES} ${TEST_NAME}:${BASH_LINENO[1]}"
 }
 
-_S2I_PATH=$(command -v s2i)
-if [ -z "$_S2I_PATH" ]; then
-  error "s2i is not on PATH. Please install s2i or download it from https://github.com/openshift/source-to-image."
-  exit 1
+if [ -z "$(command -v s2i)" ]; then
+  info "s2i is not on PATH. A version of s2i will be downloaded to $SCRIPT_BIN_DIR."
+  mkdir -p "$SCRIPT_BIN_DIR"
+  ARCH="$(uname -m)"
+  if [[ "$ARCH" == aarch64 ]]; then
+    ARCH=arm64
+  elif [[ "$ARCH" == x86_64 ]]; then
+    ARCH=amd64
+  fi
+  curl -sL "https://github.com/openshift/source-to-image/releases/download/v1.4.0/source-to-image-v1.4.0-d3544c7e-linux-$ARCH.tar.gz" | tar -xz -C "$SCRIPT_BIN_DIR"
 fi
 
 _PODMAN_PATH=$(command -v podman)

--- a/9.0/build/test/testcommon
+++ b/9.0/build/test/testcommon
@@ -2,6 +2,11 @@
 # The code is duplicated in both folders because the images are built
 # and tested after copying the sub-directories into a container repo.
 
+SCRIPT_PATH=$(realpath $0)
+SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
+SCRIPT_BIN_DIR="$SCRIPT_DIR/.bin"
+PATH="$SCRIPT_BIN_DIR:$PATH"
+
 TEST_PORT=${TEST_PORT:-8080}
 CURLE_COULNDT_CONNECT=7
 CURLE_RECV_ERROR=56
@@ -33,10 +38,16 @@ error_exit() {
   TEST_FAILURES="${TEST_FAILURES} ${TEST_NAME}:${BASH_LINENO[1]}"
 }
 
-_S2I_PATH=$(command -v s2i)
-if [ -z "$_S2I_PATH" ]; then
-  error "s2i is not on PATH. Please install s2i or download it from https://github.com/openshift/source-to-image."
-  exit 1
+if [ -z "$(command -v s2i)" ]; then
+  info "s2i is not on PATH. A version of s2i will be downloaded to $SCRIPT_BIN_DIR."
+  mkdir -p "$SCRIPT_BIN_DIR"
+  ARCH="$(uname -m)"
+  if [[ "$ARCH" == aarch64 ]]; then
+    ARCH=arm64
+  elif [[ "$ARCH" == x86_64 ]]; then
+    ARCH=amd64
+  fi
+  curl -sL "https://github.com/openshift/source-to-image/releases/download/v1.4.0/source-to-image-v1.4.0-d3544c7e-linux-$ARCH.tar.gz" | tar -xz -C "$SCRIPT_BIN_DIR"
 fi
 
 _PODMAN_PATH=$(command -v podman)

--- a/9.0/runtime/test/testcommon
+++ b/9.0/runtime/test/testcommon
@@ -2,6 +2,11 @@
 # The code is duplicated in both folders because the images are built
 # and tested after copying the sub-directories into a container repo.
 
+SCRIPT_PATH=$(realpath $0)
+SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
+SCRIPT_BIN_DIR="$SCRIPT_DIR/.bin"
+PATH="$SCRIPT_BIN_DIR:$PATH"
+
 TEST_PORT=${TEST_PORT:-8080}
 CURLE_COULNDT_CONNECT=7
 CURLE_RECV_ERROR=56
@@ -33,10 +38,16 @@ error_exit() {
   TEST_FAILURES="${TEST_FAILURES} ${TEST_NAME}:${BASH_LINENO[1]}"
 }
 
-_S2I_PATH=$(command -v s2i)
-if [ -z "$_S2I_PATH" ]; then
-  error "s2i is not on PATH. Please install s2i or download it from https://github.com/openshift/source-to-image."
-  exit 1
+if [ -z "$(command -v s2i)" ]; then
+  info "s2i is not on PATH. A version of s2i will be downloaded to $SCRIPT_BIN_DIR."
+  mkdir -p "$SCRIPT_BIN_DIR"
+  ARCH="$(uname -m)"
+  if [[ "$ARCH" == aarch64 ]]; then
+    ARCH=arm64
+  elif [[ "$ARCH" == x86_64 ]]; then
+    ARCH=amd64
+  fi
+  curl -sL "https://github.com/openshift/source-to-image/releases/download/v1.4.0/source-to-image-v1.4.0-d3544c7e-linux-$ARCH.tar.gz" | tar -xz -C "$SCRIPT_BIN_DIR"
 fi
 
 _PODMAN_PATH=$(command -v podman)


### PR DESCRIPTION
Currently users of the test script are required to provide s2i.

This makes that unnecessary by automatically downloading s2i when it is not yet available.