### PR TITLE
Automatically infer runtime image when testing the build images

### DIFF
--- a/8.0/build/test/run
+++ b/8.0/build/test/run
@@ -8,6 +8,10 @@
 # short image name such as 'foobar', or it may be a fully qualified name in the
 # form of example.com/project/repository/image@sha256:hashinhex
 #
+# RUNTIME_IMAGE_NAME specifies the name of the runtime image used for split
+# builds.  If blank or unset, it is computed automatically as the base image
+# used to build IMAGE_NAME.
+#
 # OPENSHIFT_ONLY environment variable, if 'true', only tests features used by
 # OpenShift's try-it feature.
 #
@@ -32,7 +36,16 @@ STOP_ON_ERROR=${STOP_ON_ERROR:-true}
 IMAGE_OS=${IMAGE_OS:-RHEL8}
 
 IMAGE_NAME=${IMAGE_NAME:-localhost/ubi8/dotnet-80}
-RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-localhost/ubi8/dotnet-80-runtime}
+# Infer runtime image from SDK image when it is not explicitly set
+if [[ ${RUNTIME_IMAGE_NAME:-} == "" ]]; then
+  if [[ $(podman images -n --filter reference="${IMAGE_NAME}") == "" ]]; then
+    podman pull "${IMAGE_NAME}"
+  fi
+  base_image=$(podman image history --format json "${IMAGE_NAME}" | jq -r '[.[].comment | select (. != null )][0]' | cut -d' ' -f2)
+  echo "${base_image}"
+  RUNTIME_IMAGE_NAME="${base_image}"
+fi
+
 OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 
 test_dir="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
@@ -631,6 +644,7 @@ test_msbuild_exec_task() {
 }
 
 info "Testing ${IMAGE_NAME}"
+info "Using runtime image ${RUNTIME_IMAGE_NAME}"
 
 if [ ${OPENSHIFT_ONLY} != true ]; then
   test_image

--- a/9.0/build/test/run
+++ b/9.0/build/test/run
@@ -8,6 +8,10 @@
 # short image name such as 'foobar', or it may be a fully qualified name in the
 # form of example.com/project/repository/image@sha256:hashinhex
 #
+# RUNTIME_IMAGE_NAME specifies the name of the runtime image used for split
+# builds.  If blank or unset, it is computed automatically as the base image
+# used to build IMAGE_NAME.
+#
 # OPENSHIFT_ONLY environment variable, if 'true', only tests features used by
 # OpenShift's try-it feature.
 #
@@ -32,7 +36,16 @@ STOP_ON_ERROR=${STOP_ON_ERROR:-true}
 IMAGE_OS=${IMAGE_OS:-RHEL8}
 
 IMAGE_NAME=${IMAGE_NAME:-localhost/ubi8/dotnet-90}
-RUNTIME_IMAGE_NAME=${RUNTIME_IMAGE_NAME:-localhost/ubi8/dotnet-90-runtime}
+# Infer runtime image from SDK image when it is not explicitly set
+if [[ ${RUNTIME_IMAGE_NAME:-} == "" ]]; then
+  if [[ $(podman images -n --filter reference="${IMAGE_NAME}") == "" ]]; then
+    podman pull "${IMAGE_NAME}"
+  fi
+  base_image=$(podman image history --format json "${IMAGE_NAME}" | jq -r '[.[].comment | select (. != null )][0]' | cut -d' ' -f2)
+  echo "${base_image}"
+  RUNTIME_IMAGE_NAME="${base_image}"
+fi
+
 OPENSHIFT_ONLY=${OPENSHIFT_ONLY:-false}
 
 test_dir="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
@@ -594,6 +607,7 @@ test_msbuild_exec_task() {
 }
 
 info "Testing ${IMAGE_NAME}"
+info "Using runtime image ${RUNTIME_IMAGE_NAME}"
 
 if [ ${OPENSHIFT_ONLY} != true ]; then
   test_image


### PR DESCRIPTION
Instead of guessing/assuming the base runtime image, compute it from the exact base (`FROM`) of the build container image. A nice advantage is that if build image uses an exact image-with-hash as the base image, the tests will run against the exact same image whenever they are re-run.

Also log the runtime image name for later diagnosis.

