### PR TITLE
Update container labels for .NET 10.

### DIFF
--- a/10.0/build/Dockerfile.rhel9
+++ b/10.0/build/Dockerfile.rhel9
@@ -27,8 +27,7 @@ LABEL name="ubi9/dotnet-100" \
       summary=".NET 10 SDK" \
       com.redhat.component="dotnet-100-container" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
-      # .NET version for this component
-      dotnet_version="$DOTNET_SDK_VERSION"
+      dotnet_sdk_version="$DOTNET_SDK_VERSION"
 
 # Switch to root for package installs
 USER 0

--- a/10.0/runtime/Dockerfile.rhel9
+++ b/10.0/runtime/Dockerfile.rhel9
@@ -39,8 +39,8 @@ LABEL name="ubi9/dotnet-100-runtime" \
       com.redhat.component="dotnet-100-runtime-container" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       dotnet_version_major_minor="10.0" \
-      # .NET version for this component
-      dotnet_version="$ASPNET_VERSION"
+      dotnet_version="$DOTNET_VERSION" \
+      aspnet_version="$ASPNET_VERSION"
 
 COPY ./root/usr/bin /usr/bin
 


### PR DESCRIPTION
We no longer set the 'version' label so that the label from the base image is preserved.

The 'dotnet_version' label is used for the version of the component.
For the SDK image, it is the full SDK version, like 10.0.100.
For the runtime image, it is the full ASP.NET Core runtime version, like 10.0.0.

The 'dotnet_version_major_minor' contains only the major.minor part, like 10.0.