### PR TITLE
Do not try and set labels in dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,3 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    labels:
-      - 'ready for review'


### PR DESCRIPTION
Otherwise dependabot posts a message about the label missing: https://github.com/redhat-developer/s2i-dotnetcore/pull/536#issuecomment-4858897568