<!-- testing-farm = {"lock":"false","comment-id":"2978988731","data":[{"id":"5f92e57e-64ca-4f45-be40-9b4e3fe80108","name":"rhel9 (aarch64) - 8.0","status":"complete","outcome":"passed","runTime":4308.149796,"created":"2025-06-17T04:14:01.605931","updated":"2025-06-17T04:14:01.605937","compose":"RHEL-9-Nightly","arch":"aarch64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f92e57e-64ca-4f45-be40-9b4e3fe80108\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f92e57e-64ca-4f45-be40-9b4e3fe80108/pipeline.log\">pipeline</a>"]},{"id":"3c2adb9f-003e-44e5-9670-80311da0f3d9","name":"rhel9 (aarch64) - 9.0","status":"complete","outcome":"passed","runTime":4354.584923,"created":"2025-06-17T04:13:59.266617","updated":"2025-06-17T04:13:59.266623","compose":"RHEL-9-Nightly","arch":"aarch64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c2adb9f-003e-44e5-9670-80311da0f3d9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c2adb9f-003e-44e5-9670-80311da0f3d9/pipeline.log\">pipeline</a>"]},{"id":"dec838a3-9778-4231-8b5d-b392e428f19a","name":"rhel8 (s390x) - 9.0","status":"complete","outcome":"passed","runTime":4854.016913,"created":"2025-06-17T04:13:59.975556","updated":"2025-06-17T04:13:59.975562","compose":"RHEL-8-Nightly","arch":"s390x","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dec838a3-9778-4231-8b5d-b392e428f19a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dec838a3-9778-4231-8b5d-b392e428f19a/pipeline.log\">pipeline</a>"]},{"id":"5bf38653-8e5d-41ef-8605-7906f9ce5f9e","name":"rhel8 (x86_64) - 8.0","status":"complete","outcome":"passed","runTime":5263.311354,"created":"2025-06-17T04:14:00.615654","updated":"2025-06-17T04:14:00.615660","compose":"RHEL-8-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5bf38653-8e5d-41ef-8605-7906f9ce5f9e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5bf38653-8e5d-41ef-8605-7906f9ce5f9e/pipeline.log\">pipeline</a>"]},{"id":"04c51c77-ba63-4e90-a752-7614add6c9ca","name":"rhel9 (x86_64) - 8.0","status":"complete","outcome":"passed","runTime":5269.230817,"created":"2025-06-17T04:14:01.513707","updated":"2025-06-17T04:14:01.513714","compose":"RHEL-9-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/04c51c77-ba63-4e90-a752-7614add6c9ca\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/04c51c77-ba63-4e90-a752-7614add6c9ca/pipeline.log\">pipeline</a>"]},{"id":"9c8b5eb6-67ce-44bd-899c-4050b023997f","name":"rhel9 (x86_64) - 9.0","status":"complete","outcome":"passed","runTime":5208.935202,"created":"2025-06-17T04:14:02.070536","updated":"2025-06-17T04:14:02.070543","compose":"RHEL-9-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c8b5eb6-67ce-44bd-899c-4050b023997f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c8b5eb6-67ce-44bd-899c-4050b023997f/pipeline.log\">pipeline</a>"]},{"id":"915348e3-7e45-4bb9-ab45-cc838e4b44d5","name":"rhel8 (x86_64) - 9.0","status":"complete","outcome":"passed","runTime":5365.361883,"created":"2025-06-17T04:14:01.892569","updated":"2025-06-17T04:14:01.892576","compose":"RHEL-8-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/915348e3-7e45-4bb9-ab45-cc838e4b44d5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/915348e3-7e45-4bb9-ab45-cc838e4b44d5/pipeline.log\">pipeline</a>"]},{"id":"a9a41cae-7cc6-467c-8309-621d3986e642","name":"rhel8 (aarch64) - 8.0","status":"complete","outcome":"passed","runTime":5461.430398,"created":"2025-06-17T04:13:59.884737","updated":"2025-06-17T04:13:59.884744","compose":"RHEL-8-Nightly","arch":"aarch64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a9a41cae-7cc6-467c-8309-621d3986e642\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a9a41cae-7cc6-467c-8309-621d3986e642/pipeline.log\">pipeline</a>"]},{"id":"4fbab853-79e3-43bd-8345-d757836ec751","name":"rhel8 (aarch64) - 9.0","status":"complete","outcome":"passed","runTime":5461.698515,"created":"2025-06-17T04:14:02.144039","updated":"2025-06-17T04:14:02.144045","compose":"RHEL-8-Nightly","arch":"aarch64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4fbab853-79e3-43bd-8345-d757836ec751\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4fbab853-79e3-43bd-8345-d757836ec751/pipeline.log\">pipeline</a>"]},{"id":"67f64c6b-1380-4973-a353-9fd5d56ca57a","name":"rhel9 (s390x) - 9.0","status":"complete","outcome":"passed","runTime":5629.620229,"created":"2025-06-17T04:14:00.824001","updated":"2025-06-17T04:14:00.824007","compose":"RHEL-9-Nightly","arch":"s390x","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/67f64c6b-1380-4973-a353-9fd5d56ca57a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/67f64c6b-1380-4973-a353-9fd5d56ca57a/pipeline.log\">pipeline</a>"]},{"id":"6f9c49ad-a8ee-4e0a-986b-877583f05a70","name":"rhel9 (s390x) - 8.0","status":"complete","outcome":"passed","runTime":5783.839054,"created":"2025-06-17T04:13:59.183866","updated":"2025-06-17T04:13:59.183872","compose":"RHEL-9-Nightly","arch":"s390x","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f9c49ad-a8ee-4e0a-986b-877583f05a70\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f9c49ad-a8ee-4e0a-986b-877583f05a70/pipeline.log\">pipeline</a>"]},{"id":"1f75d24e-58af-4635-a5ef-aafaf8f0ecb5","name":"rhel8 (s390x) - 8.0","status":"complete","outcome":"passed","runTime":6131.785292,"created":"2025-06-17T04:14:02.911578","updated":"2025-06-17T04:14:02.911584","compose":"RHEL-8-Nightly","arch":"s390x","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1f75d24e-58af-4635-a5ef-aafaf8f0ecb5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1f75d24e-58af-4635-a5ef-aafaf8f0ecb5/pipeline.log\">pipeline</a>"]},{"id":"1b5172bd-3dd8-4c15-9ce7-4ed91349813c","name":"rhel9 (ppc64le) - 9.0","status":"complete","outcome":"passed","runTime":6444.556782,"created":"2025-06-17T04:13:59.739966","updated":"2025-06-17T04:13:59.739973","compose":"RHEL-9-Nightly","arch":"ppc64le","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1b5172bd-3dd8-4c15-9ce7-4ed91349813c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1b5172bd-3dd8-4c15-9ce7-4ed91349813c/pipeline.log\">pipeline</a>"]},{"id":"b018a5d2-8547-41eb-b790-c05b332ebf01","name":"rhel8 (ppc64le) - 9.0","status":"complete","outcome":"passed","runTime":7289.608865,"created":"2025-06-17T04:13:59.927067","updated":"2025-06-17T04:13:59.927074","compose":"RHEL-8-Nightly","arch":"ppc64le","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b018a5d2-8547-41eb-b790-c05b332ebf01\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b018a5d2-8547-41eb-b790-c05b332ebf01/pipeline.log\">pipeline</a>"]},{"id":"ec22d9ff-95f5-4232-8fef-8a76ab6f99f3","name":"rhel8 (ppc64le) - 8.0","status":"complete","outcome":"passed","runTime":7748.000566,"created":"2025-06-17T04:13:59.859353","updated":"2025-06-17T04:13:59.859360","compose":"RHEL-8-Nightly","arch":"ppc64le","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ec22d9ff-95f5-4232-8fef-8a76ab6f99f3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ec22d9ff-95f5-4232-8fef-8a76ab6f99f3/pipeline.log\">pipeline</a>"]},{"id":"83e76665-b9ce-4fde-a523-355b25e66e37","name":"rhel9 (ppc64le) - 8.0","runTime":10712.871725,"created":"2025-06-17T04:14:01.760169","updated":"2025-06-17T04:14:01.760177","compose":"RHEL-9-Nightly","arch":"ppc64le","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/83e76665-b9ce-4fde-a523-355b25e66e37\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/83e76665-b9ce-4fde-a523-355b25e66e37/pipeline.log\">pipeline</a>"]}]} -->