### PR TITLE
Don't use IMAGE_OS in tests

### DIFF
--- a/8.0/build/test/run
+++ b/8.0/build/test/run
@@ -585,7 +585,7 @@ test_incremental_without_packages()
 test_repos() {
   test_start
 
-  local output=$(docker_run_as $IMAGE_NAME 0 microdnf install -y zlib-devel)
+  local output=$(docker_run_as $IMAGE_NAME 0 bash -c 'microdnf install -y zlib-devel || dnf install -y zlib-devel')
   assert_contains "$output" "Complete"
 }
 
@@ -635,9 +635,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_config
   test_usage
   test_default_cmd
-  if [ "$IMAGE_OS" = "RHEL8" ]; then
-    test_repos
-  fi
+  test_repos
   test_rm_tmp_dotnet
   test_consoleapp
   test_multiframework

--- a/8.0/runtime/test/run
+++ b/8.0/runtime/test/run
@@ -222,7 +222,7 @@ test_s2i_build() {
 test_repos() {
     test_start
 
-    local output=$(docker_run_as $IMAGE_NAME 0 microdnf install -y zlib-devel)
+    local output=$(docker_run_as $IMAGE_NAME 0 bash -c 'microdnf install -y zlib-devel || dnf install -y zlib-devel')
     assert_contains "$output" "Complete"
 }
 
@@ -241,9 +241,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_s2i_usage
   test_s2i_build
   test_run_dotnet_in_dockerfile
-  if [ "$IMAGE_OS" = "RHEL8" ]; then
-    test_repos
-  fi
+  test_repos
 fi
 
 if [ "$STOP_ON_ERROR" != "true" ]; then

--- a/9.0/build/test/run
+++ b/9.0/build/test/run
@@ -548,7 +548,7 @@ test_incremental_without_packages()
 test_repos() {
   test_start
 
-  local output=$(docker_run_as $IMAGE_NAME 0 microdnf install -y zlib-devel)
+  local output=$(docker_run_as $IMAGE_NAME 0 bash -c 'microdnf install -y zlib-devel || dnf install -y zlib-devel')
   assert_contains "$output" "Complete"
 }
 
@@ -598,9 +598,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_config
   test_usage
   test_default_cmd
-  if [ "$IMAGE_OS" = "RHEL8" ]; then
-    test_repos
-  fi
+  test_repos
   test_rm_tmp_dotnet
   test_consoleapp
   test_multiframework

--- a/9.0/runtime/test/run
+++ b/9.0/runtime/test/run
@@ -193,7 +193,7 @@ EOF
 test_repos() {
     test_start
 
-    local output=$(docker_run_as $IMAGE_NAME 0 microdnf install -y zlib-devel)
+    local output=$(docker_run_as $IMAGE_NAME 0 bash -c 'microdnf install -y zlib-devel || dnf install -y zlib-devel')
     assert_contains "$output" "Complete"
 }
 
@@ -210,9 +210,7 @@ if [ ${OPENSHIFT_ONLY} != true ]; then
   test_port
   test_aspnet
   test_run_dotnet_in_dockerfile
-  if [ "$IMAGE_OS" = "RHEL8" ]; then
-    test_repos
-  fi
+  test_repos
 fi
 
 if [ "$STOP_ON_ERROR" != "true" ]; then


### PR DESCRIPTION
This makes it easier to run tests against more operating systems, and doesn't require users to set IMAGE_OS correctly.

<!-- testing-farm = {"lock":"false","comment-id":"2917026285","data":[{"id":"e99acb29-e166-44b8-97f7-ea58ba77dcb5","name":"rhel8 (x86_64) - 8.0","status":"complete","outcome":"passed","runTime":1450.791994,"created":"2025-05-29T20:01:54.933809","updated":"2025-05-29T20:01:54.933819","compose":"RHEL-8-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e99acb29-e166-44b8-97f7-ea58ba77dcb5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e99acb29-e166-44b8-97f7-ea58ba77dcb5/pipeline.log\">pipeline</a>"]},{"id":"2100e2d4-d5ca-49af-a8a4-6331b1da44ad","name":"rhel9 (x86_64) - 8.0","status":"complete","outcome":"passed","runTime":1757.503687,"created":"2025-05-29T20:01:54.646711","updated":"2025-05-29T20:01:54.646719","compose":"RHEL-9-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2100e2d4-d5ca-49af-a8a4-6331b1da44ad\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2100e2d4-d5ca-49af-a8a4-6331b1da44ad/pipeline.log\">pipeline</a>"]},{"id":"5bac97f6-3c63-4b02-ae03-56c3ea2ec7c3","name":"rhel8 (x86_64) - 9.0","status":"complete","outcome":"passed","runTime":1422.632164,"created":"2025-05-29T20:01:52.447292","updated":"2025-05-29T20:01:52.447299","compose":"RHEL-8-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5bac97f6-3c63-4b02-ae03-56c3ea2ec7c3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5bac97f6-3c63-4b02-ae03-56c3ea2ec7c3/pipeline.log\">pipeline</a>"]},{"id":"734356d6-e9aa-4f03-a07d-bd9c8acc8a40","name":"rhel9 (x86_64) - 9.0","status":"complete","outcome":"passed","runTime":1456.927229,"created":"2025-05-29T20:01:53.165022","updated":"2025-05-29T20:01:53.165027","compose":"RHEL-9-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/734356d6-e9aa-4f03-a07d-bd9c8acc8a40\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/734356d6-e9aa-4f03-a07d-bd9c8acc8a40/pipeline.log\">pipeline</a>"]},{"id":"5eb83b1f-d3c8-4748-9480-753f1c0bc5cd","name":"rhel9 (aarch64) - 8.0","status":"complete","outcome":"passed","runTime":1571.155024,"created":"2025-05-29T20:01:55.253065","updated":"2025-05-29T20:01:55.253071","compose":"RHEL-9-Nightly","arch":"aarch64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5eb83b1f-d3c8-4748-9480-753f1c0bc5cd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5eb83b1f-d3c8-4748-9480-753f1c0bc5cd/pipeline.log\">pipeline</a>"]},{"id":"46a31f30-b98f-412d-9b5f-9e9a491613cd","name":"rhel9 (aarch64) - 9.0","status":"complete","outcome":"passed","runTime":1519.246821,"created":"2025-05-29T20:01:56.980776","updated":"2025-05-29T20:01:56.980784","compose":"RHEL-9-Nightly","arch":"aarch64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/46a31f30-b98f-412d-9b5f-9e9a491613cd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/46a31f30-b98f-412d-9b5f-9e9a491613cd/pipeline.log\">pipeline</a>"]},{"id":"6ba99f92-ac4b-41dc-856c-ad1099c29900","name":"rhel8 (aarch64) - 9.0","status":"complete","outcome":"passed","runTime":1589.232401,"created":"2025-05-29T20:01:54.704577","updated":"2025-05-29T20:01:54.704584","compose":"RHEL-8-Nightly","arch":"aarch64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ba99f92-ac4b-41dc-856c-ad1099c29900\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ba99f92-ac4b-41dc-856c-ad1099c29900/pipeline.log\">pipeline</a>"]},{"id":"aecab237-5eeb-47b7-8c96-1d285a041e2c","name":"rhel8 (aarch64) - 8.0","status":"complete","outcome":"passed","runTime":1599.881239,"created":"2025-05-29T20:01:54.541758","updated":"2025-05-29T20:01:54.541765","compose":"RHEL-8-Nightly","arch":"aarch64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/aecab237-5eeb-47b7-8c96-1d285a041e2c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/aecab237-5eeb-47b7-8c96-1d285a041e2c/pipeline.log\">pipeline</a>"]},{"id":"d17251a3-2958-41b3-b2fb-281ce1615778","name":"rhel9 (s390x) - 9.0","status":"complete","outcome":"passed","runTime":1647.441216,"created":"2025-05-29T20:01:52.416484","updated":"2025-05-29T20:01:52.416510","compose":"RHEL-9-Nightly","arch":"s390x","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d17251a3-2958-41b3-b2fb-281ce1615778\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d17251a3-2958-41b3-b2fb-281ce1615778/pipeline.log\">pipeline</a>"]},{"id":"f4713fdc-b565-4580-8bdd-d0e3a7720221","name":"rhel9 (s390x) - 8.0","status":"complete","outcome":"passed","runTime":1742.027887,"created":"2025-05-29T20:01:57.125031","updated":"2025-05-29T20:01:57.125038","compose":"RHEL-9-Nightly","arch":"s390x","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f4713fdc-b565-4580-8bdd-d0e3a7720221\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f4713fdc-b565-4580-8bdd-d0e3a7720221/pipeline.log\">pipeline</a>"]},{"id":"0262146c-9e4f-46de-940a-33b78cf1c4b4","name":"rhel8 (s390x) - 9.0","status":"complete","outcome":"passed","runTime":2132.852434,"created":"2025-05-29T20:01:54.555638","updated":"2025-05-29T20:01:54.555647","compose":"RHEL-8-Nightly","arch":"s390x","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0262146c-9e4f-46de-940a-33b78cf1c4b4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0262146c-9e4f-46de-940a-33b78cf1c4b4/pipeline.log\">pipeline</a>"]},{"id":"d8e49a77-9b73-4f1d-8d17-5b23c5a57d88","name":"rhel8 (s390x) - 8.0","status":"complete","outcome":"passed","runTime":2229.928663,"created":"2025-05-29T20:01:53.127280","updated":"2025-05-29T20:01:53.127286","compose":"RHEL-8-Nightly","arch":"s390x","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d8e49a77-9b73-4f1d-8d17-5b23c5a57d88\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d8e49a77-9b73-4f1d-8d17-5b23c5a57d88/pipeline.log\">pipeline</a>"]},{"id":"2fbd8c6d-4c18-4977-933f-ce903a038650","name":"rhel8 (ppc64le) - 9.0","status":"complete","outcome":"passed","runTime":3692.756949,"created":"2025-05-29T20:01:53.754572","updated":"2025-05-29T20:01:53.754579","compose":"RHEL-8-Nightly","arch":"ppc64le","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2fbd8c6d-4c18-4977-933f-ce903a038650\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2fbd8c6d-4c18-4977-933f-ce903a038650/pipeline.log\">pipeline</a>"]},{"id":"cc444fea-225c-4112-b7cd-76190ea76fc3","name":"rhel8 (ppc64le) - 8.0","runTime":3877.975014,"created":"2025-05-29T20:01:57.464694","updated":"2025-05-29T20:01:57.464701","compose":"RHEL-8-Nightly","arch":"ppc64le","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cc444fea-225c-4112-b7cd-76190ea76fc3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cc444fea-225c-4112-b7cd-76190ea76fc3/pipeline.log\">pipeline</a>"]}]} -->