### PR TITLE
Support testing image names with a hash/tag

### DIFF
--- a/8.0/build/test/run
+++ b/8.0/build/test/run
@@ -4,7 +4,9 @@
 # of the image
 #
 # IMAGE_NAME specifies a name of the candidate image used for testing.
-# The image has to be available before this script is executed.
+# The image has to be available before this script is executed. It may be a
+# short image name such as 'foobar', or it may be a fully qualified name in the
+# form of example.com/project/repository/image@sha256:hashinhex
 #
 # OPENSHIFT_ONLY environment variable, if 'true', only tests features used by
 # OpenShift's try-it feature.

--- a/8.0/build/test/testcommon
+++ b/8.0/build/test/testcommon
@@ -274,7 +274,7 @@ container_url() {
 
 s2i_image_tag() {
   local app="$1"
-  echo "localhost/${IMAGE_NAME}-${app}"
+  echo "localhost/${IMAGE_NAME%@*}-${app}"
 }
 
 s2i_build_core() {

--- a/8.0/runtime/test/run
+++ b/8.0/runtime/test/run
@@ -5,6 +5,9 @@
 #
 # IMAGE_NAME specifies a name of the candidate image used for testing.
 # The image has to be available before this script is executed.
+# The image has to be available before this script is executed. It may be a
+# short image name such as 'foobar', or it may be a fully qualified name in the
+# form of example.com/project/repository/image@sha256:hashinhex
 #
 # TEST_PORT specifies the port on the docker host to be used for testing.
 # The container application will still use 8080, but this port will be bound

--- a/8.0/runtime/test/testcommon
+++ b/8.0/runtime/test/testcommon
@@ -274,7 +274,7 @@ container_url() {
 
 s2i_image_tag() {
   local app="$1"
-  echo "localhost/${IMAGE_NAME}-${app}"
+  echo "localhost/${IMAGE_NAME%@*}-${app}"
 }
 
 s2i_build_core() {

--- a/9.0/build/test/run
+++ b/9.0/build/test/run
@@ -4,7 +4,9 @@
 # of the image
 #
 # IMAGE_NAME specifies a name of the candidate image used for testing.
-# The image has to be available before this script is executed.
+# The image has to be available before this script is executed. It may be a
+# short image name such as 'foobar', or it may be a fully qualified name in the
+# form of example.com/project/repository/image@sha256:hashinhex
 #
 # OPENSHIFT_ONLY environment variable, if 'true', only tests features used by
 # OpenShift's try-it feature.

--- a/9.0/build/test/testcommon
+++ b/9.0/build/test/testcommon
@@ -274,7 +274,7 @@ container_url() {
 
 s2i_image_tag() {
   local app="$1"
-  echo "localhost/${IMAGE_NAME}-${app}"
+  echo "localhost/${IMAGE_NAME%@*}-${app}"
 }
 
 s2i_build_core() {

--- a/9.0/runtime/test/run
+++ b/9.0/runtime/test/run
@@ -4,7 +4,9 @@
 # of the image
 #
 # IMAGE_NAME specifies a name of the candidate image used for testing.
-# The image has to be available before this script is executed.
+# The image has to be available before this script is executed. It may be a
+# short image name such as 'foobar', or it may be a fully qualified name in the
+# form of example.com/project/repository/image@sha256:hashinhex
 #
 # TEST_PORT specifies the port on the docker host to be used for testing.
 # The container application will still use 8080, but this port will be bound

--- a/9.0/runtime/test/testcommon
+++ b/9.0/runtime/test/testcommon
@@ -274,7 +274,7 @@ container_url() {
 
 s2i_image_tag() {
   local app="$1"
-  echo "localhost/${IMAGE_NAME}-${app}"
+  echo "localhost/${IMAGE_NAME%@*}-${app}"
 }
 
 s2i_build_core() {


### PR DESCRIPTION
I am trying to use the test suite to test images with an image from a (non-local) regitry and the image name contains a hash or a tag. It would be great to support testing that directly without having to retag the image.

The only real change is to adjust the name used for the s2i app.